### PR TITLE
refactor(admin): pilot Tier 1a — OperationLoggingFilter + drop ExecuteAsync wrappers in ModelAuthorController

### DIFF
--- a/Services/ConduitLLM.Admin/Controllers/ModelAuthorController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelAuthorController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Models.ModelAuthors;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Extensions;
@@ -13,9 +14,16 @@ namespace ConduitLLM.Admin.Controllers
     /// <summary>
     /// Controller for managing ModelAuthor entities
     /// </summary>
+    /// <remarks>
+    /// Error handling is delegated to the global <c>AdminExceptionMiddleware</c> (thrown exceptions
+    /// are mapped to standardized responses via <c>ExceptionToResponseMapper</c>), and success
+    /// logging is provided by <see cref="OperationLoggingFilter"/>. This keeps actions free of the
+    /// per-action <c>ExecuteAsync</c> wrapper boilerplate.
+    /// </remarks>
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ModelAuthorController : AdminControllerBase
     {
         private readonly IModelAuthorRepository _repository;
@@ -38,17 +46,11 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelAuthorDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var authors = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
-                        _repository.GetPaginatedAsync);
-                    return authors.Select(a => a.ToDto());
-                },
-                Ok,
-                "GetAll");
+            var authors = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                _repository.GetPaginatedAsync);
+            return Ok(authors.Select(a => a.ToDto()));
         }
 
         /// <summary>
@@ -60,14 +62,15 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelAuthorDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetById(int id)
+        public async Task<IActionResult> GetById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _repository.GetByIdAsync(id),
-                author => Ok(author.ToDto()),
-                "Model author",
-                id,
-                "GetById");
+            var author = await _repository.GetByIdAsync(id);
+            if (author == null)
+            {
+                return this.NotFoundEntity("Model author", id);
+            }
+
+            return Ok(author.ToDto());
         }
 
         /// <summary>
@@ -79,25 +82,23 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<SimpleModelSeriesDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetSeriesByAuthor(int id)
+        public async Task<IActionResult> GetSeriesByAuthor(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _repository.GetSeriesByAuthorAsync(id),
-                series =>
-                {
-                    var dtos = series.Select(s => new SimpleModelSeriesDto
-                    {
-                        Id = s.Id,
-                        Name = s.Name,
-                        Description = s.Description,
-                        TokenizerType = s.TokenizerType
-                    });
+            var series = await _repository.GetSeriesByAuthorAsync(id);
+            if (series == null)
+            {
+                return this.NotFoundEntity("Model author", id);
+            }
 
-                    return Ok(dtos);
-                },
-                "Model author",
-                id,
-                "GetSeriesByAuthor");
+            var dtos = series.Select(s => new SimpleModelSeriesDto
+            {
+                Id = s.Id,
+                Name = s.Name,
+                Description = s.Description,
+                TokenizerType = s.TokenizerType
+            });
+
+            return Ok(dtos);
         }
 
         /// <summary>
@@ -110,35 +111,29 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Create([FromBody] CreateModelAuthorDto dto)
+        public async Task<IActionResult> Create([FromBody] CreateModelAuthorDto dto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Check if author with same name already exists
-                    var existing = await _repository.GetByNameAsync(dto.Name);
-                    if (existing != null)
-                    {
-                        throw new InvalidOperationException($"A model author with name '{dto.Name}' already exists");
-                    }
+            // Check if author with same name already exists
+            var existing = await _repository.GetByNameAsync(dto.Name);
+            if (existing != null)
+            {
+                throw new InvalidOperationException($"A model author with name '{dto.Name}' already exists");
+            }
 
-                    var author = new ModelAuthor
-                    {
-                        Name = dto.Name,
-                        Description = dto.Description,
-                        WebsiteUrl = dto.WebsiteUrl
-                    };
+            var author = new ModelAuthor
+            {
+                Name = dto.Name,
+                Description = dto.Description,
+                WebsiteUrl = dto.WebsiteUrl
+            };
 
-                    await _repository.CreateAsync(author);
-                    LogAdminAudit("Created", "ModelAuthor", author.Id, $"Name: {LoggingSanitizer.S(author.Name)}");
+            await _repository.CreateAsync(author);
+            LogAdminAudit("Created", "ModelAuthor", author.Id, $"Name: {LoggingSanitizer.S(author.Name)}");
 
-                    return author;
-                },
-                author => CreatedAtAction(
-                    nameof(GetById),
-                    new { id = author.Id },
-                    author.ToDto()),
-                "Create");
+            return CreatedAtAction(
+                nameof(GetById),
+                new { id = author.Id },
+                author.ToDto());
         }
 
         /// <summary>
