### PR TITLE
fix: resolve CodeQL null reference warnings in test files (issue #787)

### DIFF
--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.CrudOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.CrudOperations.cs
@@ -82,15 +82,13 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<CreatedAtActionResult>();
-            var createdResult = result as CreatedAtActionResult;
-            createdResult!.StatusCode.Should().Be(StatusCodes.Status201Created);
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            createdResult.StatusCode.Should().Be(StatusCodes.Status201Created);
             createdResult.ActionName.Should().Be(nameof(ModelController.GetModelById));
             createdResult.RouteValues!["id"].Should().Be(1);
 
-            var dto = createdResult.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.Id.Should().Be(1);
+            var dto = Assert.IsType<ModelDto>(createdResult.Value);
+            dto.Id.Should().Be(1);
             dto.Name.Should().Be("new-test-model");
             dto.IsActive.Should().BeTrue();
 
@@ -142,11 +140,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<CreatedAtActionResult>();
-            var createdResult = result as CreatedAtActionResult;
-            var dto = createdResult!.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.ModelParameters.Should().Be("{\"temperature\": {\"min\": 0, \"max\": 1.5}}");
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+            var dto = Assert.IsType<ModelDto>(createdResult.Value);
+            dto.ModelParameters.Should().Be("{\"temperature\": {\"min\": 0, \"max\": 1.5}}");
 
             _mockRepository.Verify(r => r.CreateAsync(It.Is<Model>(m => 
                 m.ModelParameters == createDto.ModelParameters)), Times.Once);
@@ -162,9 +158,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Model data is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Model data is required");
 
             _mockRepository.Verify(r => r.CreateAsync(It.IsAny<Model>()), Times.Never);
         }
@@ -185,9 +180,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Model name is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Model name is required");
 
             _mockRepository.Verify(r => r.CreateAsync(It.IsAny<Model>()), Times.Never);
         }
@@ -217,9 +211,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<ConflictObjectResult>();
-            var conflictResult = result as ConflictObjectResult;
-            conflictResult!.Value.Should().Be("A model with name 'existing-model' already exists");
+            var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+            conflictResult.Value.Should().Be("A model with name 'existing-model' already exists");
 
             _mockRepository.Verify(r => r.CreateAsync(It.IsAny<Model>()), Times.Never);
         }
@@ -244,9 +237,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.CreateModel(createDto);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while creating the model");
 
             _mockLogger.Verify(
@@ -308,12 +300,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var dto = okResult!.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.Id.Should().Be(modelId);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ModelDto>(okResult.Value);
+            dto.Id.Should().Be(modelId);
             dto.Name.Should().Be("updated-model-name");
             dto.IsActive.Should().BeFalse();
 
@@ -342,9 +331,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<NotFoundObjectResult>();
-            var notFoundResult = result as NotFoundObjectResult;
-            notFoundResult!.Value.Should().Be($"Model with ID {modelId} not found");
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            notFoundResult.Value.Should().Be($"Model with ID {modelId} not found");
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(modelId), Times.Once);
             _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<Model>()), Times.Never);
@@ -396,11 +384,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            var dto = okResult!.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.ModelParameters.Should().Be("{\"temperature\": {\"min\": 0, \"max\": 2}}");
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ModelDto>(okResult.Value);
+            dto.ModelParameters.Should().Be("{\"temperature\": {\"min\": 0, \"max\": 2}}");
 
             _mockRepository.Verify(r => r.UpdateAsync(It.Is<Model>(m => 
                 m.ModelParameters == updateDto.ModelParameters)), Times.Once);
@@ -452,11 +438,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            var dto = okResult!.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.ModelParameters.Should().BeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ModelDto>(okResult.Value);
+            dto.ModelParameters.Should().BeNull();
 
             _mockRepository.Verify(r => r.UpdateAsync(It.Is<Model>(m => 
                 m.ModelParameters == null)), Times.Once);
@@ -473,9 +457,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Update data is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Update data is required");
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(It.IsAny<int>()), Times.Never);
             _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<Model>()), Times.Never);
@@ -500,9 +483,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while updating the model");
 
             _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<Model>()), Times.Never);
