### PR TITLE
fix: Update MediaAssetsContent to handle virtual key group filtering …

### DIFF
--- a/ConduitLLM.WebUI/src/app/media-assets/components/MediaAssetsContent.tsx
+++ b/ConduitLLM.WebUI/src/app/media-assets/components/MediaAssetsContent.tsx
@@ -76,10 +76,16 @@ export default function MediaAssetsContent() {
     const fetchVirtualKeys = async () => {
       try {
         setLoadingVirtualKeys(true);
-        const result = await withAdminClient(client => 
-          client.virtualKeys.list(1, 1000, selectedKeyGroup)
-        );
-        const items = result.items;
+        const result = await withAdminClient(client => {
+          // If selectedKeyGroup is defined, we need to filter after getting all keys
+          // The SDK list method doesn't support virtualKeyGroupId directly
+          return client.virtualKeys.list(1, 1000);
+        });
+        
+        // Filter by key group if one is selected
+        const items = selectedKeyGroup 
+          ? result.items.filter(item => item.virtualKeyGroupId === selectedKeyGroup)
+          : result.items;
           
         const virtualKeysData: VirtualKeyInfo[] = items.map(item => ({
           id: item.id ?? 0,


### PR DESCRIPTION
…client-side

The SDK's virtualKeys.list() method signature doesn't support virtualKeyGroupId as a direct parameter. Filter results client-side when a key group is selected.