### PR TITLE
feat: implement Redis-based leader election for background services (…

### DIFF
--- a/ConduitLLM.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/ConduitLLM.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -180,11 +180,12 @@ public static class ServiceCollectionExtensions
         // Register cache management service
         services.AddScoped<ICacheManagementService, CacheManagementService>();
 
-        // Register billing audit service for comprehensive billing event tracking
+        // Register billing audit service for comprehensive billing event tracking - with leader election
         services.AddSingleton<ConduitLLM.Configuration.Interfaces.IBillingAuditService, ConduitLLM.Configuration.Services.BillingAuditService>();
-        services.AddHostedService<ConduitLLM.Configuration.Services.BillingAuditService>(provider => 
-            provider.GetRequiredService<ConduitLLM.Configuration.Interfaces.IBillingAuditService>() as ConduitLLM.Configuration.Services.BillingAuditService 
-            ?? throw new InvalidOperationException("BillingAuditService must implement IHostedService"));
+        services.AddLeaderElectedHostedService<ConduitLLM.Configuration.Services.BillingAuditService>(
+            provider => provider.GetRequiredService<ConduitLLM.Configuration.Interfaces.IBillingAuditService>() as ConduitLLM.Configuration.Services.BillingAuditService 
+            ?? throw new InvalidOperationException("BillingAuditService must implement IHostedService"),
+            "BillingAuditService");
 
         // Register Redis error store with deferred resolution
         // IConnectionMultiplexer will be registered by AddRedisDataProtection in Program.cs after this method

--- a/ConduitLLM.Admin/Program.cs
+++ b/ConduitLLM.Admin/Program.cs
@@ -94,6 +94,10 @@ public partial class Program
             });
         });
 
+        // Add leader election service for distributed background service coordination
+        builder.Services.AddLeaderElection();
+        Console.WriteLine("[ConduitLLM.Admin] Leader election service configured for background service coordination");
+
         // Add Core services
         builder.Services.AddCoreServices(builder.Configuration);
 
@@ -245,12 +249,14 @@ public partial class Program
         // Add basic health checks
         builder.Services.AddHealthChecks();
         
-        // Add connection pool warmer for better startup performance
-        builder.Services.AddHostedService<ConduitLLM.Core.Services.ConnectionPoolWarmer>(serviceProvider =>
-        {
-            var logger = serviceProvider.GetRequiredService<ILogger<ConduitLLM.Core.Services.ConnectionPoolWarmer>>();
-            return new ConduitLLM.Core.Services.ConnectionPoolWarmer(serviceProvider, logger, "AdminAPI");
-        });
+        // Add connection pool warmer for better startup performance - with leader election
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Core.Services.ConnectionPoolWarmer>(
+            serviceProvider =>
+            {
+                var logger = serviceProvider.GetRequiredService<ILogger<ConduitLLM.Core.Services.ConnectionPoolWarmer>>();
+                return new ConduitLLM.Core.Services.ConnectionPoolWarmer(serviceProvider, logger, "AdminAPI");
+            },
+            "ConnectionPoolWarmer");
 
         // Configure OpenTelemetry metrics
         builder.Services.AddOpenTelemetry()
@@ -267,8 +273,8 @@ public partial class Program
                     .AddPrometheusExporter();
             });
 
-        // Add monitoring services
-        builder.Services.AddHostedService<ConduitLLM.Admin.Services.AdminOperationsMetricsService>();
+        // Add monitoring services - with leader election
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Admin.Services.AdminOperationsMetricsService>("AdminOperationsMetricsService");
         
         // Add cache infrastructure
         builder.Services.AddCacheInfrastructure(builder.Configuration);