@@ -153,44 +148,39 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Update(int id, [FromBody] UpdateModelAuthorDto dto)
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateModelAuthorDto dto)
         {
             if (id != dto.Id)
             {
-                return Task.FromResult<IActionResult>(BadRequest("ID mismatch"));
+                return BadRequest("ID mismatch");
             }
 
-            return ExecuteAsync(
-                async () =>
+            var author = await _repository.GetByIdAsync(id);
+            if (author == null)
+            {
+                throw new KeyNotFoundException($"Model author with ID {id} not found");
+            }
+
+            // Check for name conflicts if name is being changed
+            if (!string.IsNullOrEmpty(dto.Name) && dto.Name != author.Name)
+            {
+                var existing = await _repository.GetByNameAsync(dto.Name);
+                if (existing != null && existing.Id != id)
                 {
-                    var author = await _repository.GetByIdAsync(id);
-                    if (author == null)
-                    {
-                        throw new KeyNotFoundException($"Model author with ID {id} not found");
-                    }
+                    throw new InvalidOperationException($"A model author with name '{dto.Name}' already exists");
+                }
+                author.Name = dto.Name;
+            }
 
-                    // Check for name conflicts if name is being changed
-                    if (!string.IsNullOrEmpty(dto.Name) && dto.Name != author.Name)
-                    {
-                        var existing = await _repository.GetByNameAsync(dto.Name);
-                        if (existing != null && existing.Id != id)
-                        {
-                            throw new InvalidOperationException($"A model author with name '{dto.Name}' already exists");
-                        }
-                        author.Name = dto.Name;
-                    }
+            if (dto.Description != null)
+                author.Description = dto.Description;
+            if (dto.WebsiteUrl != null)
+                author.WebsiteUrl = dto.WebsiteUrl;
 
-                    if (dto.Description != null)
-                        author.Description = dto.Description;
-                    if (dto.WebsiteUrl != null)
-                        author.WebsiteUrl = dto.WebsiteUrl;
+            await _repository.UpdateAsync(author);
+            LogAdminAudit("Updated", "ModelAuthor", id, $"Name: {LoggingSanitizer.S(author.Name)}");
 
-                    await _repository.UpdateAsync(author);
-                    LogAdminAudit("Updated", "ModelAuthor", id, $"Name: {LoggingSanitizer.S(author.Name)}");
-                },
-                NoContent(),
-                "Update",
-                new { Id = id });
+            return NoContent();
         }
 
         /// <summary>
@@ -203,30 +193,25 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Delete(int id)
+        public async Task<IActionResult> Delete(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var author = await _repository.GetByIdAsync(id);
-                    if (author == null)
-                    {
-                        throw new KeyNotFoundException($"Model author with ID {id} not found");
-                    }
+            var author = await _repository.GetByIdAsync(id);
+            if (author == null)
+            {
+                throw new KeyNotFoundException($"Model author with ID {id} not found");
+            }
 
-                    // Check if author has series
-                    var series = await _repository.GetSeriesByAuthorAsync(id);
-                    if (series != null && series.Any())
-                    {
-                        throw new InvalidOperationException($"Cannot delete model author with {series.Count()} associated series. Delete the series first.");
-                    }
+            // Check if author has series
+            var series = await _repository.GetSeriesByAuthorAsync(id);
+            if (series != null && series.Any())
+            {
+                throw new InvalidOperationException($"Cannot delete model author with {series.Count()} associated series. Delete the series first.");
+            }
 
-                    await _repository.DeleteAsync(id);
-                    LogAdminAudit("Deleted", "ModelAuthor", id, $"Name: {LoggingSanitizer.S(author.Name)}");
-                },
-                NoContent(),
-                "Delete",
-                new { Id = id });
+            await _repository.DeleteAsync(id);
+            LogAdminAudit("Deleted", "ModelAuthor", id, $"Name: {LoggingSanitizer.S(author.Name)}");
+
+            return NoContent();
         }
 
     }