@@ -527,9 +509,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.UpdateModel(modelId, updateDto);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while updating the model");
 
             _mockLogger.Verify(
@@ -593,9 +574,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.DeleteModel(modelId);
 
             // Assert
-            result.Should().BeOfType<NotFoundObjectResult>();
-            var notFoundResult = result as NotFoundObjectResult;
-            notFoundResult!.Value.Should().Be($"Model with ID {modelId} not found");
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            notFoundResult.Value.Should().Be($"Model with ID {modelId} not found");
 
             _mockRepository.Verify(r => r.GetByIdAsync(modelId), Times.Once);
             _mockRepository.Verify(r => r.DeleteAsync(It.IsAny<int>()), Times.Never);
@@ -614,9 +594,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.DeleteModel(modelId);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while deleting the model");
 
             _mockLogger.Verify(

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
@@ -82,7 +82,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelDto>>();
+            var dtos = (IEnumerable<ModelDto>)okResult.Value;
             dtos.Should().HaveCount(2);
 
             var firstDto = dtos.First();
@@ -107,7 +108,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelDto>>();
+            var dtos = (IEnumerable<ModelDto>)okResult.Value;
             dtos.Should().BeEmpty();
 
             _mockRepository.Verify(r => r.GetAllWithDetailsAsync(), Times.Once);
@@ -283,7 +285,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var identifiers = Assert.IsType<IEnumerable<object>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<object>>();
+            var identifiers = (IEnumerable<object>)okResult.Value;
             identifiers.Should().HaveCount(3);
 
             // Verify the structure by serializing to JSON and deserializing
@@ -330,7 +333,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var identifiers = Assert.IsType<IEnumerable<object>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<object>>();
+            var identifiers = (IEnumerable<object>)okResult.Value;
             identifiers.Should().BeEmpty();
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(modelId), Times.Once);

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
@@ -81,14 +81,11 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetAllModels();
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var dtos = okResult!.Value as IEnumerable<ModelDto>;
-            dtos.Should().NotBeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelDto>>(okResult.Value);
             dtos.Should().HaveCount(2);
 
-            var firstDto = dtos!.First();
+            var firstDto = dtos.First();
             firstDto.Id.Should().Be(1);
             firstDto.Name.Should().Be("test-model-1");
             firstDto.IsActive.Should().BeTrue();
@@ -109,11 +106,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetAllModels();
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var dtos = okResult!.Value as IEnumerable<ModelDto>;
-            dtos.Should().NotBeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelDto>>(okResult.Value);
             dtos.Should().BeEmpty();
 
             _mockRepository.Verify(r => r.GetAllWithDetailsAsync(), Times.Once);
@@ -131,9 +125,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetAllModels();
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while retrieving models");
 
             // Verify logging occurred
@@ -177,12 +170,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelById(modelId);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var dto = okResult!.Value as ModelDto;
-            dto.Should().NotBeNull();
-            dto!.Id.Should().Be(modelId);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dto = Assert.IsType<ModelDto>(okResult.Value);
+            dto.Id.Should().Be(modelId);
             dto.Name.Should().Be("test-model");
             dto.IsActive.Should().BeTrue();
             // Capabilities are now flat fields on the model - verify the Id exists
@@ -203,9 +193,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelById(modelId);
 
             // Assert
-            result.Should().BeOfType<NotFoundObjectResult>();
-            var notFoundResult = result as NotFoundObjectResult;
-            notFoundResult!.Value.Should().Be($"Model with ID {modelId} not found");
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            notFoundResult.Value.Should().Be($"Model with ID {modelId} not found");
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(modelId), Times.Once);
         }
@@ -223,9 +212,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelById(modelId);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while retrieving the model");
 
             // Verify logging occurred
@@ -294,11 +282,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelIdentifiers(modelId);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var identifiers = okResult!.Value as IEnumerable<object>;
-            identifiers.Should().NotBeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var identifiers = Assert.IsType<IEnumerable<object>>(okResult.Value);
             identifiers.Should().HaveCount(3);
 
             // Verify the structure by serializing to JSON and deserializing
@@ -344,11 +329,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelIdentifiers(modelId);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            
-            var identifiers = okResult!.Value as IEnumerable<object>;
-            identifiers.Should().NotBeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var identifiers = Assert.IsType<IEnumerable<object>>(okResult.Value);
             identifiers.Should().BeEmpty();
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(modelId), Times.Once);
@@ -366,9 +348,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelIdentifiers(modelId);
 
             // Assert
-            result.Should().BeOfType<NotFoundObjectResult>();
-            var notFoundResult = result as NotFoundObjectResult;
-            notFoundResult!.Value.Should().Be($"Model with ID {modelId} not found");
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            notFoundResult.Value.Should().Be($"Model with ID {modelId} not found");
 
             _mockRepository.Verify(r => r.GetByIdWithDetailsAsync(modelId), Times.Once);
         }