--- a/ConduitLLM.Core/Extensions/LeaderElectionServiceExtensions.cs
+++ b/ConduitLLM.Core/Extensions/LeaderElectionServiceExtensions.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace ConduitLLM.Core.Extensions
+{
+    /// <summary>
+    /// Extension methods for configuring leader election services
+    /// </summary>
+    public static class LeaderElectionServiceExtensions
+    {
+        /// <summary>
+        /// Adds leader election service to the service collection
+        /// </summary>
+        public static IServiceCollection AddLeaderElection(this IServiceCollection services)
+        {
+            // Register the leader election service as singleton
+            services.AddSingleton<ILeaderElectionService>(serviceProvider =>
+            {
+                var redis = serviceProvider.GetService<IConnectionMultiplexer>();
+                var logger = serviceProvider.GetRequiredService<ILogger<RedisLeaderElectionService>>();
+
+                if (redis != null)
+                {
+                    // Use Redis-based leader election if Redis is available
+                    return new RedisLeaderElectionService(redis, logger);
+                }
+                else
+                {
+                    // Fall back to in-memory implementation for development
+                    var inMemoryLogger = serviceProvider.GetRequiredService<ILogger<InMemoryLeaderElectionService>>();
+                    return new InMemoryLeaderElectionService(inMemoryLogger);
+                }
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a hosted service with leader election
+        /// </summary>
+        /// <typeparam name="TService">The type of hosted service to add</typeparam>
+        /// <param name="services">The service collection</param>
+        /// <param name="serviceName">Optional unique name for the service (defaults to type name)</param>
+        /// <returns>The service collection for chaining</returns>
+        public static IServiceCollection AddLeaderElectedHostedService<TService>(
+            this IServiceCollection services,
+            string? serviceName = null)
+            where TService : class, IHostedService
+        {
+            // Register the actual service
+            services.AddSingleton<TService>();
+
+            // Register the wrapper as a hosted service
+            services.AddHostedService(serviceProvider =>
+            {
+                var innerService = serviceProvider.GetRequiredService<TService>();
+                var leaderElectionService = serviceProvider.GetRequiredService<ILeaderElectionService>();
+                var logger = serviceProvider.GetRequiredService<ILogger<Services.LeaderElectedServiceWrapper>>();
+                var name = serviceName ?? typeof(TService).Name;
+
+                return new Services.LeaderElectedServiceWrapper(innerService, leaderElectionService, logger, name);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a hosted service with leader election using a factory
+        /// </summary>
+        public static IServiceCollection AddLeaderElectedHostedService<TService>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TService> implementationFactory,
+            string? serviceName = null)
+            where TService : class, IHostedService
+        {
+            // Register the wrapper as a hosted service
+            services.AddHostedService(serviceProvider =>
+            {
+                var innerService = implementationFactory(serviceProvider);
+                var leaderElectionService = serviceProvider.GetRequiredService<ILeaderElectionService>();
+                var logger = serviceProvider.GetRequiredService<ILogger<Services.LeaderElectedServiceWrapper>>();
+                var name = serviceName ?? typeof(TService).Name;
+
+                return new Services.LeaderElectedServiceWrapper(innerService, leaderElectionService, logger, name);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Converts an existing hosted service registration to use leader election
+        /// </summary>
+        public static IServiceCollection ConvertToLeaderElected<TService>(
+            this IServiceCollection services,
+            string? serviceName = null)
+            where TService : class, IHostedService
+        {
+            // Find and remove the existing hosted service registration
+            var hostedServiceDescriptor = services.FirstOrDefault(d =>
+                d.ServiceType == typeof(IHostedService) &&
+                d.ImplementationType == typeof(TService));
+
+            if (hostedServiceDescriptor != null)
+            {
+                services.Remove(hostedServiceDescriptor);
+            }
+
+            // Add it back with leader election
+            return services.AddLeaderElectedHostedService<TService>(serviceName);
+        }
+    }
+}

--- a/ConduitLLM.Core/Interfaces/ILeaderElectionService.cs
+++ b/ConduitLLM.Core/Interfaces/ILeaderElectionService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConduitLLM.Core.Interfaces
+{
+    /// <summary>
+    /// Service for managing distributed leader election for background services
+    /// </summary>
+    public interface ILeaderElectionService
+    {
+        /// <summary>
+        /// Attempts to acquire leadership for a specific service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service requiring leadership</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>True if leadership was acquired, false otherwise</returns>
+        Task<bool> TryAcquireLeadershipAsync(string serviceName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Releases leadership for a specific service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task ReleaseLeadershipAsync(string serviceName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Checks if the current instance is the leader for a specific service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>True if this instance is the leader, false otherwise</returns>
+        Task<bool> IsLeaderAsync(string serviceName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the current leader instance ID for a specific service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Instance ID of the current leader, or null if no leader</returns>
+        Task<string?> GetCurrentLeaderAsync(string serviceName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Starts automatic leadership renewal for a service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task StartLeadershipMaintenanceAsync(string serviceName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Stops automatic leadership renewal for a service
+        /// </summary>
+        /// <param name="serviceName">Unique name of the service</param>
+        Task StopLeadershipMaintenanceAsync(string serviceName);
+    }
+}

--- a/ConduitLLM.Core/Services/InMemoryLeaderElectionService.cs
+++ b/ConduitLLM.Core/Services/InMemoryLeaderElectionService.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using ConduitLLM.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Core.Services
+{
+    /// <summary>
+    /// In-memory implementation of leader election service for development/single-instance scenarios
+    /// </summary>
+    public class InMemoryLeaderElectionService : ILeaderElectionService
+    {
+        private readonly ILogger<InMemoryLeaderElectionService> _logger;
+        private readonly ConcurrentDictionary<string, string> _leaders;
+        private readonly string _instanceId;
+
+        public InMemoryLeaderElectionService(ILogger<InMemoryLeaderElectionService> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _leaders = new ConcurrentDictionary<string, string>();
+            _instanceId = $"InMemory:{Guid.NewGuid():N}";
+            
+            _logger.LogWarning(
+                "Using in-memory leader election service. This should only be used in development or single-instance deployments.");
+        }
+
+        public Task<bool> TryAcquireLeadershipAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var acquired = _leaders.TryAdd(serviceName, _instanceId);
+            
+            if (acquired)
+            {
+                _logger.LogInformation("Leadership acquired for service {ServiceName}", serviceName);
+            }
+            
+            return Task.FromResult(acquired);
+        }
+
+        public Task ReleaseLeadershipAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            if (_leaders.TryRemove(serviceName, out _))
+            {
+                _logger.LogInformation("Leadership released for service {ServiceName}", serviceName);
+            }
+            
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsLeaderAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var isLeader = _leaders.TryGetValue(serviceName, out var leader) && leader == _instanceId;
+            return Task.FromResult(isLeader);
+        }
+
+        public Task<string?> GetCurrentLeaderAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            _leaders.TryGetValue(serviceName, out var leader);
+            return Task.FromResult(leader);
+        }
+
+        public Task StartLeadershipMaintenanceAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            // No-op for in-memory implementation
+            return Task.CompletedTask;
+        }
+
+        public Task StopLeadershipMaintenanceAsync(string serviceName)
+        {
+            // No-op for in-memory implementation
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ConduitLLM.Core/Services/LeaderElectedBackgroundService.cs
+++ b/ConduitLLM.Core/Services/LeaderElectedBackgroundService.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ConduitLLM.Core.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Core.Services
+{
+    /// <summary>
+    /// Base class for background services that require leader election to ensure single-instance processing
+    /// </summary>
+    public abstract class LeaderElectedBackgroundService : BackgroundService
+    {
+        private readonly ILeaderElectionService _leaderElectionService;
+        private readonly ILogger _logger;
+        private readonly string _serviceName;
+        private readonly TimeSpan _leaderCheckInterval;
+        private bool _isLeader;
+        private bool _wasLeader;
+
+        /// <summary>
+        /// Initializes a new instance of the LeaderElectedBackgroundService class
+        /// </summary>
+        /// <param name="leaderElectionService">Leader election service</param>
+        /// <param name="logger">Logger instance</param>
+        /// <param name="serviceName">Unique name for this service (used for leader election)</param>
+        protected LeaderElectedBackgroundService(
+            ILeaderElectionService leaderElectionService,
+            ILogger logger,
+            string? serviceName = null)
+        {
+            _leaderElectionService = leaderElectionService ?? throw new ArgumentNullException(nameof(leaderElectionService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _serviceName = serviceName ?? GetType().Name;
+            _leaderCheckInterval = TimeSpan.FromSeconds(10);
+            _isLeader = false;
+            _wasLeader = false;
+        }
+
+        /// <summary>
+        /// Gets whether this instance is currently the leader
+        /// </summary>
+        protected bool IsLeader => _isLeader;
+
+        /// <summary>
+        /// Gets the unique service name used for leader election
+        /// </summary>
+        protected string ServiceName => _serviceName;
+
+        /// <summary>
+        /// Main execution loop with leader election
+        /// </summary>
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("Starting leader-elected service {ServiceName}", _serviceName);
+
+            // Initial delay to allow system to stabilize
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Check if we are the leader
+                    _isLeader = await _leaderElectionService.IsLeaderAsync(_serviceName, stoppingToken);
+
+                    if (!_isLeader)
+                    {
+                        // Try to acquire leadership
+                        _isLeader = await _leaderElectionService.TryAcquireLeadershipAsync(_serviceName, stoppingToken);
+                    }
+
+                    if (_isLeader && !_wasLeader)
+                    {
+                        // Just became leader
+                        _logger.LogInformation("Service {ServiceName} became leader on instance {InstanceId}", 
+                            _serviceName, Environment.MachineName);
+                        await OnBecameLeaderAsync(stoppingToken);
+                        _wasLeader = true;
+                    }
+                    else if (!_isLeader && _wasLeader)
+                    {
+                        // Lost leadership
+                        _logger.LogInformation("Service {ServiceName} lost leadership on instance {InstanceId}", 
+                            _serviceName, Environment.MachineName);
+                        await OnLostLeadershipAsync(stoppingToken);
+                        _wasLeader = false;
+                    }
+
+                    if (_isLeader)
+                    {
+                        // Execute the service logic
+                        await ExecuteLeaderWorkAsync(stoppingToken);
+                    }
+                    else
+                    {
+                        // Not leader, wait before checking again
+                        _logger.LogTrace("Service {ServiceName} is not leader, waiting {Interval} before retry", 
+                            _serviceName, _leaderCheckInterval);
+                        await Task.Delay(_leaderCheckInterval, stoppingToken);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when cancellation is requested
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error in leader-elected service {ServiceName}", _serviceName);
+                    
+                    // Wait before retrying
+                    await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+                }
+            }
+
+            // Clean up leadership on shutdown
+            if (_isLeader)
+            {
+                try
+                {
+                    await _leaderElectionService.ReleaseLeadershipAsync(_serviceName);
+                    _logger.LogInformation("Service {ServiceName} released leadership on shutdown", _serviceName);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error releasing leadership for service {ServiceName} on shutdown", _serviceName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when this instance becomes the leader
+        /// Override to perform initialization tasks when becoming leader
+        /// </summary>
+        protected virtual Task OnBecameLeaderAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Called when this instance loses leadership
+        /// Override to perform cleanup tasks when losing leadership
+        /// </summary>
+        protected virtual Task OnLostLeadershipAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Executes the main work of the service when this instance is the leader
+        /// Must be implemented by derived classes
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Task representing the asynchronous operation</returns>
+        protected abstract Task ExecuteLeaderWorkAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Disposes resources used by the service
+        /// </summary>
+        public override async void Dispose()
+        {
+            if (_isLeader)
+            {
+                try
+                {
+                    await _leaderElectionService.ReleaseLeadershipAsync(_serviceName);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error releasing leadership during disposal for service {ServiceName}", _serviceName);
+                }
+            }
+
+            base.Dispose();
+        }
+    }
+}

--- a/ConduitLLM.Core/Services/LeaderElectedServiceWrapper.cs
+++ b/ConduitLLM.Core/Services/LeaderElectedServiceWrapper.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Core.Services
+{
+    /// <summary>
+    /// Wraps an existing IHostedService with leader election capability
+    /// </summary>
+    public class LeaderElectedServiceWrapper : LeaderElectedBackgroundService
+    {
+        private readonly IHostedService _innerService;
+        private readonly ILogger<LeaderElectedServiceWrapper> _logger;
+        private CancellationTokenSource? _innerServiceCts;
+
+        public LeaderElectedServiceWrapper(
+            IHostedService innerService,
+            ILeaderElectionService leaderElectionService,
+            ILogger<LeaderElectedServiceWrapper> logger,
+            string serviceName)
+            : base(leaderElectionService, logger, serviceName)
+        {
+            _innerService = innerService ?? throw new ArgumentNullException(nameof(innerService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        protected override async Task OnBecameLeaderAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Starting inner service {ServiceName} as leader", ServiceName);
+            
+            // Create a new cancellation token source for the inner service
+            _innerServiceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            
+            // Start the inner service
+            await _innerService.StartAsync(_innerServiceCts.Token);
+        }
+
+        protected override async Task OnLostLeadershipAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Stopping inner service {ServiceName} as leadership was lost", ServiceName);
+            
+            // Stop the inner service
+            if (_innerServiceCts != null)
+            {
+                _innerServiceCts.Cancel();
+                
+                try
+                {
+                    // Give the service time to stop gracefully
+                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    await _innerService.StopAsync(cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error stopping inner service {ServiceName}", ServiceName);
+                }
+                finally
+                {
+                    _innerServiceCts.Dispose();
+                    _innerServiceCts = null;
+                }
+            }
+        }
+
+        protected override async Task ExecuteLeaderWorkAsync(CancellationToken cancellationToken)
+        {
+            // The inner service is already running in its own execution context
+            // Just wait for a short period before checking leadership again
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+        }
+
+        public override async void Dispose()
+        {
+            // Stop the inner service if it's running
+            if (_innerServiceCts != null)
+            {
+                _innerServiceCts.Cancel();
+                
+                try
+                {
+                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                    await _innerService.StopAsync(cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error stopping inner service during disposal");
+                }
+                finally
+                {
+                    _innerServiceCts.Dispose();
+                }
+            }
+
+            // Dispose the inner service if it's disposable
+            if (_innerService is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            base.Dispose();
+        }
+    }
+}

--- a/ConduitLLM.Core/Services/RedisLeaderElectionService.cs
+++ b/ConduitLLM.Core/Services/RedisLeaderElectionService.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using ConduitLLM.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace ConduitLLM.Core.Services
+{
+    /// <summary>
+    /// Redis-based implementation of leader election service using distributed locks
+    /// </summary>
+    public class RedisLeaderElectionService : ILeaderElectionService, IDisposable
+    {
+        private readonly IConnectionMultiplexer _redis;
+        private readonly ILogger<RedisLeaderElectionService> _logger;
+        private readonly string _instanceId;
+        private readonly TimeSpan _leadershipTtl;
+        private readonly TimeSpan _renewalInterval;
+        private readonly ConcurrentDictionary<string, Timer> _renewalTimers;
+        private readonly ConcurrentDictionary<string, bool> _activeLeaderships;
+        private bool _disposed;
+
+        public RedisLeaderElectionService(
+            IConnectionMultiplexer redis,
+            ILogger<RedisLeaderElectionService> logger)
+        {
+            _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            
+            // Generate unique instance ID
+            _instanceId = $"{Environment.MachineName}:{Process.GetCurrentProcess().Id}:{Guid.NewGuid():N}";
+            
+            // Configure TTL and renewal intervals
+            _leadershipTtl = TimeSpan.FromSeconds(60);
+            _renewalInterval = TimeSpan.FromSeconds(30); // Renew at half the TTL
+            
+            _renewalTimers = new ConcurrentDictionary<string, Timer>();
+            _activeLeaderships = new ConcurrentDictionary<string, bool>();
+            
+            _logger.LogInformation("Leader election service initialized with instance ID: {InstanceId}", _instanceId);
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> TryAcquireLeadershipAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var lockKey = GetLockKey(serviceName);
+            var db = _redis.GetDatabase();
+
+            try
+            {
+                // Try to acquire the lock with SET NX (only if not exists) and EX (expiration)
+                var acquired = await db.StringSetAsync(
+                    lockKey,
+                    _instanceId,
+                    _leadershipTtl,
+                    When.NotExists,
+                    CommandFlags.None);
+
+                if (acquired)
+                {
+                    _activeLeaderships[serviceName] = true;
+                    _logger.LogInformation(
+                        "Leadership acquired for service {ServiceName} by instance {InstanceId}",
+                        serviceName, _instanceId);
+                    
+                    // Start automatic renewal
+                    await StartLeadershipMaintenanceAsync(serviceName, cancellationToken);
+                }
+                else
+                {
+                    var currentLeader = await db.StringGetAsync(lockKey);
+                    _logger.LogDebug(
+                        "Failed to acquire leadership for service {ServiceName}. Current leader: {CurrentLeader}",
+                        serviceName, currentLeader);
+                }
+
+                return acquired;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error acquiring leadership for service {ServiceName}", serviceName);
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task ReleaseLeadershipAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var lockKey = GetLockKey(serviceName);
+            var db = _redis.GetDatabase();
+
+            try
+            {
+                // Stop renewal timer first
+                await StopLeadershipMaintenanceAsync(serviceName);
+
+                // Only delete if we own the lock (atomic check and delete)
+                var script = @"
+                    if redis.call('get', KEYS[1]) == ARGV[1] then
+                        return redis.call('del', KEYS[1])
+                    else
+                        return 0
+                    end";
+
+                var result = await db.ScriptEvaluateAsync(
+                    script,
+                    new RedisKey[] { lockKey },
+                    new RedisValue[] { _instanceId });
+
+                if ((long)result == 1)
+                {
+                    _activeLeaderships.TryRemove(serviceName, out _);
+                    _logger.LogInformation(
+                        "Leadership released for service {ServiceName} by instance {InstanceId}",
+                        serviceName, _instanceId);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Could not release leadership for service {ServiceName} - not the current leader",
+                        serviceName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error releasing leadership for service {ServiceName}", serviceName);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> IsLeaderAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var lockKey = GetLockKey(serviceName);
+            var db = _redis.GetDatabase();
+
+            try
+            {
+                var currentLeader = await db.StringGetAsync(lockKey);
+                var isLeader = currentLeader == _instanceId;
+                
+                // Update local cache
+                _activeLeaderships[serviceName] = isLeader;
+                
+                return isLeader;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking leadership status for service {ServiceName}", serviceName);
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<string?> GetCurrentLeaderAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            var lockKey = GetLockKey(serviceName);
+            var db = _redis.GetDatabase();
+
+            try
+            {
+                var currentLeader = await db.StringGetAsync(lockKey);
+                return currentLeader.HasValue ? currentLeader.ToString() : null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting current leader for service {ServiceName}", serviceName);
+                return null;
+            }
+        }
+
+        /// <inheritdoc/>
+        public Task StartLeadershipMaintenanceAsync(string serviceName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            // Stop any existing timer
+            StopLeadershipMaintenanceAsync(serviceName).Wait();
+
+            // Create new renewal timer
+            var timer = new Timer(
+                async _ => await RenewLeadershipAsync(serviceName),
+                null,
+                _renewalInterval,
+                _renewalInterval);
+
+            _renewalTimers[serviceName] = timer;
+            
+            _logger.LogDebug(
+                "Started leadership maintenance for service {ServiceName} with renewal interval {RenewalInterval}",
+                serviceName, _renewalInterval);
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task StopLeadershipMaintenanceAsync(string serviceName)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                throw new ArgumentException("Service name cannot be null or empty", nameof(serviceName));
+
+            if (_renewalTimers.TryRemove(serviceName, out var timer))
+            {
+                timer?.Dispose();
+                _logger.LogDebug("Stopped leadership maintenance for service {ServiceName}", serviceName);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task RenewLeadershipAsync(string serviceName)
+        {
+            var lockKey = GetLockKey(serviceName);
+            var db = _redis.GetDatabase();
+
+            try
+            {
+                // Atomic check and extend TTL
+                var script = @"
+                    if redis.call('get', KEYS[1]) == ARGV[1] then
+                        return redis.call('expire', KEYS[1], ARGV[2])
+                    else
+                        return 0
+                    end";
+
+                var result = await db.ScriptEvaluateAsync(
+                    script,
+                    new RedisKey[] { lockKey },
+                    new RedisValue[] { _instanceId, (int)_leadershipTtl.TotalSeconds });
+
+                if ((long)result == 1)
+                {
+                    _logger.LogTrace(
+                        "Leadership renewed for service {ServiceName} by instance {InstanceId}",
+                        serviceName, _instanceId);
+                }
+                else
+                {
+                    // Lost leadership
+                    _activeLeaderships.TryRemove(serviceName, out _);
+                    await StopLeadershipMaintenanceAsync(serviceName);
+                    
+                    _logger.LogWarning(
+                        "Lost leadership for service {ServiceName}. Stopping renewal.",
+                        serviceName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error renewing leadership for service {ServiceName}", serviceName);
+                
+                // On error, check if we're still the leader
+                if (!await IsLeaderAsync(serviceName))
+                {
+                    _activeLeaderships.TryRemove(serviceName, out _);
+                    await StopLeadershipMaintenanceAsync(serviceName);
+                }
+            }
+        }
+
+        private string GetLockKey(string serviceName)
+        {
+            return $"leader:{serviceName}";
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            // Release all active leaderships
+            foreach (var serviceName in _activeLeaderships.Keys)
+            {
+                try
+                {
+                    ReleaseLeadershipAsync(serviceName).Wait(TimeSpan.FromSeconds(5));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error releasing leadership for service {ServiceName} during disposal", serviceName);
+                }
+            }
+
+            // Dispose all timers
+            foreach (var timer in _renewalTimers.Values)
+            {
+                timer?.Dispose();
+            }
+
+            _renewalTimers.Clear();
+            _activeLeaderships.Clear();
+        }
+    }
+}

--- a/ConduitLLM.Http/HealthChecks/LeaderElectionHealthCheck.cs
+++ b/ConduitLLM.Http/HealthChecks/LeaderElectionHealthCheck.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ConduitLLM.Core.Interfaces;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Http.HealthChecks
+{
+    /// <summary>
+    /// Health check for monitoring leader election status of background services
+    /// </summary>
+    public class LeaderElectionHealthCheck : IHealthCheck
+    {
+        private readonly ILeaderElectionService _leaderElectionService;
+        private readonly ILogger<LeaderElectionHealthCheck> _logger;
+        private readonly string[] _criticalServices;
+
+        public LeaderElectionHealthCheck(
+            ILeaderElectionService leaderElectionService,
+            ILogger<LeaderElectionHealthCheck> logger)
+        {
+            _leaderElectionService = leaderElectionService ?? throw new ArgumentNullException(nameof(leaderElectionService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            
+            // Define critical services that must have a leader
+            _criticalServices = new[]
+            {
+                "BillingAuditService",
+                "SpendNotificationService",
+                "BatchSpendUpdateService",
+                "MetricsAggregationService",
+                "WebhookDeliveryNotificationService"
+            };
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var data = new Dictionary<string, object>();
+                var servicesWithoutLeader = new List<string>();
+                var leadershipStatus = new Dictionary<string, string>();
+
+                foreach (var serviceName in _criticalServices)
+                {
+                    var currentLeader = await _leaderElectionService.GetCurrentLeaderAsync(serviceName, cancellationToken);
+                    
+                    if (string.IsNullOrEmpty(currentLeader))
+                    {
+                        servicesWithoutLeader.Add(serviceName);
+                        leadershipStatus[serviceName] = "No Leader";
+                    }
+                    else
+                    {
+                        var isLeader = await _leaderElectionService.IsLeaderAsync(serviceName, cancellationToken);
+                        leadershipStatus[serviceName] = isLeader ? $"Leader (This Instance)" : $"Follower (Leader: {currentLeader})";
+                    }
+                }
+
+                data["LeadershipStatus"] = leadershipStatus;
+                data["ServicesWithoutLeader"] = servicesWithoutLeader.Count;
+                data["TotalServices"] = _criticalServices.Length;
+
+                if (servicesWithoutLeader.Any())
+                {
+                    var message = $"Services without leader: {string.Join(", ", servicesWithoutLeader)}";
+                    _logger.LogWarning("Leader election health check degraded: {Message}", message);
+                    
+                    return HealthCheckResult.Degraded(
+                        $"Leader election degraded: {servicesWithoutLeader.Count} services without leader",
+                        data: data);
+                }
+
+                return HealthCheckResult.Healthy(
+                    "All critical services have elected leaders",
+                    data: data);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during leader election health check");
+                
+                return HealthCheckResult.Unhealthy(
+                    "Failed to check leader election status",
+                    exception: ex,
+                    data: new Dictionary<string, object>
+                    {
+                        ["Error"] = ex.Message
+                    });
+            }
+        }
+    }
+}

--- a/ConduitLLM.Http/Program.CoreServices.cs
+++ b/ConduitLLM.Http/Program.CoreServices.cs
@@ -4,8 +4,8 @@ using ConduitLLM.Core;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
-using ConduitLLM.Http.Extensions;
 using ConduitLLM.Http.Security;
+using ConduitLLM.Http.Extensions;
 using ConduitLLM.Http.Services;
 using ConduitLLM.Providers.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +20,10 @@ public partial class Program
 {
     public static void ConfigureCoreServices(WebApplicationBuilder builder)
     {
+        // Add leader election service for distributed background service coordination
+        builder.Services.AddLeaderElection();
+        Console.WriteLine("[Conduit] Leader election service configured for background service coordination");
+
         // Rate Limiter registration
         builder.Services.AddRateLimiter(options =>
         {
@@ -47,11 +51,12 @@ public partial class Program
         // Virtual key service (Configuration layer - used by RealtimeUsageTracker)
         builder.Services.AddScoped<ConduitLLM.Configuration.Interfaces.IVirtualKeyService, ConduitLLM.Configuration.Services.VirtualKeyService>();
 
-        // Billing audit service for comprehensive billing event tracking
+        // Billing audit service for comprehensive billing event tracking - with leader election
         builder.Services.AddSingleton<ConduitLLM.Configuration.Interfaces.IBillingAuditService, ConduitLLM.Configuration.Services.BillingAuditService>();
-        builder.Services.AddHostedService<ConduitLLM.Configuration.Services.BillingAuditService>(provider => 
-            provider.GetRequiredService<ConduitLLM.Configuration.Interfaces.IBillingAuditService>() as ConduitLLM.Configuration.Services.BillingAuditService 
-            ?? throw new InvalidOperationException("BillingAuditService must implement IHostedService"));
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Configuration.Services.BillingAuditService>(
+            provider => provider.GetRequiredService<ConduitLLM.Configuration.Interfaces.IBillingAuditService>() as ConduitLLM.Configuration.Services.BillingAuditService 
+            ?? throw new InvalidOperationException("BillingAuditService must implement IHostedService"),
+            "BillingAuditService");
 
         // Provider error tracking service
         builder.Services.AddSingleton<IRedisErrorStore, RedisErrorStore>();
@@ -213,15 +218,17 @@ public partial class Program
         // Register Webhook Delivery Service
         builder.Services.AddSingleton<ConduitLLM.Core.Interfaces.IWebhookDeliveryService, ConduitLLM.Http.Services.WebhookDeliveryService>();
 
-        // Register Distributed Spend Notification Service (Redis-based for multi-instance consistency)
+        // Register Distributed Spend Notification Service (Redis-based for multi-instance consistency) - with leader election
         builder.Services.AddSingleton<ConduitLLM.Core.Interfaces.ISpendNotificationService, ConduitLLM.Http.Services.SpendNotification.DistributedSpendNotificationService>();
-        builder.Services.AddHostedService<ConduitLLM.Http.Services.SpendNotification.DistributedSpendNotificationService>(sp => 
-            (ConduitLLM.Http.Services.SpendNotification.DistributedSpendNotificationService)sp.GetRequiredService<ConduitLLM.Core.Interfaces.ISpendNotificationService>());
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Http.Services.SpendNotification.DistributedSpendNotificationService>(
+            sp => (ConduitLLM.Http.Services.SpendNotification.DistributedSpendNotificationService)sp.GetRequiredService<ConduitLLM.Core.Interfaces.ISpendNotificationService>(),
+            "SpendNotificationService");
 
-        // Register Webhook Delivery Notification Service
+        // Register Webhook Delivery Notification Service - with leader election
         builder.Services.AddSingleton<ConduitLLM.Http.Services.IWebhookDeliveryNotificationService, ConduitLLM.Http.Services.WebhookDeliveryNotificationService>();
-        builder.Services.AddHostedService<ConduitLLM.Http.Services.WebhookDeliveryNotificationService>(sp => 
-            (ConduitLLM.Http.Services.WebhookDeliveryNotificationService)sp.GetRequiredService<ConduitLLM.Http.Services.IWebhookDeliveryNotificationService>());
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Http.Services.WebhookDeliveryNotificationService>(
+            sp => (ConduitLLM.Http.Services.WebhookDeliveryNotificationService)sp.GetRequiredService<ConduitLLM.Http.Services.IWebhookDeliveryNotificationService>(),
+            "WebhookDeliveryNotificationService");
 
         // Model Capability Service is registered via ServiceCollectionExtensions
 
@@ -402,7 +409,7 @@ public partial class Program
         builder.Services.AddDiscoveryCache(builder.Configuration);
         
         // Register Discovery Cache warming as a hosted service (runs on startup)
-        builder.Services.AddHostedService<DiscoveryCacheWarmingService>();
+        builder.Services.AddLeaderElectedHostedService<DiscoveryCacheWarmingService>("DiscoveryCacheWarmingService");
 
         // Register Redis batch operations for optimized cache management
         builder.Services.AddSingleton<ConduitLLM.Core.Interfaces.IRedisBatchOperations, ConduitLLM.Http.Services.RedisBatchOperations>();

--- a/ConduitLLM.Http/Program.Monitoring.cs
+++ b/ConduitLLM.Http/Program.Monitoring.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Configuration.Data;
+using ConduitLLM.Core.Extensions;
 using ConduitLLM.Http.Extensions;
 
 public partial class Program
@@ -108,6 +109,12 @@ public partial class Program
                     "redis_circuit_breaker",
                     failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,
                     tags: new[] { "circuit_breaker", "redis", "resilience" });
+                
+                // Add leader election health check
+                healthChecksBuilder.AddCheck<ConduitLLM.Http.HealthChecks.LeaderElectionHealthCheck>(
+                    "leader_election",
+                    failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded,
+                    tags: new[] { "leader_election", "background_services", "distributed" });
             }
 
             // Audio health checks removed per YAGNI principle
@@ -122,12 +129,14 @@ public partial class Program
         // Add database migration services
         builder.Services.AddDatabaseMigration();
 
-        // Add connection pool warmer for better startup performance
-        builder.Services.AddHostedService<ConduitLLM.Core.Services.ConnectionPoolWarmer>(serviceProvider =>
-        {
-            var logger = serviceProvider.GetRequiredService<ILogger<ConduitLLM.Core.Services.ConnectionPoolWarmer>>();
-            return new ConduitLLM.Core.Services.ConnectionPoolWarmer(serviceProvider, logger, "CoreAPI");
-        });
+        // Add connection pool warmer for better startup performance - with leader election
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Core.Services.ConnectionPoolWarmer>(
+            serviceProvider =>
+            {
+                var logger = serviceProvider.GetRequiredService<ILogger<ConduitLLM.Core.Services.ConnectionPoolWarmer>>();
+                return new ConduitLLM.Core.Services.ConnectionPoolWarmer(serviceProvider, logger, "CoreAPI");
+            },
+            "ConnectionPoolWarmer");
 
         // Add cache statistics registration service
         builder.Services.AddHostedService<ConduitLLM.Http.Services.CacheStatisticsRegistrationService>();

--- a/ConduitLLM.Http/Program.SignalR.cs
+++ b/ConduitLLM.Http/Program.SignalR.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Extensions;
 using ConduitLLM.Http.Services;
 using ConduitLLM.Http.Interfaces;
 using Microsoft.AspNetCore.SignalR;
@@ -28,10 +29,11 @@ public partial class Program
         // Register VirtualKeyHubFilter for SignalR authentication
         builder.Services.AddScoped<ConduitLLM.Http.Authentication.VirtualKeyHubFilter>();
 
-        // Register rate limit cache service for SignalR
+        // Register rate limit cache service for SignalR - with leader election
         builder.Services.AddSingleton<ConduitLLM.Http.Services.VirtualKeyRateLimitCache>();
-        builder.Services.AddHostedService<ConduitLLM.Http.Services.VirtualKeyRateLimitCache>(provider => 
-            provider.GetRequiredService<ConduitLLM.Http.Services.VirtualKeyRateLimitCache>());
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Http.Services.VirtualKeyRateLimitCache>(
+            provider => provider.GetRequiredService<ConduitLLM.Http.Services.VirtualKeyRateLimitCache>(),
+            "VirtualKeyRateLimitCache");
 
         // Register SignalR rate limit filter
         builder.Services.AddSingleton<ConduitLLM.Http.Authentication.VirtualKeySignalRRateLimitFilter>();
@@ -49,13 +51,14 @@ public partial class Program
         // Register SignalR authentication service
         builder.Services.AddScoped<ConduitLLM.Http.Authentication.ISignalRAuthenticationService, ConduitLLM.Http.Authentication.SignalRAuthenticationService>();
 
-        // Register Metrics Aggregation Service and Hub
+        // Register Metrics Aggregation Service and Hub - with leader election
         builder.Services.AddSingleton<ConduitLLM.Http.Hubs.IMetricsAggregationService, ConduitLLM.Http.Services.MetricsAggregationService>();
-        builder.Services.AddHostedService<ConduitLLM.Http.Services.MetricsAggregationService>(sp => 
-            (ConduitLLM.Http.Services.MetricsAggregationService)sp.GetRequiredService<ConduitLLM.Http.Hubs.IMetricsAggregationService>());
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Http.Services.MetricsAggregationService>(
+            sp => (ConduitLLM.Http.Services.MetricsAggregationService)sp.GetRequiredService<ConduitLLM.Http.Hubs.IMetricsAggregationService>(),
+            "MetricsAggregationService");
 
-        // Register Business Metrics Background Service
-        builder.Services.AddHostedService<ConduitLLM.Http.Services.BusinessMetricsService>();
+        // Register Business Metrics Background Service - with leader election
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Http.Services.BusinessMetricsService>("BusinessMetricsService");
 
         // Add SignalR for real-time navigation state updates
         var signalRBuilder = builder.Services.AddSignalR(options =>
@@ -159,7 +162,8 @@ public partial class Program
         });
         builder.Services.AddSingleton<IBatchSpendUpdateService>(serviceProvider =>
             serviceProvider.GetRequiredService<ConduitLLM.Configuration.Services.BatchSpendUpdateService>());
-        builder.Services.AddHostedService<ConduitLLM.Configuration.Services.BatchSpendUpdateService>(serviceProvider =>
-            serviceProvider.GetRequiredService<ConduitLLM.Configuration.Services.BatchSpendUpdateService>());
+        builder.Services.AddLeaderElectedHostedService<ConduitLLM.Configuration.Services.BatchSpendUpdateService>(
+            serviceProvider => serviceProvider.GetRequiredService<ConduitLLM.Configuration.Services.BatchSpendUpdateService>(),
+            "BatchSpendUpdateService");
     }
 }


### PR DESCRIPTION
…#820)

Resolves duplicate processing issue when running multiple instances by implementing distributed leader election for all background services.

## Changes:
- Add RedisLeaderElectionService with 60s TTL and 30s renewal
- Create LeaderElectedBackgroundService base class
- Implement LeaderElectedServiceWrapper for existing services
- Add InMemoryLeaderElectionService fallback for development
- Update all background services to use leader election:
  * BillingAuditService
  * SpendNotificationService
  * BatchSpendUpdateService
  * MetricsAggregationService
  * WebhookDeliveryNotificationService
  * ConnectionPoolWarmer
  * DiscoveryCacheWarmingService
  * AdminOperationsMetricsService
- Add health checks for leadership monitoring
- Configure automatic failover on leader failure

## Benefits:
- Eliminates duplicate background task processing
- Automatic failover within 60 seconds
- Graceful leadership transfer during deployments
- Resource efficiency across instances
- Observable leadership status via health checks

🤖 Generated with [Claude Code](https://claude.ai/code)