### PR TITLE
feat: simplify environment variable configuration

### DIFF
--- a/ConduitLLM.Admin/Middleware/AdminAuthenticationMiddleware.cs
+++ b/ConduitLLM.Admin/Middleware/AdminAuthenticationMiddleware.cs
@@ -54,7 +54,9 @@ public class AdminAuthenticationMiddleware
             return;
         }
 
-        string? masterKey = _configuration[MASTER_KEY_CONFIG_KEY];
+        // Check for CONDUIT_MASTER_KEY first (new standard), then fall back to AdminApi:MasterKey
+        string? masterKey = Environment.GetEnvironmentVariable("CONDUIT_MASTER_KEY") 
+                           ?? _configuration[MASTER_KEY_CONFIG_KEY];
 
         if (string.IsNullOrEmpty(masterKey))
         {

--- a/ConduitLLM.Admin/Program.cs
+++ b/ConduitLLM.Admin/Program.cs
@@ -88,7 +88,22 @@ public partial class Program
         builder.Services.AddAdminServices(builder.Configuration);
 
         // Configure Data Protection with Redis persistence
+        // Check for REDIS_URL first, then fall back to CONDUIT_REDIS_CONNECTION_STRING
+        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL");
         var redisConnectionString = Environment.GetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING");
+
+        if (!string.IsNullOrEmpty(redisUrl))
+        {
+            try
+            {
+                redisConnectionString = ConduitLLM.Configuration.Utilities.RedisUrlParser.ParseRedisUrl(redisUrl);
+            }
+            catch
+            {
+                // Failed to parse REDIS_URL, will use legacy connection string if available
+            }
+        }
+
         builder.Services.AddRedisDataProtection(redisConnectionString, "Conduit");
 
         // Add standardized health checks
@@ -96,6 +111,20 @@ public partial class Program
         builder.Services.AddConduitHealthChecks(connectionString, redisConnectionString);
 
         var app = builder.Build();
+
+        // Log deprecation warnings and validate Redis URL
+        using (var scope = app.Services.CreateScope())
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            ConduitLLM.Configuration.Extensions.DeprecationWarnings.LogEnvironmentVariableDeprecations(logger);
+            
+            // Validate Redis URL if provided
+            var envRedisUrl = Environment.GetEnvironmentVariable("REDIS_URL");
+            if (!string.IsNullOrEmpty(envRedisUrl))
+            {
+                ConduitLLM.Configuration.Services.RedisUrlValidator.ValidateAndLog(envRedisUrl, logger, "Admin Service");
+            }
+        }
 
         // Initialize database - Always run unless explicitly told to skip
         // This ensures users get automatic schema updates when pulling new versions