@@ -386,9 +367,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelIdentifiers(modelId);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while retrieving model identifiers");
 
             // Verify logging occurred

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
@@ -111,7 +111,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelWithProviderIdDto>>();
+            var dtos = (IEnumerable<ModelWithProviderIdDto>)okResult.Value;
             dtos.Should().HaveCount(2);
 
             var firstDto = dtos.First();
@@ -235,7 +236,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelWithProviderIdDto>>();
+            var dtos = (IEnumerable<ModelWithProviderIdDto>)okResult.Value;
             var dto = dtos.First();
 
             // Should use the groq-specific identifier
@@ -281,7 +283,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelWithProviderIdDto>>();
+            var dtos = (IEnumerable<ModelWithProviderIdDto>)okResult.Value;
             var dto = dtos.First();
 
             // Should match case-insensitively
@@ -357,7 +360,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            okResult.Value.Should().BeAssignableTo<IEnumerable<ModelWithProviderIdDto>>();
+            var dtos = (IEnumerable<ModelWithProviderIdDto>)okResult.Value;
             var dto = dtos.First();
 
             // After consolidation, capability fields have default values

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
@@ -110,21 +110,17 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            okResult.Should().NotBeNull();
-            
-            var dtos = okResult!.Value as IEnumerable<ModelWithProviderIdDto>;
-            dtos.Should().NotBeNull();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
             dtos.Should().HaveCount(2);
 
-            var firstDto = dtos!.First();
+            var firstDto = dtos.First();
             firstDto.Id.Should().Be(1);
             firstDto.Name.Should().Be("llama-3.1-8b");
             firstDto.ProviderModelId.Should().Be("llama-3.1-8b-instant");
             firstDto.SupportsChat.Should().BeTrue();
 
-            var secondDto = dtos!.Last();
+            var secondDto = dtos.Last();
             secondDto.Id.Should().Be(2);
             secondDto.Name.Should().Be("mixtral-8x7b");
             secondDto.ProviderModelId.Should().Be("mixtral-8x7b-32768");
@@ -142,9 +138,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Provider name is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Provider name is required");
 
             _mockRepository.Verify(r => r.GetByProviderAsync(It.IsAny<ProviderType>()), Times.Never);
         }
@@ -159,9 +154,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Provider name is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Provider name is required");
 
             _mockRepository.Verify(r => r.GetByProviderAsync(It.IsAny<ProviderType>()), Times.Never);
         }
@@ -176,9 +170,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
-            var badRequestResult = result as BadRequestObjectResult;
-            badRequestResult!.Value.Should().Be("Provider name is required");
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            badRequestResult.Value.Should().Be("Provider name is required");
 
             _mockRepository.Verify(r => r.GetByProviderAsync(It.IsAny<ProviderType>()), Times.Never);
         }
@@ -222,11 +215,11 @@ namespace ConduitLLM.Tests.Admin.Controllers
                     Identifiers = new List<ModelProviderTypeAssociation>
                     {
                         // Identifier for groq provider
-                        new ModelProviderTypeAssociation 
-                        { 
-                            Id = 1, 
-                            ModelId = 1, 
-                            Identifier = "test-model-groq", 
+                        new ModelProviderTypeAssociation
+                        {
+                            Id = 1,
+                            ModelId = 1,
+                            Identifier = "test-model-groq",
                             Provider = ProviderType.Groq,
                             IsPrimary = true
                         }
@@ -241,11 +234,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            var dtos = okResult!.Value as IEnumerable<ModelWithProviderIdDto>;
-            var dto = dtos!.First();
-            
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            var dto = dtos.First();
+
             // Should use the groq-specific identifier
             dto.ProviderModelId.Should().Be("test-model-groq");
         }
@@ -288,11 +280,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            var dtos = okResult!.Value as IEnumerable<ModelWithProviderIdDto>;
-            var dto = dtos!.First();
-            
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            var dto = dtos.First();
+
             // Should match case-insensitively
             dto.ProviderModelId.Should().Be("test-model-groq");
         }
@@ -311,9 +302,8 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<ObjectResult>();
-            var objectResult = result as ObjectResult;
-            objectResult!.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
             objectResult.Value.Should().Be("An error occurred while retrieving models");
 
             // Verify logging occurred
@@ -366,11 +356,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
             var result = await _controller.GetModelsByProvider(provider);
 
             // Assert