--- a/Services/ConduitLLM.Admin/Filters/OperationLoggingFilter.cs
+++ b/Services/ConduitLLM.Admin/Filters/OperationLoggingFilter.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace ConduitLLM.Admin.Filters
+{
+    /// <summary>
+    /// Logs successful completion of controller actions, replacing the per-action success
+    /// logging that previously lived inside <c>AdminControllerBase.ExecuteAsync</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Logs at <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/> for mutations
+    /// (POST/PUT/PATCH/DELETE) and <see cref="Microsoft.Extensions.Logging.LogLevel.Debug"/> for
+    /// reads — matching the previous <c>LogOperationSuccess</c> behavior. The log category is the
+    /// concrete controller type, so existing per-controller log filtering keeps working.
+    /// </para>
+    /// <para>
+    /// Exceptions are intentionally ignored here: they propagate to the global
+    /// <c>AdminExceptionMiddleware</c>, which owns exception-to-response mapping and error logging.
+    /// </para>
+    /// <para>
+    /// Applied per controller via <c>[ServiceFilter(typeof(OperationLoggingFilter))]</c> during the
+    /// incremental Tier 1a migration (issue #902). Once every controller is converted off the
+    /// <c>ExecuteAsync</c> wrappers, this can be promoted to a single global filter registered in
+    /// <c>AddControllers(o =&gt; o.Filters.Add&lt;OperationLoggingFilter&gt;())</c> and the
+    /// per-controller attributes removed.
+    /// </para>
+    /// </remarks>
+    public sealed class OperationLoggingFilter : IAsyncActionFilter
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationLoggingFilter"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">Factory used to create a logger categorized to the controller type.</param>
+        public OperationLoggingFilter(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        /// <inheritdoc/>
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var executed = await next();
+
+            // Success only — exceptions are owned by the global exception middleware. Leave the
+            // exception unhandled so it continues to propagate there.
+            if (executed.Exception != null && !executed.ExceptionHandled)
+            {
+                return;
+            }
+
+            var descriptor = context.ActionDescriptor as ControllerActionDescriptor;
+            var actionName = descriptor?.ActionName ?? "Unknown";
+
+            var logger = descriptor?.ControllerTypeInfo.FullName is { } categoryName
+                ? _loggerFactory.CreateLogger(categoryName)
+                : _loggerFactory.CreateLogger<OperationLoggingFilter>();
+
+            var method = context.HttpContext.Request.Method;
+            var isMutation = method is "POST" or "PUT" or "PATCH" or "DELETE";
+
+            if (isMutation)
+            {
+                logger.LogInformation("{Action} completed successfully", actionName);
+            }
+            else
+            {
+                logger.LogDebug("{Action} completed successfully", actionName);
+            }
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Core.Converters;
@@ -40,6 +41,13 @@ public partial class Program
                 options.JsonSerializerOptions.Converters.Add(new UtcDateTimeConverter());
                 options.JsonSerializerOptions.Converters.Add(new NullableUtcDateTimeConverter());
             });
+
+        // Operation-logging action filter — replaces the per-action success logging that used to
+        // live in AdminControllerBase.ExecuteAsync. Applied per controller via [ServiceFilter]
+        // during the incremental Tier 1a migration (#902); promote to a global filter once all
+        // controllers are converted.
+        builder.Services.AddScoped<OperationLoggingFilter>();
+
         builder.Services.AddEndpointsApiExplorer();
 
         // Add HttpClient factory for provider connection testing


### PR DESCRIPTION
## What

**Tier 1a pilot** of the boilerplate-reduction epic #901 (issue #902): introduce a reusable success-logging action filter and convert the first Admin controller off the per-action `ExecuteAsync` wrappers, relying on the already-wired global exception handler for error mapping.

This PR is intentionally scoped to **one controller** so the *pattern* can be reviewed before the remaining 36 Admin controllers (216 wrapper calls) are converted in follow-up PRs.

## Changes

- **New `OperationLoggingFilter`** (`IAsyncActionFilter`) — reproduces the success logging that previously lived inside `AdminControllerBase.ExecuteAsync`: `Information` for mutations (POST/PUT/PATCH/DELETE), `Debug` for reads, logged under the concrete controller's category so existing per-controller log filtering keeps working. Exceptions are deliberately left to propagate.
- **Registered** `OperationLoggingFilter` in DI (`Program.cs`).
- **`ModelAuthorController` converted** off all 6 `ExecuteAsync` / `ExecuteWithNotFoundAsync` wrappers, with the filter applied at class level via `[ServiceFilter]`.

## Why this preserves behavior

- **Error responses are identical.** Thrown `InvalidOperationException` / `KeyNotFoundException` now propagate to the global `AdminExceptionMiddleware`, which maps them with the **same `ExceptionToResponseMapper`** the wrappers used → same status codes and same `ErrorResponseDto` bodies. The global handler is already in the pipeline (`UseAdminMiddleware` → `UseAdminExceptionHandling`).
- **404s are byte-identical.** Null lookups call `this.NotFoundEntity("Model author", id)` directly — the exact helper the wrapper used.
- **Audit logging unchanged** — `LogAdminAudit` calls are retained as-is.

## Rollout plan (this filter)

Applied per-controller via `[ServiceFilter(typeof(OperationLoggingFilter))]` during the incremental migration to avoid double-logging while other controllers still wrap. Once **all** controllers are converted, promote it to a single global registration (`AddControllers(o => o.Filters.Add<OperationLoggingFilter>())`) and drop the per-controller attributes.

## Verification

- `dotnet build` (Admin project + dependencies): **0 warnings, 0 errors**.
- `dotnet test --filter ModelAuthor`: **18/18 passing**.
- `[ProducesResponseType]` attributes and XML docs were intentionally left in place — they're addressed in Tier 2b (#905).

## Scope note

`ModelAuthorController`: 233 → 218 lines, **6 → 0** wrapper calls. The per-file LOC delta is modest by design (docs/attributes retained); the Tier 1a win is structural — direct action bodies and removal of the redundant per-action error-mapping layer across the codebase.

Part of #902. Epic: #901.