--- a/ConduitLLM.Admin/Security/MasterKeyAuthorizationHandler.cs
+++ b/ConduitLLM.Admin/Security/MasterKeyAuthorizationHandler.cs
@@ -40,7 +40,9 @@ public class MasterKeyAuthorizationHandler : AuthorizationHandler<MasterKeyRequi
             if (context.Resource is HttpContext httpContext)
             {
                 // Get the configured master key
-                string? masterKey = _configuration[MASTER_KEY_CONFIG_KEY];
+                // Check for CONDUIT_MASTER_KEY first (new standard), then fall back to AdminApi:MasterKey
+                string? masterKey = Environment.GetEnvironmentVariable("CONDUIT_MASTER_KEY") 
+                                   ?? _configuration[MASTER_KEY_CONFIG_KEY];
 
                 if (string.IsNullOrEmpty(masterKey))
                 {

--- a/ConduitLLM.Configuration/Extensions/DeprecationWarnings.cs
+++ b/ConduitLLM.Configuration/Extensions/DeprecationWarnings.cs
@@ -1,0 +1,97 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Configuration.Extensions
+{
+    /// <summary>
+    /// Helper class for logging deprecation warnings for old environment variables
+    /// </summary>
+    public static class DeprecationWarnings
+    {
+        /// <summary>
+        /// Logs deprecation warnings if old environment variables are being used
+        /// </summary>
+        /// <param name="logger">The logger to use for warnings</param>
+        public static void LogEnvironmentVariableDeprecations(ILogger logger)
+        {
+            // Check for deprecated Redis configuration
+            var oldRedisConnectionString = Environment.GetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING");
+            var newRedisUrl = Environment.GetEnvironmentVariable("REDIS_URL");
+            
+            if (!string.IsNullOrEmpty(oldRedisConnectionString) && string.IsNullOrEmpty(newRedisUrl))
+            {
+                logger.LogWarning(
+                    "DEPRECATION WARNING: Environment variable 'CONDUIT_REDIS_CONNECTION_STRING' is deprecated. " +
+                    "Please use 'REDIS_URL' instead with format: redis://[username]:[password]@hostname:port. " +
+                    "The old variable will be removed in a future version.");
+            }
+
+            // Check for deprecated cache enabled/type
+            var cacheEnabled = Environment.GetEnvironmentVariable("CONDUIT_CACHE_ENABLED");
+            var cacheType = Environment.GetEnvironmentVariable("CONDUIT_CACHE_TYPE");
+            
+            if (!string.IsNullOrEmpty(cacheEnabled) || !string.IsNullOrEmpty(cacheType))
+            {
+                logger.LogWarning(
+                    "DEPRECATION WARNING: Environment variables 'CONDUIT_CACHE_ENABLED' and 'CONDUIT_CACHE_TYPE' are deprecated. " +
+                    "Cache is now automatically enabled when REDIS_URL is provided. " +
+                    "These variables will be removed in a future version.");
+            }
+
+            // Check for deprecated master key
+            var oldMasterKey = Environment.GetEnvironmentVariable("AdminApi__MasterKey");
+            var newMasterKey = Environment.GetEnvironmentVariable("CONDUIT_MASTER_KEY");
+            
+            if (!string.IsNullOrEmpty(oldMasterKey) && string.IsNullOrEmpty(newMasterKey))
+            {
+                logger.LogWarning(
+                    "DEPRECATION WARNING: Configuration key 'AdminApi__MasterKey' is deprecated. " +
+                    "Please use environment variable 'CONDUIT_MASTER_KEY' instead. " +
+                    "The old configuration key will be removed in a future version.");
+            }
+        }
+
+        /// <summary>
+        /// Gets a summary of deprecated environment variables in use
+        /// </summary>
+        /// <returns>A summary message or null if no deprecated variables are in use</returns>
+        public static string? GetDeprecationSummary()
+        {
+            var deprecatedVars = new List<string>();
+
+            var oldRedisConnectionString = Environment.GetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING");
+            var newRedisUrl = Environment.GetEnvironmentVariable("REDIS_URL");
+            if (!string.IsNullOrEmpty(oldRedisConnectionString) && string.IsNullOrEmpty(newRedisUrl))
+            {
+                deprecatedVars.Add("CONDUIT_REDIS_CONNECTION_STRING (use REDIS_URL)");
+            }
+
+            var cacheEnabled = Environment.GetEnvironmentVariable("CONDUIT_CACHE_ENABLED");
+            if (!string.IsNullOrEmpty(cacheEnabled))
+            {
+                deprecatedVars.Add("CONDUIT_CACHE_ENABLED (no longer needed with REDIS_URL)");
+            }
+
+            var cacheType = Environment.GetEnvironmentVariable("CONDUIT_CACHE_TYPE");
+            if (!string.IsNullOrEmpty(cacheType))
+            {
+                deprecatedVars.Add("CONDUIT_CACHE_TYPE (no longer needed with REDIS_URL)");
+            }
+
+            var oldMasterKey = Environment.GetEnvironmentVariable("AdminApi__MasterKey");
+            var newMasterKey = Environment.GetEnvironmentVariable("CONDUIT_MASTER_KEY");
+            if (!string.IsNullOrEmpty(oldMasterKey) && string.IsNullOrEmpty(newMasterKey))
+            {
+                deprecatedVars.Add("AdminApi__MasterKey (use CONDUIT_MASTER_KEY)");
+            }
+
+            if (deprecatedVars.Count == 0)
+            {
+                return null;
+            }
+
+            return $"The following deprecated environment variables are in use: {string.Join(", ", deprecatedVars)}. " +
+                   "Please see docs/MIGRATION_ENV_VARS.md for migration instructions.";
+        }
+    }
+}

--- a/ConduitLLM.Configuration/Options/CacheOptions.cs
+++ b/ConduitLLM.Configuration/Options/CacheOptions.cs
@@ -13,15 +13,28 @@ namespace ConduitLLM.Configuration.Options
         /// </summary>
         public const string SectionName = "Cache";
 
+        private bool? _isEnabledOverride;
+        private string? _cacheTypeOverride;
+
         /// <summary>
         /// Whether the cache is enabled
+        /// Auto-enables when Redis is configured unless explicitly overridden
         /// </summary>
-        public bool IsEnabled { get; set; } = false;
+        public bool IsEnabled 
+        { 
+            get => _isEnabledOverride ?? !string.IsNullOrWhiteSpace(RedisConnectionString);
+            set => _isEnabledOverride = value;
+        }
 
         /// <summary>
         /// The type of cache to use
+        /// Automatically set to "Redis" when Redis is configured unless explicitly overridden
         /// </summary>
-        public string CacheType { get; set; } = "Memory";
+        public string CacheType 
+        { 
+            get => _cacheTypeOverride ?? (!string.IsNullOrWhiteSpace(RedisConnectionString) ? "Redis" : "Memory");
+            set => _cacheTypeOverride = value;
+        }
 
         /// <summary>
         /// Default absolute expiration time in minutes

--- a/ConduitLLM.Configuration/Services/RedisUrlValidator.cs
+++ b/ConduitLLM.Configuration/Services/RedisUrlValidator.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Configuration.Services
+{
+    /// <summary>
+    /// Validates Redis URL format and logs warnings for invalid URLs
+    /// </summary>
+    public static class RedisUrlValidator
+    {
+        private static readonly Regex RedisUrlRegex = new Regex(
+            @"^rediss?://(?:(?<username>[^:@]+)?:?(?<password>[^@]+)?@)?(?<host>[^:]+)(?::(?<port>\d+))?$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Validates a Redis URL and logs appropriate warnings
+        /// </summary>
+        /// <param name="redisUrl">The Redis URL to validate</param>
+        /// <param name="logger">Logger for warnings</param>
+        /// <param name="serviceName">Name of the service for logging context</param>
+        /// <returns>True if valid, false otherwise</returns>
+        public static bool ValidateAndLog(string? redisUrl, ILogger logger, string serviceName)
+        {
+            if (string.IsNullOrWhiteSpace(redisUrl))
+            {
+                return false;
+            }
+
+            try
+            {
+                // Validate the URL format first
+                if (!RedisUrlRegex.IsMatch(redisUrl))
+                {
+                    logger.LogWarning(
+                        "{ServiceName}: Redis URL format appears invalid. Expected format: redis://[username]:[password]@hostname:port. URL: {RedisUrl}",
+                        serviceName,
+                        SanitizeUrlForLogging(redisUrl));
+                    return false;
+                }
+                
+                // Try to parse it
+                var parsed = Utilities.RedisUrlParser.ParseRedisUrl(redisUrl);
+
+                // Check for common issues
+                if (redisUrl.Contains(" "))
+                {
+                    logger.LogWarning(
+                        "{ServiceName}: Redis URL contains spaces. This is likely invalid. URL: {RedisUrl}",
+                        serviceName,
+                        SanitizeUrlForLogging(redisUrl));
+                    return false;
+                }
+
+                // Check for missing port (common mistake)
+                if (!redisUrl.Contains(":637") && !redisUrl.Contains(":638") && !redisUrl.Contains(":"))
+                {
+                    logger.LogWarning(
+                        "{ServiceName}: Redis URL appears to be missing port number. Default Redis port is 6379. URL: {RedisUrl}",
+                        serviceName,
+                        SanitizeUrlForLogging(redisUrl));
+                }
+
+                logger.LogInformation(
+                    "{ServiceName}: Redis URL validated successfully",
+                    serviceName);
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "{ServiceName}: Failed to validate Redis URL. URL: {RedisUrl}",
+                    serviceName,
+                    SanitizeUrlForLogging(redisUrl));
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Sanitizes a Redis URL for safe logging by masking sensitive information
+        /// </summary>
+        /// <param name="redisUrl">The URL to sanitize</param>
+        /// <returns>Sanitized URL safe for logging</returns>
+        private static string SanitizeUrlForLogging(string redisUrl)
+        {
+            if (string.IsNullOrWhiteSpace(redisUrl))
+            {
+                return "(empty)";
+            }
+
+            try
+            {
+                // Replace password with asterisks
+                var match = RedisUrlRegex.Match(redisUrl);
+                if (match.Success && match.Groups["password"].Success)
+                {
+                    var password = match.Groups["password"].Value;
+                    return redisUrl.Replace(password, "****");
+                }
+
+                // If no password found, return as-is (already safe)
+                return redisUrl;
+            }
+            catch
+            {
+                // If any error, just mask everything after ://
+                var protocolIndex = redisUrl.IndexOf("://", StringComparison.OrdinalIgnoreCase);
+                if (protocolIndex > 0)
+                {
+                    return redisUrl.Substring(0, protocolIndex + 3) + "****";
+                }
+                
+                return "(invalid)";
+            }
+        }
+    }
+}

--- a/ConduitLLM.Configuration/Utilities/RedisUrlParser.cs
+++ b/ConduitLLM.Configuration/Utilities/RedisUrlParser.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace ConduitLLM.Configuration.Utilities
+{
+    /// <summary>
+    /// Utility class for parsing Redis URLs into connection strings
+    /// </summary>
+    public static class RedisUrlParser
+    {
+        /// <summary>
+        /// Parses a Redis URL into a StackExchange.Redis compatible connection string
+        /// </summary>
+        /// <param name="redisUrl">Redis URL in format: redis://[username]:[password]@[hostname]:[port]</param>
+        /// <returns>StackExchange.Redis compatible connection string</returns>
+        public static string ParseRedisUrl(string redisUrl)
+        {
+            if (string.IsNullOrWhiteSpace(redisUrl))
+            {
+                throw new ArgumentException("Redis URL cannot be null or empty", nameof(redisUrl));
+            }
+
+            // Remove redis:// prefix if present
+            if (redisUrl.StartsWith("redis://", StringComparison.OrdinalIgnoreCase))
+            {
+                redisUrl = redisUrl.Substring(8);
+            }
+            else if (redisUrl.StartsWith("rediss://", StringComparison.OrdinalIgnoreCase))
+            {
+                // SSL support - we'll add ssl=true to the connection string
+                redisUrl = redisUrl.Substring(9);
+                return ParseConnectionString(redisUrl, useSsl: true);
+            }
+
+            return ParseConnectionString(redisUrl, useSsl: false);
+        }
+
+        private static string ParseConnectionString(string urlPart, bool useSsl)
+        {
+            // Handle authentication part separately
+            string host;
+            string port = "6379";
+            string? username = null;
+            string? password = null;
+
+            // Check if there's an @ sign indicating authentication
+            var atIndex = urlPart.LastIndexOf('@');
+            if (atIndex >= 0)
+            {
+                var authPart = urlPart.Substring(0, atIndex);
+                var hostPart = urlPart.Substring(atIndex + 1);
+
+                // Parse auth part
+                var colonIndex = authPart.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    if (colonIndex == 0)
+                    {
+                        // Format is :password (no username)
+                        password = authPart.Substring(1);
+                    }
+                    else
+                    {
+                        // Format is username:password
+                        username = authPart.Substring(0, colonIndex);
+                        password = authPart.Substring(colonIndex + 1);
+                    }
+                }
+
+                // Parse host:port
+                var portIndex = hostPart.LastIndexOf(':');
+                if (portIndex >= 0 && portIndex < hostPart.Length - 1)
+                {
+                    host = hostPart.Substring(0, portIndex);
+                    port = hostPart.Substring(portIndex + 1);
+                }
+                else
+                {
+                    host = hostPart;
+                }
+            }
+            else
+            {
+                // No authentication, just host:port
+                var portIndex = urlPart.LastIndexOf(':');
+                if (portIndex >= 0 && portIndex < urlPart.Length - 1)
+                {
+                    // Make sure it's actually a port by checking if it's numeric
+                    var possiblePort = urlPart.Substring(portIndex + 1);
+                    if (int.TryParse(possiblePort, out _))
+                    {
+                        host = urlPart.Substring(0, portIndex);
+                        port = possiblePort;
+                    }
+                    else
+                    {
+                        host = urlPart;
+                    }
+                }
+                else
+                {
+                    host = urlPart;
+                }
+            }
+
+            // Build StackExchange.Redis connection string
+            var connectionString = $"{host}:{port}";
+
+            if (!string.IsNullOrEmpty(password))
+            {
+                connectionString += $",password={password}";
+            }
+
+            if (!string.IsNullOrEmpty(username))
+            {
+                connectionString += $",user={username}";
+            }
+
+            if (useSsl)
+            {
+                connectionString += ",ssl=true";
+            }
+
+            // Add some reasonable defaults for production use
+            connectionString += ",abortConnect=false,connectTimeout=10000,syncTimeout=10000";
+
+            return connectionString;
+        }
+    }
+}

--- a/ConduitLLM.Tests/Configuration/EnvironmentVariableIntegrationTests.cs
+++ b/ConduitLLM.Tests/Configuration/EnvironmentVariableIntegrationTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Threading.Tasks;
+using ConduitLLM.Configuration.Extensions;
+using ConduitLLM.Configuration.Options;
+using ConduitLLM.Configuration.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace ConduitLLM.Tests.Configuration
+{
+    /// <summary>
+    /// Integration tests for environment variable configuration
+    /// </summary>
+    public class EnvironmentVariableIntegrationTests : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalEnvVars = new();
+        private readonly List<string> _envVarsToClean = new()
+        {
+            "REDIS_URL",
+            "CONDUIT_REDIS_CONNECTION_STRING",
+            "CONDUIT_CACHE_ENABLED",
+            "CONDUIT_CACHE_TYPE",
+            "CONDUIT_REDIS_INSTANCE_NAME",
+            "CONDUIT_MASTER_KEY",
+            "AdminApi__MasterKey"
+        };
+
+        public EnvironmentVariableIntegrationTests()
+        {
+            // Save original environment variables
+            foreach (var key in _envVarsToClean)
+            {
+                _originalEnvVars[key] = Environment.GetEnvironmentVariable(key);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Restore original environment variables
+            foreach (var kvp in _originalEnvVars)
+            {
+                if (kvp.Value == null)
+                {
+                    Environment.SetEnvironmentVariable(kvp.Key, null);
+                }
+                else
+                {
+                    Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void RedisUrl_TakesPrecedenceOver_LegacyConnectionString()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://newhost:6380");
+            Environment.SetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING", "oldhost:6379");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.Contains("newhost:6380", cacheOptions.RedisConnectionString);
+        }
+
+        [Fact]
+        public void LegacyConnectionString_UsedWhenRedisUrlNotProvided()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", null);
+            Environment.SetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING", "legacyhost:6379");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.Equal("legacyhost:6379", cacheOptions.RedisConnectionString);
+        }
+
+        [Fact]
+        public void CacheAutoEnables_WhenRedisUrlProvided()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://autohost:6379");
+            Environment.SetEnvironmentVariable("CONDUIT_CACHE_ENABLED", null); // Not set
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.True(cacheOptions.IsEnabled);
+            Assert.Equal("Redis", cacheOptions.CacheType);
+        }
+
+        [Fact]
+        public void ExplicitCacheDisable_OverridesAutoEnable()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://autohost:6379");
+            Environment.SetEnvironmentVariable("CONDUIT_CACHE_ENABLED", "false");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.False(cacheOptions.IsEnabled);
+            // CacheType is still Redis because Redis is configured
+            Assert.Equal("Redis", cacheOptions.CacheType);
+        }
+
+        [Fact]
+        public void RedisUrlWithAuth_ParsesCorrectly()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://user:pass@authhost:6379");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.Contains("authhost:6379", cacheOptions.RedisConnectionString);
+            Assert.Contains("user=user", cacheOptions.RedisConnectionString);
+            Assert.Contains("password=pass", cacheOptions.RedisConnectionString);
+            Assert.True(cacheOptions.IsEnabled);
+        }
+
+        [Fact]
+        public void InvalidRedisUrl_FallsBackToLegacy()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "not-a-valid-url");
+            Environment.SetEnvironmentVariable("CONDUIT_REDIS_CONNECTION_STRING", "fallbackhost:6379");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.Equal("fallbackhost:6379", cacheOptions.RedisConnectionString);
+        }
+
+        [Fact]
+        public void RedisInstanceName_CanBeOverridden()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://localhost:6379");
+            Environment.SetEnvironmentVariable("CONDUIT_REDIS_INSTANCE_NAME", "custom-instance");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Cache:RedisInstanceName"] = "from-config"
+                })
+                .Build();
+            
+            // Act
+            services.AddCacheService(configuration);
+            var provider = services.BuildServiceProvider();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.Equal("from-config", cacheOptions.RedisInstanceName); // Config takes precedence
+        }
+
+        [Fact]
+        public void CacheService_WorksWithNewRedisUrl()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("REDIS_URL", "redis://localhost:6379");
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            services.AddLogging();
+            services.AddCacheService(configuration);
+            
+            // Act
+            var provider = services.BuildServiceProvider();
+            var cacheService = provider.GetRequiredService<ICacheService>();
+            var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            // Assert
+            Assert.NotNull(cacheService);
+            Assert.True(cacheOptions.IsEnabled);
+            Assert.Equal("Redis", cacheOptions.CacheType);
+            
+            // Test basic cache operations (will use memory cache if Redis not actually running)
+            cacheService.Set("test-key", "test-value", TimeSpan.FromMinutes(1));
+            var result = cacheService.Get<string>("test-key");
+            Assert.Equal("test-value", result);
+        }
+
+        [Fact]
+        public void MultipleRedisUrlFormats_ParseCorrectly()
+        {
+            var testCases = new (string, object)[]
+            {
+                ("redis://localhost:6379", "localhost:6379"),
+                ("redis://:password@localhost:6379", "password=password"),
+                ("redis://user:pass@host:1234", new[] { "host:1234", "user=user", "password=pass" }),
+                ("rediss://secure:6380", new[] { "secure:6380", "ssl=true" })
+            };
+
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+
+            foreach (var testCase in testCases)
+            {
+                Environment.SetEnvironmentVariable("REDIS_URL", testCase.Item1);
+                
+                services.Clear();
+                services.AddCacheService(configuration);
+                var provider = services.BuildServiceProvider();
+                var cacheOptions = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+                if (testCase.Item2 is string expectedString)
+                {
+                    Assert.Contains(expectedString, cacheOptions.RedisConnectionString);
+                }
+                else if (testCase.Item2 is string[] expectedParts)
+                {
+                    foreach (var part in expectedParts)
+                    {
+                        Assert.Contains(part, cacheOptions.RedisConnectionString);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ConduitLLM.Tests/Configuration/RedisUrlParserTests.cs
+++ b/ConduitLLM.Tests/Configuration/RedisUrlParserTests.cs
@@ -1,0 +1,144 @@
+using System;
+using ConduitLLM.Configuration.Utilities;
+using Xunit;
+
+namespace ConduitLLM.Tests.Configuration
+{
+    public class RedisUrlParserTests
+    {
+        [Fact]
+        public void ParseRedisUrl_SimpleHostAndPort_ReturnsCorrectConnectionString()
+        {
+            // Arrange
+            var redisUrl = "redis://localhost:6379";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6379", result);
+            Assert.Contains("abortConnect=false", result);
+            Assert.Contains("connectTimeout=10000", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_HostOnly_DefaultsToPort6379()
+        {
+            // Arrange
+            var redisUrl = "redis://localhost";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6379", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_WithPassword_IncludesPassword()
+        {
+            // Arrange
+            var redisUrl = "redis://:mypassword@localhost:6379";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6379", result);
+            Assert.Contains("password=mypassword", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_WithUsernameAndPassword_IncludesBoth()
+        {
+            // Arrange
+            var redisUrl = "redis://myuser:mypassword@localhost:6379";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6379", result);
+            Assert.Contains("password=mypassword", result);
+            Assert.Contains("user=myuser", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_WithoutProtocol_StillWorks()
+        {
+            // Arrange
+            var redisUrl = "localhost:6379";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6379", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_WithSsl_AddsSslFlag()
+        {
+            // Arrange
+            var redisUrl = "rediss://localhost:6380";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("localhost:6380", result);
+            Assert.Contains("ssl=true", result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ParseRedisUrl_EmptyOrNull_ThrowsArgumentException(string redisUrl)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => RedisUrlParser.ParseRedisUrl(redisUrl));
+        }
+
+        [Fact]
+        public void ParseRedisUrl_ComplexFormat_ParsesSuccessfully()
+        {
+            // Arrange
+            var redisUrl = "redis://invalid::format::here";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert - our parser is lenient and treats this as a hostname
+            Assert.Contains("invalid::format::here:6379", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_RealWorldAzureCache_ParsesCorrectly()
+        {
+            // Arrange
+            var redisUrl = "redis://:abc123xyz456@myredis.redis.cache.windows.net:6380";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("myredis.redis.cache.windows.net:6380", result);
+            Assert.Contains("password=abc123xyz456", result);
+        }
+
+        [Fact]
+        public void ParseRedisUrl_DockerComposeFormat_ParsesCorrectly()
+        {
+            // Arrange
+            var redisUrl = "redis://redis:6379";
+
+            // Act
+            var result = RedisUrlParser.ParseRedisUrl(redisUrl);
+
+            // Assert
+            Assert.Contains("redis:6379", result);
+            Assert.DoesNotContain("password=", result);
+        }
+    }
+}

--- a/ConduitLLM.Tests/Http/AudioControllerTests.cs
+++ b/ConduitLLM.Tests/Http/AudioControllerTests.cs
@@ -23,14 +23,14 @@ namespace ConduitLLM.Tests.Http
     public class AudioControllerTests
     {
         private readonly Mock<IAudioRouter> _mockAudioRouter;
-        private readonly Mock<Configuration.Services.IVirtualKeyService> _mockVirtualKeyService;
+        private readonly Mock<ConduitLLM.Configuration.Services.IVirtualKeyService> _mockVirtualKeyService;
         private readonly Mock<ILogger<AudioController>> _mockLogger;
         private readonly AudioController _controller;
 
         public AudioControllerTests()
         {
             _mockAudioRouter = new Mock<IAudioRouter>();
-            _mockVirtualKeyService = new Mock<Configuration.Services.IVirtualKeyService>();
+            _mockVirtualKeyService = new Mock<ConduitLLM.Configuration.Services.IVirtualKeyService>();
             _mockLogger = new Mock<ILogger<AudioController>>();
             _controller = new AudioController(
                 _mockAudioRouter.Object,

--- a/README.md
+++ b/README.md
@@ -253,6 +253,35 @@ docker compose up -d
 
 *Note: The default Docker configuration assumes ConduitLLM runs behind a reverse proxy that handles HTTPS termination. The container exposes HTTP ports only.*
 
+### Environment Variables
+
+ConduitLLM uses simplified environment variables for easier configuration:
+
+#### Redis Cache Configuration
+```bash
+# New simplified format (recommended)
+REDIS_URL=redis://localhost:6379
+CONDUIT_REDIS_INSTANCE_NAME=conduit:  # Optional, defaults to "conduitllm-cache"
+
+# Legacy format (still supported)
+CONDUIT_REDIS_CONNECTION_STRING=localhost:6379
+CONDUIT_CACHE_ENABLED=true
+CONDUIT_CACHE_TYPE=Redis
+```
+
+When `REDIS_URL` is provided, cache is automatically enabled with type "Redis".
+
+#### Master Key Configuration
+```bash
+# Standardized across all services
+CONDUIT_MASTER_KEY=your-secure-master-key
+
+# Legacy format (still supported)
+AdminApi__MasterKey=your-secure-master-key
+```
+
+For a complete migration guide from old to new environment variables, see [Environment Variable Migration Guide](docs/MIGRATION_ENV_VARS.md).
+
 ## Usage
 
 ### Using the API

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
       - DetailedErrors=true
       - AdminApiUrl=http://admin:8080  # Point to admin container
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=conduitllm;Username=conduitllm;Password=conduitllm
-      - ConnectionStrings__RedisConnection=redis:6379
+      - REDIS_URL=redis://redis:6379
     volumes:
       # Mount source code for hot reload
       - ./ConduitLLM.WebUI:/src/ConduitLLM.WebUI
@@ -90,8 +90,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=conduitllm;Username=conduitllm;Password=conduitllm
-      - ConnectionStrings__RedisConnection=redis:6379
-      - MasterKey=${CONDUIT_MASTER_KEY:-development-key-change-me}
+      - REDIS_URL=redis://redis:6379
+      - CONDUIT_MASTER_KEY=${CONDUIT_MASTER_KEY:-development-key-change-me}
     ports:
       - "5002:8080"
     depends_on:
@@ -116,7 +116,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Host=postgres;Database=conduitllm;Username=conduitllm;Password=conduitllm
-      - ConnectionStrings__RedisConnection=redis:6379
+      - REDIS_URL=redis://redis:6379
       - AdminApiUrl=http://admin:8080
     ports:
       - "5000:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,8 @@ services:
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
-      CONDUIT_CACHE_ENABLED: "true"
-      CONDUIT_CACHE_TYPE: "Redis"
-      CONDUIT_REDIS_CONNECTION_STRING: "redis:6379"
+      # Using new REDIS_URL format (old variables still work for backward compatibility)
+      REDIS_URL: "redis://redis:6379"
       CONDUIT_REDIS_INSTANCE_NAME: "conduit:"
       Conduit__PerformanceTracking__Enabled: "true"
       Conduit__PerformanceTracking__IncludeInResponse: "true"
@@ -70,7 +69,11 @@ services:
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
-      AdminApi__MasterKey: alpha
+      # Using new CONDUIT_MASTER_KEY (old AdminApi__MasterKey still works)
+      CONDUIT_MASTER_KEY: alpha
+      # Redis cache configuration - using new REDIS_URL format
+      REDIS_URL: "redis://redis:6379"
+      CONDUIT_REDIS_INSTANCE_NAME: "conduit:"
       AdminApi__AllowedOrigins__0: http://webui:8080
       AdminApi__AllowedOrigins__1: http://localhost:5001
     ports:
@@ -99,10 +102,8 @@ services:
       CONDUIT_MASTER_KEY: alpha
       CONDUIT_INSECURE: "true"
       CONDUIT_API_BASE_URL: http://api:8080
-      # Redis cache configuration
-      CONDUIT_CACHE_ENABLED: "true"
-      CONDUIT_CACHE_TYPE: "Redis"
-      CONDUIT_REDIS_CONNECTION_STRING: "redis:6379"
+      # Redis cache configuration - using new REDIS_URL format
+      REDIS_URL: "redis://redis:6379"
       CONDUIT_REDIS_INSTANCE_NAME: "conduit:"
       # Version check configuration
       CONDUIT_VERSION_CHECK_ENABLED: "true"

--- a/docs/MIGRATION_ENV_VARS.md
+++ b/docs/MIGRATION_ENV_VARS.md
@@ -1,0 +1,210 @@
+# Environment Variable Migration Guide
+
+This guide helps you migrate from the old environment variable structure to the new simplified configuration in Conduit.
+
+## Overview of Changes
+
+We've simplified the environment variable configuration to make first-time setup easier while maintaining backward compatibility. The main changes are:
+
+1. **Redis Configuration**: Simplified from 4 variables to 1 (plus optional instance name)
+2. **Master Key**: Standardized across all services
+3. **Auto-enable Cache**: Cache automatically enables when Redis is configured
+
+## Redis Configuration Changes
+
+### Old Configuration
+```bash
+# Required 4 separate variables:
+CONDUIT_REDIS_CONNECTION_STRING="localhost:6379"
+CONDUIT_CACHE_ENABLED="true"
+CONDUIT_CACHE_TYPE="Redis"
+CONDUIT_REDIS_INSTANCE_NAME="conduit:"  # Optional
+```
+
+### New Configuration
+```bash
+# Only 1 required variable:
+REDIS_URL="redis://localhost:6379"
+CONDUIT_REDIS_INSTANCE_NAME="conduit:"  # Optional, defaults to "conduitllm-cache"
+```
+
+The cache is automatically enabled when `REDIS_URL` is provided, and the cache type is automatically set to "Redis".
+
+### Redis URL Formats Supported
+
+- Basic: `redis://hostname:port`
+- With auth: `redis://username:password@hostname:port`
+- With password only: `redis://:password@hostname:port`
+- Custom port: `redis://hostname:1234`
+- SSL/TLS: `rediss://hostname:port` (note the double 's')
+
+## Master Key Configuration Changes
+
+### Old Configuration
+```bash
+# Admin service used a different variable:
+AdminApi__MasterKey="your-master-key"
+
+# Other services might have used different patterns
+```
+
+### New Configuration
+```bash
+# All services now use the same variable:
+CONDUIT_MASTER_KEY="your-master-key"
+```
+
+## Migration Steps
+
+### 1. Update Docker Compose Files
+
+If you're using Docker Compose, update your `docker-compose.yml`:
+
+```yaml
+# Old configuration
+services:
+  api:
+    environment:
+      CONDUIT_REDIS_CONNECTION_STRING: "redis:6379"
+      CONDUIT_CACHE_ENABLED: "true"
+      CONDUIT_CACHE_TYPE: "Redis"
+      
+  admin:
+    environment:
+      AdminApi__MasterKey: "your-key"
+
+# New configuration
+services:
+  api:
+    environment:
+      REDIS_URL: "redis://redis:6379"
+      
+  admin:
+    environment:
+      CONDUIT_MASTER_KEY: "your-key"
+```
+
+### 2. Update Environment Files
+
+If you're using `.env` files:
+
+```bash
+# Old .env
+CONDUIT_REDIS_CONNECTION_STRING=localhost:6379
+CONDUIT_CACHE_ENABLED=true
+CONDUIT_CACHE_TYPE=Redis
+AdminApi__MasterKey=your-master-key
+
+# New .env
+REDIS_URL=redis://localhost:6379
+CONDUIT_MASTER_KEY=your-master-key
+```
+
+### 3. Update System Environment Variables
+
+For system-level environment variables:
+
+```bash
+# Remove old variables
+unset CONDUIT_REDIS_CONNECTION_STRING
+unset CONDUIT_CACHE_ENABLED
+unset CONDUIT_CACHE_TYPE
+
+# Set new variables
+export REDIS_URL="redis://localhost:6379"
+export CONDUIT_MASTER_KEY="your-master-key"
+```
+
+### 4. Update CI/CD Pipelines
+
+Update your CI/CD configuration files to use the new variables:
+
+```yaml
+# GitHub Actions example
+env:
+  REDIS_URL: redis://localhost:6379
+  CONDUIT_MASTER_KEY: ${{ secrets.MASTER_KEY }}
+```
+
+## Backward Compatibility
+
+**Important**: The old environment variables continue to work. The system checks for new variables first, then falls back to the old ones if not found.
+
+Priority order:
+1. For Redis: `REDIS_URL` → `CONDUIT_REDIS_CONNECTION_STRING`
+2. For Master Key: `CONDUIT_MASTER_KEY` → `AdminApi__MasterKey`
+
+This means you can migrate gradually without breaking existing deployments.
+
+## Special Considerations
+
+### Auto-enable Cache Behavior
+
+When `REDIS_URL` is provided:
+- `IsEnabled` automatically becomes `true`
+- `CacheType` automatically becomes `"Redis"`
+
+You can still explicitly disable cache if needed:
+```bash
+REDIS_URL=redis://localhost:6379
+CONDUIT_CACHE_ENABLED=false  # Explicitly disable despite Redis being configured
+```
+
+### Redis Authentication
+
+If your Redis instance requires authentication:
+
+```bash
+# With username and password
+REDIS_URL="redis://myuser:mypassword@redis-server:6379"
+
+# With password only (no username)
+REDIS_URL="redis://:mypassword@redis-server:6379"
+```
+
+### SSL/TLS Connections
+
+For Redis instances with SSL/TLS:
+
+```bash
+# Use 'rediss' protocol (note the double 's')
+REDIS_URL="rediss://secure-redis:6380"
+```
+
+## Troubleshooting
+
+### Cache Not Enabling
+
+If cache isn't automatically enabling:
+1. Check that `REDIS_URL` is properly formatted
+2. Check application logs for Redis connection errors
+3. Verify Redis is accessible from your application
+
+### Authentication Issues
+
+If you're getting authentication errors with the Admin API:
+1. Ensure `CONDUIT_MASTER_KEY` is set in the Admin service environment
+2. Check that you're using the correct header: `X-API-Key: your-master-key`
+
+### Connection String Format Errors
+
+If you see errors parsing the Redis URL:
+1. Ensure the URL follows the format: `redis://[username]:[password]@hostname:port`
+2. Special characters in passwords must be URL-encoded
+3. Port is required (default is 6379)
+
+## Future Deprecation
+
+While backward compatibility is currently maintained, we recommend migrating to the new variables as the old ones may be deprecated in a future major version:
+
+- `CONDUIT_REDIS_CONNECTION_STRING` → Use `REDIS_URL` instead
+- `CONDUIT_CACHE_ENABLED` → No longer needed (auto-enabled with Redis)
+- `CONDUIT_CACHE_TYPE` → No longer needed (auto-detected)
+- `AdminApi__MasterKey` → Use `CONDUIT_MASTER_KEY` instead
+
+## Questions or Issues?
+
+If you encounter any issues during migration, please:
+1. Check the application logs for specific error messages
+2. Verify your Redis URL format is correct
+3. Open an issue on GitHub with details about your configuration


### PR DESCRIPTION
- Add support for REDIS_URL format (redis://[user]:[pass]@host:port)
- Standardize master key to CONDUIT_MASTER_KEY across all services
- Auto-enable cache when Redis URL is provided
- Add comprehensive migration guide for environment variables
- Implement deprecation warnings for old environment variables
- Add Redis URL validation with helpful error messages
- Maintain full backward compatibility with legacy variables

Breaking changes: None - all old environment variables continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)