-            result.Should().BeOfType<OkObjectResult>();
-            var okResult = result as OkObjectResult;
-            var dtos = okResult!.Value as IEnumerable<ModelWithProviderIdDto>;
-            var dto = dtos!.First();
-            
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var dtos = Assert.IsType<IEnumerable<ModelWithProviderIdDto>>(okResult.Value);
+            var dto = dtos.First();
+
             // After consolidation, capability fields have default values
             dto.SupportsChat.Should().BeFalse();
             dto.SupportsVision.Should().BeFalse();

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Delete.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Delete.cs
@@ -31,10 +31,11 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
             
             var createResult = await _controller.CreateModelCost(createDto);
-            var createdCost = (createResult as CreatedAtActionResult)?.Value as ModelCostDto;
+            var createdResult = Assert.IsType<CreatedAtActionResult>(createResult);
+            var createdCost = Assert.IsType<ModelCostDto>(createdResult.Value);
 
             // Act
-            var deleteResult = await _controller.DeleteModelCost(createdCost!.Id);
+            var deleteResult = await _controller.DeleteModelCost(createdCost.Id);
 
             // Assert
             Assert.IsType<NoContentResult>(deleteResult);

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.EdgeCases.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.EdgeCases.cs
@@ -67,12 +67,13 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
             
             var createResult = await _controller.CreateModelCost(createDto);
-            var createdCost = (createResult as CreatedAtActionResult)?.Value as ModelCostDto;
+            var createdResult = Assert.IsType<CreatedAtActionResult>(createResult);
+            var createdCost = Assert.IsType<ModelCostDto>(createdResult.Value);
 
             // Prepare two concurrent updates
             var update1 = new UpdateModelCostDto
             {
-                Id = createdCost!.Id,
+                Id = createdCost.Id,
                 CostName = "Update 1",
                 InputCostPerMillionTokens = 15.00m,
                 OutputCostPerMillionTokens = 25.00m

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Get.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Get.cs
@@ -45,10 +45,11 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
             
             var createResult = await _controller.CreateModelCost(createDto);
-            var createdCost = (createResult as CreatedAtActionResult)?.Value as ModelCostDto;
+            var createdResult = Assert.IsType<CreatedAtActionResult>(createResult);
+            var createdCost = Assert.IsType<ModelCostDto>(createdResult.Value);
 
             // Act
-            var getResult = await _controller.GetModelCostById(createdCost!.Id);
+            var getResult = await _controller.GetModelCostById(createdCost.Id);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(getResult);

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Update.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Update.cs
@@ -47,13 +47,13 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
             
             var createResult = await _controller.CreateModelCost(createDto);
-            var createdCost = (createResult as CreatedAtActionResult)?.Value as ModelCostDto;
-            createdCost.Should().NotBeNull();
+            var createdResult = Assert.IsType<CreatedAtActionResult>(createResult);
+            var createdCost = Assert.IsType<ModelCostDto>(createdResult.Value);
 
             // Update with different mappings
             var updateDto = new UpdateModelCostDto
             {
-                Id = createdCost!.Id,
+                Id = createdCost.Id,
                 CostName = "Updated Pricing",
                 InputCostPerMillionTokens = 15.00m,
                 OutputCostPerMillionTokens = 25.00m,
@@ -94,12 +94,13 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
             
             var createResult = await _controller.CreateModelCost(createDto);
-            var createdCost = (createResult as CreatedAtActionResult)?.Value as ModelCostDto;
+            var createdResult = Assert.IsType<CreatedAtActionResult>(createResult);
+            var createdCost = Assert.IsType<ModelCostDto>(createdResult.Value);
 
             // Update to remove all mappings
             var updateDto = new UpdateModelCostDto
             {
-                Id = createdCost!.Id,
+                Id = createdCost.Id,
                 CostName = createdCost.CostName,
                 InputCostPerMillionTokens = 10.00m,
                 OutputCostPerMillionTokens = 20.00m,


### PR DESCRIPTION
Replace 'as' casting with null-forgiving operators with Assert.IsType<T>() pattern to eliminate 42+ CodeQL warnings across test files. This improves static analysis compliance and makes test assertions more explicit.

Changes:
- ModelControllerTests.ProviderOperations.cs: 8 instances fixed
- ModelControllerTests.CrudOperations.cs: 17 instances fixed
- ModelControllerTests.GetOperations.cs: 12 instances fixed
- ModelCostIntegrationTests files: 5 instances fixed

The Assert.IsType<T>() pattern both validates the type and returns a non-null typed value, eliminating the need for null-forgiving operators and satisfying static analysis requirements.

Fixes #787