### PR TITLE
refactor(gateway): Tier 1a — drop ExecuteAsync wrappers across Gateway controllers

### DIFF
--- a/Services/ConduitLLM.Gateway/Controllers/AuthController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/AuthController.cs
@@ -3,6 +3,7 @@ using ConduitLLM.Core.Models;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ConduitLLM.Gateway.Filters;
 using ConduitLLM.Gateway.Models;
 using ConduitLLM.Gateway.Services;
 
@@ -14,6 +15,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/auth")]
     [Tags("Authentication")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class AuthController : GatewayControllerBase
     {
         private readonly IEphemeralKeyService _ephemeralKeyService;
@@ -39,52 +41,49 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(EphemeralKeyResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GenerateEphemeralKey([FromBody] GenerateEphemeralKeyRequest? request = null)
+        public async Task<IActionResult> GenerateEphemeralKey([FromBody] GenerateEphemeralKeyRequest? request = null)
         {
-            return ExecuteAsync(async () =>
+            // Get virtual key ID from claims
+            var virtualKeyIdClaim = HttpContext.User.FindFirst("VirtualKeyId")?.Value;
+            if (string.IsNullOrEmpty(virtualKeyIdClaim) || !int.TryParse(virtualKeyIdClaim, out int virtualKeyId))
             {
-                // Get virtual key ID from claims
-                var virtualKeyIdClaim = HttpContext.User.FindFirst("VirtualKeyId")?.Value;
-                if (string.IsNullOrEmpty(virtualKeyIdClaim) || !int.TryParse(virtualKeyIdClaim, out int virtualKeyId))
+                Logger.LogWarning("Failed to extract virtual key ID from claims");
+                return Unauthorized(new OpenAIErrorResponse
                 {
-                    Logger.LogWarning("Failed to extract virtual key ID from claims");
-                    return Unauthorized(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "Virtual key not found in request context",
-                            Type = "authentication_error",
-                            Code = "unauthorized"
-                        }
-                    });
-                }
+                        Message = "Virtual key not found in request context",
+                        Type = "authentication_error",
+                        Code = "unauthorized"
+                    }
+                });
+            }
 
-                // Get the actual virtual key value from claims
-                var virtualKey = HttpContext.User.FindFirst("VirtualKey")?.Value;
-                if (string.IsNullOrEmpty(virtualKey))
+            // Get the actual virtual key value from claims
+            var virtualKey = HttpContext.User.FindFirst("VirtualKey")?.Value;
+            if (string.IsNullOrEmpty(virtualKey))
+            {
+                Logger.LogWarning("Failed to extract virtual key from claims");
+                return Unauthorized(new OpenAIErrorResponse
                 {
-                    Logger.LogWarning("Failed to extract virtual key from claims");
-                    return Unauthorized(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "Virtual key not found in request context",
-                            Type = "authentication_error",
-                            Code = "unauthorized"
-                        }
-                    });
-                }
+                        Message = "Virtual key not found in request context",
+                        Type = "authentication_error",
+                        Code = "unauthorized"
+                    }
+                });
+            }
 
-                // Create ephemeral key with the actual virtual key
-                var response = await _ephemeralKeyService.CreateEphemeralKeyAsync(
-                    virtualKeyId,
-                    virtualKey,
-                    request?.Metadata);
+            // Create ephemeral key with the actual virtual key
+            var response = await _ephemeralKeyService.CreateEphemeralKeyAsync(
+                virtualKeyId,
+                virtualKey,
+                request?.Metadata);
 
-                Logger.LogInformation("Generated ephemeral key for virtual key {VirtualKeyId}", virtualKeyId);
+            Logger.LogInformation("Generated ephemeral key for virtual key {VirtualKeyId}", virtualKeyId);
 
-                return Ok(response);
-            }, nameof(GenerateEphemeralKey));
+            return Ok(response);
         }
     }
 

--- a/Services/ConduitLLM.Gateway/Controllers/BatchOperationsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/BatchOperationsController.cs
@@ -5,6 +5,7 @@ using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Configuration.DTOs.BatchOperations;
 using ConduitLLM.Core.Services.BatchOperations;
+using ConduitLLM.Gateway.Filters;
 using GatewayOpsMetrics = ConduitLLM.Gateway.Services.GatewayOperationsMetricsService;
 
 namespace ConduitLLM.Gateway.Controllers
@@ -16,6 +17,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/batch")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class BatchOperationsController : GatewayControllerBase
     {
         private readonly IBatchOperationService _batchOperationService;
@@ -56,74 +58,71 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(401)]
         public async Task<IActionResult> StartBatchSpendUpdate([FromBody] BatchSpendUpdateRequest request)
         {
-            return await ExecuteAsync(async () =>
+            var virtualKeyId = GetVirtualKeyId();
+
+            // Validate request
+            if (request.Updates == null || !request.Updates.Any())
             {
-                var virtualKeyId = GetVirtualKeyId();
-
-                // Validate request
-                if (request.Updates == null || !request.Updates.Any())
+                return BadRequest(new OpenAIErrorResponse
                 {
-                    return BadRequest(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "No updates provided",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                if (request.Updates.Count() > 10000)
-                {
-                    return BadRequest(new OpenAIErrorResponse
-                    {
-                        Error = new OpenAIError
-                        {
-                            Message = "Maximum 10,000 items per batch",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                // Convert to internal model
-                var spendUpdates = request.Updates.Select(u => new SpendUpdateItem
-                {
-                    VirtualKeyId = u.VirtualKeyId,
-                    Amount = u.Amount,
-                    Model = u.Model,
-                    Provider = u.ProviderType.ToString(),
-                    RequestMetadata = u.Metadata
-                }).ToList();
-
-                // Get idempotency token from header (optional)
-                var idempotencyToken = HttpContext.Request.Headers["X-Idempotency-Token"].FirstOrDefault();
-
-                // Execute batch spend update operation
-                var result = await _batchSpendUpdateOperation.ExecuteAsync(
-                    spendUpdates,
-                    virtualKeyId,
-                    idempotencyToken,
-                    HttpContext.RequestAborted);
-
-                Logger.LogInformation(
-                    "Started batch spend update operation {OperationId} with {Count} items (Idempotent: {Idempotent})",
-                    result.OperationId,
-                    request.Updates.Count(),
-                    !string.IsNullOrWhiteSpace(idempotencyToken));
-
-                GatewayOpsMetrics.RecordBatchOperation("spend_update", "accepted", request.Updates.Count());
-                return Accepted(new BatchOperationStartResponse
-                {
-                    OperationId = result.OperationId,
-                    OperationType = "spend_update",
-                    TotalItems = request.Updates.Count(),
-                    StatusUrl = $"/v1/batch/operations/{result.OperationId}",
-                    TaskId = result.OperationId,
-                    Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+                        Message = "No updates provided",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
                 });
-            }, "StartBatchSpendUpdate");
+            }
+
+            if (request.Updates.Count() > 10000)
+            {
+                return BadRequest(new OpenAIErrorResponse
+                {
+                    Error = new OpenAIError
+                    {
+                        Message = "Maximum 10,000 items per batch",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
+                });
+            }
+
+            // Convert to internal model
+            var spendUpdates = request.Updates.Select(u => new SpendUpdateItem
+            {
+                VirtualKeyId = u.VirtualKeyId,
+                Amount = u.Amount,
+                Model = u.Model,
+                Provider = u.ProviderType.ToString(),
+                RequestMetadata = u.Metadata
+            }).ToList();
+
+            // Get idempotency token from header (optional)
+            var idempotencyToken = HttpContext.Request.Headers["X-Idempotency-Token"].FirstOrDefault();
+
+            // Execute batch spend update operation
+            var result = await _batchSpendUpdateOperation.ExecuteAsync(
+                spendUpdates,
+                virtualKeyId,
+                idempotencyToken,
+                HttpContext.RequestAborted);
+
+            Logger.LogInformation(
+                "Started batch spend update operation {OperationId} with {Count} items (Idempotent: {Idempotent})",
+                result.OperationId,
+                request.Updates.Count(),
+                !string.IsNullOrWhiteSpace(idempotencyToken));
+
+            GatewayOpsMetrics.RecordBatchOperation("spend_update", "accepted", request.Updates.Count());
+            return Accepted(new BatchOperationStartResponse
+            {
+                OperationId = result.OperationId,
+                OperationType = "spend_update",
+                TotalItems = request.Updates.Count(),
+                StatusUrl = $"/v1/batch/operations/{result.OperationId}",
+                TaskId = result.OperationId,
+                Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+            });
         }
 
         /// <summary>
@@ -137,93 +136,90 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(401)]
         public async Task<IActionResult> StartBatchVirtualKeyUpdate([FromBody] BatchVirtualKeyUpdateRequest request)
         {
-            return await ExecuteAsync(async () =>
+            var virtualKeyId = GetVirtualKeyId();
+
+            // Check if user has admin permissions
+            var virtualKeyInfo = await _virtualKeyService.GetVirtualKeyInfoAsync(virtualKeyId);
+            bool isAdmin = false;
+            if (virtualKeyInfo != null && !string.IsNullOrEmpty(virtualKeyInfo.Metadata))
             {
-                var virtualKeyId = GetVirtualKeyId();
-
-                // Check if user has admin permissions
-                var virtualKeyInfo = await _virtualKeyService.GetVirtualKeyInfoAsync(virtualKeyId);
-                bool isAdmin = false;
-                if (virtualKeyInfo != null && !string.IsNullOrEmpty(virtualKeyInfo.Metadata))
+                try
                 {
-                    try
+                    var metadata = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(virtualKeyInfo.Metadata);
+                    if (metadata != null && metadata.TryGetValue("isAdmin", out var isAdminValue))
                     {
-                        var metadata = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(virtualKeyInfo.Metadata);
-                        if (metadata != null && metadata.TryGetValue("isAdmin", out var isAdminValue))
-                        {
-                            isAdmin = isAdminValue?.ToString()?.ToLower() == "true";
-                        }
-                    }
-                    catch
-                    {
-                        // Invalid metadata format
+                        isAdmin = isAdminValue?.ToString()?.ToLower() == "true";
                     }
                 }
-
-                if (!isAdmin)
+                catch
                 {
-                    return Forbid("Admin permissions required for batch virtual key updates");
+                    // Invalid metadata format
                 }
+            }
 
-                // Validate request
-                if (request.Updates == null || !request.Updates.Any())
+            if (!isAdmin)
+            {
+                return Forbid("Admin permissions required for batch virtual key updates");
+            }
+
+            // Validate request
+            if (request.Updates == null || !request.Updates.Any())
+            {
+                return BadRequest(new OpenAIErrorResponse
                 {
-                    return BadRequest(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "No updates provided",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                if (request.Updates.Count() > 1000)
-                {
-                    return BadRequest(new OpenAIErrorResponse
-                    {
-                        Error = new OpenAIError
-                        {
-                            Message = "Maximum 1,000 items per batch",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                // Convert to internal model
-                var keyUpdates = request.Updates.Select(u => new VirtualKeyUpdateItem
-                {
-                    VirtualKeyId = u.VirtualKeyId,
-                    AllowedModels = u.AllowedModels,
-                    RateLimits = u.RateLimits,
-                    IsEnabled = u.IsEnabled,
-                    ExpiresAt = u.ExpiresAt,
-                    Notes = u.Notes
-                }).ToList();
-
-                // Start operation
-                var result = await _batchVirtualKeyUpdateOperation.ExecuteAsync(
-                    keyUpdates,
-                    virtualKeyId,
-                    HttpContext.RequestAborted);
-
-                Logger.LogInformation(
-                    "Started batch virtual key update operation {OperationId} with {Count} items",
-                    result.OperationId,
-                    request.Updates.Count());
-
-                return Accepted(new BatchOperationStartResponse
-                {
-                    OperationId = result.OperationId,
-                    OperationType = "virtual_key_update",
-                    TotalItems = request.Updates.Count(),
-                    StatusUrl = $"/v1/batch/operations/{result.OperationId}",
-                    TaskId = result.OperationId,
-                    Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+                        Message = "No updates provided",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
                 });
-            }, "StartBatchVirtualKeyUpdate");
+            }
+
+            if (request.Updates.Count() > 1000)
+            {
+                return BadRequest(new OpenAIErrorResponse
+                {
+                    Error = new OpenAIError
+                    {
+                        Message = "Maximum 1,000 items per batch",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
+                });
+            }
+
+            // Convert to internal model
+            var keyUpdates = request.Updates.Select(u => new VirtualKeyUpdateItem
+            {
+                VirtualKeyId = u.VirtualKeyId,
+                AllowedModels = u.AllowedModels,
+                RateLimits = u.RateLimits,
+                IsEnabled = u.IsEnabled,
+                ExpiresAt = u.ExpiresAt,
+                Notes = u.Notes
+            }).ToList();
+
+            // Start operation
+            var result = await _batchVirtualKeyUpdateOperation.ExecuteAsync(
+                keyUpdates,
+                virtualKeyId,
+                HttpContext.RequestAborted);
+
+            Logger.LogInformation(
+                "Started batch virtual key update operation {OperationId} with {Count} items",
+                result.OperationId,
+                request.Updates.Count());
+
+            return Accepted(new BatchOperationStartResponse
+            {
+                OperationId = result.OperationId,
+                OperationType = "virtual_key_update",
+                TotalItems = request.Updates.Count(),
+                StatusUrl = $"/v1/batch/operations/{result.OperationId}",
+                TaskId = result.OperationId,
+                Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+            });
         }
 
         /// <summary>
@@ -237,69 +233,66 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(401)]
         public async Task<IActionResult> StartBatchWebhookSend([FromBody] BatchWebhookSendRequest request)
         {
-            return await ExecuteAsync(async () =>
+            var virtualKeyId = GetVirtualKeyId();
+
+            // Validate request
+            if (request.Webhooks == null || !request.Webhooks.Any())
             {
-                var virtualKeyId = GetVirtualKeyId();
-
-                // Validate request
-                if (request.Webhooks == null || !request.Webhooks.Any())
+                return BadRequest(new OpenAIErrorResponse
                 {
-                    return BadRequest(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "No webhooks provided",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                if (request.Webhooks.Count() > 5000)
-                {
-                    return BadRequest(new OpenAIErrorResponse
-                    {
-                        Error = new OpenAIError
-                        {
-                            Message = "Maximum 5,000 webhooks per batch",
-                            Type = "invalid_request_error",
-                            Code = "invalid_request"
-                        }
-                    });
-                }
-
-                // Convert to internal model
-                var webhookSends = request.Webhooks.Select(w => new WebhookSendItem
-                {
-                    WebhookUrl = w.Url,
-                    VirtualKeyId = virtualKeyId,
-                    EventType = w.EventType,
-                    Payload = w.Payload,
-                    Headers = w.Headers,
-                    Secret = w.Secret
-                }).ToList();
-
-                // Start operation
-                var result = await _batchWebhookSendOperation.ExecuteAsync(
-                    webhookSends,
-                    virtualKeyId,
-                    HttpContext.RequestAborted);
-
-                Logger.LogInformation(
-                    "Started batch webhook send operation {OperationId} with {Count} items",
-                    result.OperationId,
-                    request.Webhooks.Count());
-
-                return Accepted(new BatchOperationStartResponse
-                {
-                    OperationId = result.OperationId,
-                    OperationType = "webhook_send",
-                    TotalItems = request.Webhooks.Count(),
-                    StatusUrl = $"/v1/batch/operations/{result.OperationId}",
-                    TaskId = result.OperationId,
-                    Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+                        Message = "No webhooks provided",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
                 });
-            }, "StartBatchWebhookSend");
+            }
+
+            if (request.Webhooks.Count() > 5000)
+            {
+                return BadRequest(new OpenAIErrorResponse
+                {
+                    Error = new OpenAIError
+                    {
+                        Message = "Maximum 5,000 webhooks per batch",
+                        Type = "invalid_request_error",
+                        Code = "invalid_request"
+                    }
+                });
+            }
+
+            // Convert to internal model
+            var webhookSends = request.Webhooks.Select(w => new WebhookSendItem
+            {
+                WebhookUrl = w.Url,
+                VirtualKeyId = virtualKeyId,
+                EventType = w.EventType,
+                Payload = w.Payload,
+                Headers = w.Headers,
+                Secret = w.Secret
+            }).ToList();
+
+            // Start operation
+            var result = await _batchWebhookSendOperation.ExecuteAsync(
+                webhookSends,
+                virtualKeyId,
+                HttpContext.RequestAborted);
+
+            Logger.LogInformation(
+                "Started batch webhook send operation {OperationId} with {Count} items",
+                result.OperationId,
+                request.Webhooks.Count());
+
+            return Accepted(new BatchOperationStartResponse
+            {
+                OperationId = result.OperationId,
+                OperationType = "webhook_send",
+                TotalItems = request.Webhooks.Count(),
+                StatusUrl = $"/v1/batch/operations/{result.OperationId}",
+                TaskId = result.OperationId,
+                Message = "Batch operation started. Subscribe to TaskHub with the taskId for real-time updates."
+            });
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
@@ -4,6 +4,7 @@ using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
+using ConduitLLM.Gateway.Filters;
 using Microsoft.AspNetCore.Authorization;
 using ConduitLLM.Configuration.DTOs;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/discovery")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class DiscoveryController : GatewayControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -48,157 +50,152 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="capability">Optional capability filter (e.g., "video_generation", "vision")</param>
         /// <returns>List of models with their capabilities.</returns>
         [HttpGet("models")]
-        public Task<IActionResult> GetModels([FromQuery] string? capability = null)
+        public async Task<IActionResult> GetModels([FromQuery] string? capability = null)
         {
-            return ExecuteAsync(async () =>
+            // Get virtual key from user claims
+            var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
+            if (string.IsNullOrEmpty(virtualKeyValue))
             {
-                // Get virtual key from user claims
-                var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
-                if (string.IsNullOrEmpty(virtualKeyValue))
-                {
-                    return OpenAIError(401, "Virtual key not found", "unauthorized");
-                }
+                return OpenAIError(401, "Virtual key not found", "unauthorized");
+            }
 
-                // Validate virtual key is active
-                var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
-                if (virtualKey == null)
-                {
-                    return OpenAIError(401, "Invalid virtual key", "unauthorized");
-                }
+            // Validate virtual key is active
+            var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
+            if (virtualKey == null)
+            {
+                return OpenAIError(401, "Invalid virtual key", "unauthorized");
+            }
 
-                // Build cache key based on capability filter
-                var cacheKey = DiscoveryCacheService.BuildCacheKey(capability);
+            // Build cache key based on capability filter
+            var cacheKey = DiscoveryCacheService.BuildCacheKey(capability);
 
-                // Try to get from cache first
-                var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
-                if (cachedResult != null)
-                {
-                    Logger.LogDebug("Returning cached discovery results for capability: {Capability}", LoggingSanitizer.S(capability ?? "all"));
-                    return Ok(new
-                    {
-                        data = cachedResult.Data,
-                        count = cachedResult.Count
-                    });
-                }
-
-                using var context = await _dbContextFactory.CreateDbContextAsync();
-
-                // Get all enabled model mappings with their related data
-                var modelMappings = await context.ModelProviderMappings
-                    .Include(m => m.Provider)
-                    .Include(m => m.ModelProviderTypeAssociation)
-                        .ThenInclude(mpta => mpta.Model)
-                            .ThenInclude(m => m.Series)
-                    .AsNoTracking()
-                    .Where(m => m.IsEnabled && m.Provider != null && m.Provider.IsEnabled)
-                    .ToListAsync();
-
-                Logger.LogDebug("Found {Count} enabled model mappings for discovery (capability filter: {Capability})",
-                    modelMappings.Count, LoggingSanitizer.S(capability ?? "all"));
-
-                var models = new List<JsonElement>();
-
-                foreach (var mapping in modelMappings)
-                {
-                    // Skip if model is missing
-                    if (mapping.ModelProviderTypeAssociation?.Model == null)
-                    {
-                        Logger.LogWarning("Model mapping {ModelAlias} has no model data", LoggingSanitizer.S(mapping.ModelAlias));
-                        continue;
-                    }
-
-                    var caps = mapping.ModelProviderTypeAssociation.Model;
-
-                    // Apply capability filter if specified
-                    if (!string.IsNullOrEmpty(capability))
-                    {
-                        var capabilityKey = capability.Replace("-", "_").ToLowerInvariant();
-                        bool hasCapability = capabilityKey switch
-                        {
-                            "chat" => caps.SupportsChat,
-                            "streaming" or "chat_stream" => caps.SupportsStreaming,
-                            "vision" => caps.SupportsVision,
-                            "video_generation" => caps.SupportsVideoGeneration,
-                            "image_generation" => caps.SupportsImageGeneration,
-                            "embeddings" => caps.SupportsEmbeddings,
-                            "function_calling" => caps.SupportsFunctionCalling,
-                            _ => false
-                        };
-
-                        if (!hasCapability)
-                        {
-                            continue;
-                        }
-                    }
-
-                    // TODO: Revisit supported_parameters implementation after removing ApiParameters field
-                    // Currently commented out as we're moving to full parameter pass-through
-                    // and ApiParameters field is being deprecated. Parameters should be derived
-                    // from the UI-focused Parameters JSON object instead.
-
-                    // Use overrides from association first, then fall back to model defaults
-                    var maxInputTokens = mapping.ModelProviderTypeAssociation.MaxInputTokens ?? caps.MaxInputTokens ?? 0;
-                    var maxOutputTokens = mapping.ModelProviderTypeAssociation.MaxOutputTokens ?? caps.MaxOutputTokens ?? 0;
-
-                    // Serialize to JsonElement for cache-safe storage (anonymous objects can't round-trip through JSON deserialization)
-                    models.Add(JsonSerializer.SerializeToElement(new
-                    {
-                        // Identity
-                        id = mapping.ModelAlias,
-                        provider = mapping.Provider?.ProviderType.ToString().ToLowerInvariant(),
-                        display_name = mapping.ModelAlias,
-
-                        // Metadata
-                        description = mapping.ModelProviderTypeAssociation?.Model?.Description ?? string.Empty,
-                        model_card_url = mapping.ModelProviderTypeAssociation?.Model?.ModelCardUrl ?? string.Empty,
-                        max_tokens = maxInputTokens + maxOutputTokens, // Total context window size
-                        max_input_tokens = maxInputTokens,
-                        max_output_tokens = maxOutputTokens,
-                        tokenizer_type = caps.TokenizerType.ToString().ToLowerInvariant(),
-
-                        // UI Parameters from Model or Series
-                        parameters = mapping.ModelProviderTypeAssociation?.Model?.ModelParameters ?? mapping.ModelProviderTypeAssociation?.Model?.Series?.Parameters ?? "{}",
-
-                        // Capabilities (nested object as expected by SDK)
-                        capabilities = new
-                        {
-                            chat = caps.SupportsChat,
-                            chat_stream = caps.SupportsStreaming,
-                            embeddings = caps.SupportsEmbeddings,
-                            image_generation = caps.SupportsImageGeneration,
-                            vision = caps.SupportsVision,
-                            video_generation = caps.SupportsVideoGeneration,
-                            video_understanding = false, // Not yet supported
-                            function_calling = caps.SupportsFunctionCalling,
-                            tool_use = caps.SupportsFunctionCalling, // Same as function calling for now
-                            json_mode = false, // Not yet tracked
-                            max_tokens = maxInputTokens + maxOutputTokens,
-                            max_output_tokens = maxOutputTokens
-                        }
-                    }));
-                }
-
-                // Cache the results for future requests
-                var discoveryResult = new DiscoveryModelsResult
-                {
-                    Data = models,
-                    Count = models.Count,
-                    CapabilityFilter = capability
-                };
-
-                await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
-
-                Logger.LogInformation("Cached discovery results for capability: {Capability} with {Count} models",
-                    LoggingSanitizer.S(capability ?? "all"), models.Count);
-
+            // Try to get from cache first
+            var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
+            if (cachedResult != null)
+            {
+                Logger.LogDebug("Returning cached discovery results for capability: {Capability}", LoggingSanitizer.S(capability ?? "all"));
                 return Ok(new
                 {
-                    data = models,
-                    count = models.Count
+                    data = cachedResult.Data,
+                    count = cachedResult.Count
                 });
-            },
-            "GetModels",
-            capability);
+            }
+
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            // Get all enabled model mappings with their related data
+            var modelMappings = await context.ModelProviderMappings
+                .Include(m => m.Provider)
+                .Include(m => m.ModelProviderTypeAssociation)
+                    .ThenInclude(mpta => mpta.Model)
+                        .ThenInclude(m => m.Series)
+                .AsNoTracking()
+                .Where(m => m.IsEnabled && m.Provider != null && m.Provider.IsEnabled)
+                .ToListAsync();
+
+            Logger.LogDebug("Found {Count} enabled model mappings for discovery (capability filter: {Capability})",
+                modelMappings.Count, LoggingSanitizer.S(capability ?? "all"));
+
+            var models = new List<JsonElement>();
+
+            foreach (var mapping in modelMappings)
+            {
+                // Skip if model is missing
+                if (mapping.ModelProviderTypeAssociation?.Model == null)
+                {
+                    Logger.LogWarning("Model mapping {ModelAlias} has no model data", LoggingSanitizer.S(mapping.ModelAlias));
+                    continue;
+                }
+
+                var caps = mapping.ModelProviderTypeAssociation.Model;
+
+                // Apply capability filter if specified
+                if (!string.IsNullOrEmpty(capability))
+                {
+                    var capabilityKey = capability.Replace("-", "_").ToLowerInvariant();
+                    bool hasCapability = capabilityKey switch
+                    {
+                        "chat" => caps.SupportsChat,
+                        "streaming" or "chat_stream" => caps.SupportsStreaming,
+                        "vision" => caps.SupportsVision,
+                        "video_generation" => caps.SupportsVideoGeneration,
+                        "image_generation" => caps.SupportsImageGeneration,
+                        "embeddings" => caps.SupportsEmbeddings,
+                        "function_calling" => caps.SupportsFunctionCalling,
+                        _ => false
+                    };
+
+                    if (!hasCapability)
+                    {
+                        continue;
+                    }
+                }
+
+                // TODO: Revisit supported_parameters implementation after removing ApiParameters field
+                // Currently commented out as we're moving to full parameter pass-through
+                // and ApiParameters field is being deprecated. Parameters should be derived
+                // from the UI-focused Parameters JSON object instead.
+
+                // Use overrides from association first, then fall back to model defaults
+                var maxInputTokens = mapping.ModelProviderTypeAssociation.MaxInputTokens ?? caps.MaxInputTokens ?? 0;
+                var maxOutputTokens = mapping.ModelProviderTypeAssociation.MaxOutputTokens ?? caps.MaxOutputTokens ?? 0;
+
+                // Serialize to JsonElement for cache-safe storage (anonymous objects can't round-trip through JSON deserialization)
+                models.Add(JsonSerializer.SerializeToElement(new
+                {
+                    // Identity
+                    id = mapping.ModelAlias,
+                    provider = mapping.Provider?.ProviderType.ToString().ToLowerInvariant(),
+                    display_name = mapping.ModelAlias,
+
+                    // Metadata
+                    description = mapping.ModelProviderTypeAssociation?.Model?.Description ?? string.Empty,
+                    model_card_url = mapping.ModelProviderTypeAssociation?.Model?.ModelCardUrl ?? string.Empty,
+                    max_tokens = maxInputTokens + maxOutputTokens, // Total context window size
+                    max_input_tokens = maxInputTokens,
+                    max_output_tokens = maxOutputTokens,
+                    tokenizer_type = caps.TokenizerType.ToString().ToLowerInvariant(),
+
+                    // UI Parameters from Model or Series
+                    parameters = mapping.ModelProviderTypeAssociation?.Model?.ModelParameters ?? mapping.ModelProviderTypeAssociation?.Model?.Series?.Parameters ?? "{}",
+
+                    // Capabilities (nested object as expected by SDK)
+                    capabilities = new
+                    {
+                        chat = caps.SupportsChat,
+                        chat_stream = caps.SupportsStreaming,
+                        embeddings = caps.SupportsEmbeddings,
+                        image_generation = caps.SupportsImageGeneration,
+                        vision = caps.SupportsVision,
+                        video_generation = caps.SupportsVideoGeneration,
+                        video_understanding = false, // Not yet supported
+                        function_calling = caps.SupportsFunctionCalling,
+                        tool_use = caps.SupportsFunctionCalling, // Same as function calling for now
+                        json_mode = false, // Not yet tracked
+                        max_tokens = maxInputTokens + maxOutputTokens,
+                        max_output_tokens = maxOutputTokens
+                    }
+                }));
+            }
+
+            // Cache the results for future requests
+            var discoveryResult = new DiscoveryModelsResult
+            {
+                Data = models,
+                Count = models.Count,
+                CapabilityFilter = capability
+            };
+
+            await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
+
+            Logger.LogInformation("Cached discovery results for capability: {Capability} with {Count} models",
+                LoggingSanitizer.S(capability ?? "all"), models.Count);
+
+            return Ok(new
+            {
+                data = models,
+                count = models.Count
+            });
         }
 
         /// <summary>
@@ -206,30 +203,28 @@ namespace ConduitLLM.Gateway.Controllers
         /// </summary>
         /// <returns>List of all available capabilities.</returns>
         [HttpGet("capabilities")]
-        public Task<IActionResult> GetCapabilities()
+        public async Task<IActionResult> GetCapabilities()
         {
-            return ExecuteAsync(async () =>
-            {
-                // Return all known capabilities
-                var capabilities = new[]
-                {
-                    "chat",
-                    "chat_stream",
-                    "vision",
-                    "video_generation",
-                    "image_generation",
-                    "embeddings",
-                    "function_calling",
-                    "tool_use",
-                    "json_mode"
-                };
+            await Task.CompletedTask;
 
-                return await Task.FromResult<IActionResult>(Ok(new
-                {
-                    capabilities = capabilities
-                }));
-            },
-            "GetCapabilities");
+            // Return all known capabilities
+            var capabilities = new[]
+            {
+                "chat",
+                "chat_stream",
+                "vision",
+                "video_generation",
+                "image_generation",
+                "embeddings",
+                "function_calling",
+                "tool_use",
+                "json_mode"
+            };
+
+            return Ok(new
+            {
+                capabilities = capabilities
+            });
         }
 
         /// <summary>
@@ -238,83 +233,78 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="model">The model alias or identifier to get parameters for</param>
         /// <returns>JSON object containing UI parameter definitions for the model.</returns>
         [HttpGet("models/{model}/parameters")]
-        public Task<IActionResult> GetModelParameters(string model)
+        public async Task<IActionResult> GetModelParameters(string model)
         {
-            return ExecuteAsync(async () =>
+            // Get virtual key from user claims
+            var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
+            if (string.IsNullOrEmpty(virtualKeyValue))
             {
-                // Get virtual key from user claims
-                var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
-                if (string.IsNullOrEmpty(virtualKeyValue))
+                return OpenAIError(401, "Virtual key not found", "unauthorized");
+            }
+
+            // Validate virtual key is active
+            var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
+            if (virtualKey == null)
+            {
+                return OpenAIError(401, "Invalid virtual key", "unauthorized");
+            }
+
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            // Find the model mapping by alias
+            var modelMapping = await context.ModelProviderMappings
+                .Include(m => m.ModelProviderTypeAssociation)
+                    .ThenInclude(mpta => mpta.Model)
+                        .ThenInclude(m => m!.Series)
+                .AsNoTracking()
+                .Where(m => m.ModelAlias == model && m.IsEnabled)
+                .FirstOrDefaultAsync();
+
+            if (modelMapping == null)
+            {
+                // Try to find by Model.Id if the input is numeric
+                if (int.TryParse(model, out var modelId))
                 {
-                    return OpenAIError(401, "Virtual key not found", "unauthorized");
+                    modelMapping = await context.ModelProviderMappings
+                        .Include(m => m.ModelProviderTypeAssociation)
+                            .ThenInclude(mpta => mpta.Model)
+                                .ThenInclude(m => m!.Series)
+                        .AsNoTracking()
+                        .Where(m => m.ModelProviderTypeAssociation != null && m.ModelProviderTypeAssociation.ModelId == modelId && m.IsEnabled)
+                        .FirstOrDefaultAsync();
                 }
+            }
 
-                // Validate virtual key is active
-                var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
-                if (virtualKey == null)
+            if (modelMapping?.ModelProviderTypeAssociation?.Model == null)
+            {
+                return OpenAIError(404, $"Model '{model}' not found or has no parameter information", "model_not_found");
+            }
+
+            // Parse the Parameters JSON - check model-specific parameters first, then fall back to series
+            object? parameters = null;
+            var parametersJson = modelMapping.ModelProviderTypeAssociation.Model.ModelParameters
+                ?? modelMapping.ModelProviderTypeAssociation.Model.Series?.Parameters;
+
+            if (!string.IsNullOrEmpty(parametersJson))
+            {
+                try
                 {
-                    return OpenAIError(401, "Invalid virtual key", "unauthorized");
+                    parameters = System.Text.Json.JsonSerializer.Deserialize<object>(parametersJson);
                 }
-
-                using var context = await _dbContextFactory.CreateDbContextAsync();
-
-                // Find the model mapping by alias
-                var modelMapping = await context.ModelProviderMappings
-                    .Include(m => m.ModelProviderTypeAssociation)
-                        .ThenInclude(mpta => mpta.Model)
-                            .ThenInclude(m => m!.Series)
-                    .AsNoTracking()
-                    .Where(m => m.ModelAlias == model && m.IsEnabled)
-                    .FirstOrDefaultAsync();
-
-                if (modelMapping == null)
+                catch (Exception ex)
                 {
-                    // Try to find by Model.Id if the input is numeric
-                    if (int.TryParse(model, out var modelId))
-                    {
-                        modelMapping = await context.ModelProviderMappings
-                            .Include(m => m.ModelProviderTypeAssociation)
-                                .ThenInclude(mpta => mpta.Model)
-                                    .ThenInclude(m => m!.Series)
-                            .AsNoTracking()
-                            .Where(m => m.ModelProviderTypeAssociation != null && m.ModelProviderTypeAssociation.ModelId == modelId && m.IsEnabled)
-                            .FirstOrDefaultAsync();
-                    }
+                    Logger.LogWarning(ex, "Failed to parse parameters for model {Model}", LoggingSanitizer.S(model));
+                    parameters = new { };
                 }
+            }
 
-                if (modelMapping?.ModelProviderTypeAssociation?.Model == null)
-                {
-                    return OpenAIError(404, $"Model '{model}' not found or has no parameter information", "model_not_found");
-                }
-
-                // Parse the Parameters JSON - check model-specific parameters first, then fall back to series
-                object? parameters = null;
-                var parametersJson = modelMapping.ModelProviderTypeAssociation.Model.ModelParameters
-                    ?? modelMapping.ModelProviderTypeAssociation.Model.Series?.Parameters;
-
-                if (!string.IsNullOrEmpty(parametersJson))
-                {
-                    try
-                    {
-                        parameters = System.Text.Json.JsonSerializer.Deserialize<object>(parametersJson);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning(ex, "Failed to parse parameters for model {Model}", LoggingSanitizer.S(model));
-                        parameters = new { };
-                    }
-                }
-
-                return Ok(new
-                {
-                    model_id = modelMapping.ModelProviderTypeAssociation.ModelId,
-                    model_alias = modelMapping.ModelAlias,
-                    series_name = modelMapping.ModelProviderTypeAssociation.Model.Series?.Name ?? string.Empty,
-                    parameters = parameters ?? new { }
-                });
-            },
-            "GetModelParameters",
-            model);
+            return Ok(new
+            {
+                model_id = modelMapping.ModelProviderTypeAssociation.ModelId,
+                model_alias = modelMapping.ModelAlias,
+                series_name = modelMapping.ModelProviderTypeAssociation.Model.Series?.Name ?? string.Empty,
+                parameters = parameters ?? new { }
+            });
         }
 
         /// <summary>
@@ -324,93 +314,89 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="providerType">Optional provider type filter (e.g., "Exa", "Perplexity")</param>
         /// <returns>List of available function configurations</returns>
         [HttpGet("functions")]
-        public Task<IActionResult> GetFunctions(
+        public async Task<IActionResult> GetFunctions(
             [FromQuery] string? purpose = null,
             [FromQuery] string? providerType = null)
         {
-            return ExecuteAsync(async () =>
+            // Get virtual key from user claims
+            var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
+            if (string.IsNullOrEmpty(virtualKeyValue))
             {
-                // Get virtual key from user claims
-                var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
-                if (string.IsNullOrEmpty(virtualKeyValue))
+                return OpenAIError(401, "Virtual key not found", "unauthorized");
+            }
+
+            // Validate virtual key is active
+            var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
+            if (virtualKey == null)
+            {
+                return OpenAIError(401, "Invalid virtual key", "unauthorized");
+            }
+
+            // Build cache key based on filters
+            var cacheKey = $"functions_discovery_{purpose ?? "all"}_{providerType ?? "all"}";
+
+            // Try to get from cache first
+            var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
+            if (cachedResult != null)
+            {
+                Logger.LogDebug("Returning cached function discovery results");
+                return Ok(cachedResult.Data);
+            }
+
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            // Get all enabled function configurations
+            var query = context.FunctionConfigurations
+                .Where(fc => fc.IsEnabled);
+
+            // Apply filters
+            if (!string.IsNullOrEmpty(purpose))
+            {
+                if (Enum.TryParse<ConduitLLM.Functions.Enums.FunctionPurpose>(purpose, true, out var purposeEnum))
                 {
-                    return OpenAIError(401, "Virtual key not found", "unauthorized");
+                    query = query.Where(fc => fc.Purpose == purposeEnum);
                 }
+            }
 
-                // Validate virtual key is active
-                var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
-                if (virtualKey == null)
+            if (!string.IsNullOrEmpty(providerType))
+            {
+                if (Enum.TryParse<ConduitLLM.Functions.Enums.FunctionProviderType>(providerType, true, out var providerEnum))
                 {
-                    return OpenAIError(401, "Invalid virtual key", "unauthorized");
+                    query = query.Where(fc => fc.ProviderType == providerEnum);
                 }
+            }
 
-                // Build cache key based on filters
-                var cacheKey = $"functions_discovery_{purpose ?? "all"}_{providerType ?? "all"}";
+            var configurations = await query.AsNoTracking().ToListAsync();
 
-                // Try to get from cache first
-                var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
-                if (cachedResult != null)
+            var result = new ConduitLLM.Functions.DTOs.FunctionDiscoveryResponse
+            {
+                Functions = configurations.Select(fc => new ConduitLLM.Functions.DTOs.FunctionDiscoveryDto
                 {
-                    Logger.LogDebug("Returning cached function discovery results");
-                    return Ok(cachedResult.Data);
-                }
+                    Id = fc.Id,
+                    ConfigurationName = fc.ConfigurationName,
+                    ProviderType = fc.ProviderType.ToString(),
+                    Purpose = fc.Purpose.ToString(),
+                    Description = fc.Description,
+                    DefaultExecutionMode = fc.DefaultExecutionMode.ToString(),
+                    IsEnabled = fc.IsEnabled,
+                    TimeoutSeconds = fc.TimeoutSeconds
+                }).ToList(),
+                Count = configurations.Count
+            };
 
-                using var context = await _dbContextFactory.CreateDbContextAsync();
+            // Cache the results
+            var discoveryResult = new DiscoveryModelsResult
+            {
+                Data = new List<JsonElement> { JsonSerializer.SerializeToElement(result) },
+                Count = result.Count,
+                CapabilityFilter = purpose
+            };
 
-                // Get all enabled function configurations
-                var query = context.FunctionConfigurations
-                    .Where(fc => fc.IsEnabled);
+            await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
 
-                // Apply filters
-                if (!string.IsNullOrEmpty(purpose))
-                {
-                    if (Enum.TryParse<ConduitLLM.Functions.Enums.FunctionPurpose>(purpose, true, out var purposeEnum))
-                    {
-                        query = query.Where(fc => fc.Purpose == purposeEnum);
-                    }
-                }
+            Logger.LogInformation("Cached function discovery results with {Count} functions", result.Count);
 
-                if (!string.IsNullOrEmpty(providerType))
-                {
-                    if (Enum.TryParse<ConduitLLM.Functions.Enums.FunctionProviderType>(providerType, true, out var providerEnum))
-                    {
-                        query = query.Where(fc => fc.ProviderType == providerEnum);
-                    }
-                }
-
-                var configurations = await query.AsNoTracking().ToListAsync();
-
-                var result = new ConduitLLM.Functions.DTOs.FunctionDiscoveryResponse
-                {
-                    Functions = configurations.Select(fc => new ConduitLLM.Functions.DTOs.FunctionDiscoveryDto
-                    {
-                        Id = fc.Id,
-                        ConfigurationName = fc.ConfigurationName,
-                        ProviderType = fc.ProviderType.ToString(),
-                        Purpose = fc.Purpose.ToString(),
-                        Description = fc.Description,
-                        DefaultExecutionMode = fc.DefaultExecutionMode.ToString(),
-                        IsEnabled = fc.IsEnabled,
-                        TimeoutSeconds = fc.TimeoutSeconds
-                    }).ToList(),
-                    Count = configurations.Count
-                };
-
-                // Cache the results
-                var discoveryResult = new DiscoveryModelsResult
-                {
-                    Data = new List<JsonElement> { JsonSerializer.SerializeToElement(result) },
-                    Count = result.Count,
-                    CapabilityFilter = purpose
-                };
-
-                await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
-
-                Logger.LogInformation("Cached function discovery results with {Count} functions", result.Count);
-
-                return Ok(result);
-            },
-            "GetFunctions");
+            return Ok(result);
         }
 
         /// <summary>
@@ -420,97 +406,92 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="functionConfigurationId">The function configuration ID</param>
         /// <returns>JSON schema defining required and optional parameters</returns>
         [HttpGet("functions/{functionConfigurationId}/parameters")]
-        public Task<IActionResult> GetFunctionParameters(int functionConfigurationId)
+        public async Task<IActionResult> GetFunctionParameters(int functionConfigurationId)
         {
-            return ExecuteAsync(async () =>
+            // Get virtual key from user claims
+            var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
+            if (string.IsNullOrEmpty(virtualKeyValue))
             {
-                // Get virtual key from user claims
-                var virtualKeyValue = HttpContext.User.FindFirst("VirtualKey")?.Value;
-                if (string.IsNullOrEmpty(virtualKeyValue))
+                return OpenAIError(401, "Virtual key not found", "unauthorized");
+            }
+
+            // Validate virtual key is active
+            var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
+            if (virtualKey == null)
+            {
+                return OpenAIError(401, "Invalid virtual key", "unauthorized");
+            }
+
+            // Build cache key
+            var cacheKey = $"function_parameters_{functionConfigurationId}";
+
+            // Try to get from cache first
+            var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
+            if (cachedResult != null)
+            {
+                Logger.LogDebug("Returning cached function parameter schema for config {ConfigId}", functionConfigurationId);
+                return Ok(cachedResult.Data);
+            }
+
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            // Find the function configuration
+            var configuration = await context.FunctionConfigurations
+                .AsNoTracking()
+                .Where(fc => fc.Id == functionConfigurationId && fc.IsEnabled)
+                .FirstOrDefaultAsync();
+
+            if (configuration == null)
+            {
+                return OpenAIError(404, $"Function configuration {functionConfigurationId} not found or is disabled", "not_found");
+            }
+
+            // Parse the parameter schema
+            object? parameterSchema = null;
+            object? exampleRequest = null;
+
+            if (!string.IsNullOrEmpty(configuration.ParameterSchema))
+            {
+                try
                 {
-                    return OpenAIError(401, "Virtual key not found", "unauthorized");
-                }
+                    var schemaDoc = System.Text.Json.JsonDocument.Parse(configuration.ParameterSchema);
+                    parameterSchema = System.Text.Json.JsonSerializer.Deserialize<object>(configuration.ParameterSchema);
 
-                // Validate virtual key is active
-                var virtualKey = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKeyValue);
-                if (virtualKey == null)
-                {
-                    return OpenAIError(401, "Invalid virtual key", "unauthorized");
-                }
-
-                // Build cache key
-                var cacheKey = $"function_parameters_{functionConfigurationId}";
-
-                // Try to get from cache first
-                var cachedResult = await _discoveryCacheService.GetDiscoveryResultsAsync(cacheKey);
-                if (cachedResult != null)
-                {
-                    Logger.LogDebug("Returning cached function parameter schema for config {ConfigId}", functionConfigurationId);
-                    return Ok(cachedResult.Data);
-                }
-
-                using var context = await _dbContextFactory.CreateDbContextAsync();
-
-                // Find the function configuration
-                var configuration = await context.FunctionConfigurations
-                    .AsNoTracking()
-                    .Where(fc => fc.Id == functionConfigurationId && fc.IsEnabled)
-                    .FirstOrDefaultAsync();
-
-                if (configuration == null)
-                {
-                    return OpenAIError(404, $"Function configuration {functionConfigurationId} not found or is disabled", "not_found");
-                }
-
-                // Parse the parameter schema
-                object? parameterSchema = null;
-                object? exampleRequest = null;
-
-                if (!string.IsNullOrEmpty(configuration.ParameterSchema))
-                {
-                    try
+                    // Try to extract example request if it's in the schema
+                    if (schemaDoc.RootElement.TryGetProperty("example", out var exampleElement))
                     {
-                        var schemaDoc = System.Text.Json.JsonDocument.Parse(configuration.ParameterSchema);
-                        parameterSchema = System.Text.Json.JsonSerializer.Deserialize<object>(configuration.ParameterSchema);
-
-                        // Try to extract example request if it's in the schema
-                        if (schemaDoc.RootElement.TryGetProperty("example", out var exampleElement))
-                        {
-                            exampleRequest = System.Text.Json.JsonSerializer.Deserialize<object>(exampleElement.GetRawText());
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning(ex, "Failed to parse parameter schema for function config {ConfigId}", functionConfigurationId);
-                        parameterSchema = new { };
+                        exampleRequest = System.Text.Json.JsonSerializer.Deserialize<object>(exampleElement.GetRawText());
                     }
                 }
-
-                var result = new ConduitLLM.Functions.DTOs.FunctionParametersResponseDto
+                catch (Exception ex)
                 {
-                    FunctionConfigurationId = configuration.Id,
-                    ConfigurationName = configuration.ConfigurationName,
-                    ProviderType = configuration.ProviderType.ToString(),
-                    Purpose = configuration.Purpose.ToString(),
-                    ParameterSchema = parameterSchema ?? new { },
-                    ExampleRequest = exampleRequest
-                };
+                    Logger.LogWarning(ex, "Failed to parse parameter schema for function config {ConfigId}", functionConfigurationId);
+                    parameterSchema = new { };
+                }
+            }
 
-                // Cache the results
-                var discoveryResult = new DiscoveryModelsResult
-                {
-                    Data = new List<JsonElement> { JsonSerializer.SerializeToElement(result) },
-                    Count = 1
-                };
+            var result = new ConduitLLM.Functions.DTOs.FunctionParametersResponseDto
+            {
+                FunctionConfigurationId = configuration.Id,
+                ConfigurationName = configuration.ConfigurationName,
+                ProviderType = configuration.ProviderType.ToString(),
+                Purpose = configuration.Purpose.ToString(),
+                ParameterSchema = parameterSchema ?? new { },
+                ExampleRequest = exampleRequest
+            };
 
-                await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
+            // Cache the results
+            var discoveryResult = new DiscoveryModelsResult
+            {
+                Data = new List<JsonElement> { JsonSerializer.SerializeToElement(result) },
+                Count = 1
+            };
 
-                Logger.LogInformation("Cached function parameter schema for config {ConfigId}", functionConfigurationId);
+            await _discoveryCacheService.SetDiscoveryResultsAsync(cacheKey, discoveryResult);
 
-                return Ok(result);
-            },
-            "GetFunctionParameters",
-            functionConfigurationId);
+            Logger.LogInformation("Cached function parameter schema for config {ConfigId}", functionConfigurationId);
+
+            return Ok(result);
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Controllers/DownloadsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/DownloadsController.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Gateway.Filters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ConduitLLM.Configuration.Interfaces;
@@ -14,6 +15,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/downloads")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class DownloadsController : GatewayControllerBase
     {
         private readonly IFileRetrievalService _fileRetrievalService;
@@ -39,49 +41,46 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="inline">Whether to display inline (true) or force download (false).</param>
         /// <returns>The file content.</returns>
         [HttpGet("{**fileId}")]
-        public Task<IActionResult> DownloadFile(string fileId, [FromQuery] bool inline = false)
+        public async Task<IActionResult> DownloadFile(string fileId, [FromQuery] bool inline = false)
         {
-            return ExecuteAsync(async () =>
+            var virtualKeyId = GetVirtualKeyId();
+            Logger.LogDebug("File download requested by Virtual Key {VirtualKeyId}: {FileId}, inline: {Inline}",
+                virtualKeyId, LoggingSanitizer.S(fileId), inline);
+
+            // Validate ownership
+            if (!await ValidateFileOwnership(fileId, virtualKeyId))
             {
-                var virtualKeyId = GetVirtualKeyId();
-                Logger.LogDebug("File download requested by Virtual Key {VirtualKeyId}: {FileId}, inline: {Inline}",
-                    virtualKeyId, LoggingSanitizer.S(fileId), inline);
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+            }
 
-                // Validate ownership
-                if (!await ValidateFileOwnership(fileId, virtualKeyId))
+            var result = await _fileRetrievalService.RetrieveFileAsync(fileId);
+            if (result == null)
+            {
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+            }
+
+            using (result)
+            {
+                // Set appropriate headers
+                if (!inline && !string.IsNullOrEmpty(result.Metadata.FileName))
                 {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+                    Response.Headers["Content-Disposition"] = $"attachment; filename=\"{result.Metadata.FileName}\"";
                 }
 
-                var result = await _fileRetrievalService.RetrieveFileAsync(fileId);
-                if (result == null)
+                // Set cache headers
+                if (!string.IsNullOrEmpty(result.Metadata.ETag))
                 {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+                    Response.Headers["ETag"] = result.Metadata.ETag;
+                    Response.Headers["Cache-Control"] = "private, max-age=3600";
                 }
 
-                using (result)
-                {
-                    // Set appropriate headers
-                    if (!inline && !string.IsNullOrEmpty(result.Metadata.FileName))
-                    {
-                        Response.Headers["Content-Disposition"] = $"attachment; filename=\"{result.Metadata.FileName}\"";
-                    }
-
-                    // Set cache headers
-                    if (!string.IsNullOrEmpty(result.Metadata.ETag))
-                    {
-                        Response.Headers["ETag"] = result.Metadata.ETag;
-                        Response.Headers["Cache-Control"] = "private, max-age=3600";
-                    }
-
-                    // Return file with range processing support
-                    return File(
-                        result.ContentStream,
-                        result.Metadata.ContentType,
-                        result.Metadata.FileName,
-                        enableRangeProcessing: result.Metadata.SupportsRangeRequests);
-                }
-            }, nameof(DownloadFile), fileId);
+                // Return file with range processing support
+                return File(
+                    result.ContentStream,
+                    result.Metadata.ContentType,
+                    result.Metadata.FileName,
+                    enableRangeProcessing: result.Metadata.SupportsRangeRequests);
+            }
         }
 
         /// <summary>
@@ -90,36 +89,33 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="fileId">The file identifier.</param>
         /// <returns>File metadata.</returns>
         [HttpGet("metadata/{**fileId}")]
-        public Task<IActionResult> GetFileMetadata(string fileId)
+        public async Task<IActionResult> GetFileMetadata(string fileId)
         {
-            return ExecuteAsync(async () =>
+            // Validate ownership
+            var virtualKeyId = GetVirtualKeyId();
+            if (!await ValidateFileOwnership(fileId, virtualKeyId))
             {
-                // Validate ownership
-                var virtualKeyId = GetVirtualKeyId();
-                if (!await ValidateFileOwnership(fileId, virtualKeyId))
-                {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
-                }
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+            }
 
-                var metadata = await _fileRetrievalService.GetFileMetadataAsync(fileId);
-                if (metadata == null)
-                {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
-                }
+            var metadata = await _fileRetrievalService.GetFileMetadataAsync(fileId);
+            if (metadata == null)
+            {
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+            }
 
-                return Ok(new
-                {
-                    file_name = metadata.FileName,
-                    content_type = metadata.ContentType,
-                    size_bytes = metadata.SizeBytes,
-                    created_at = metadata.CreatedAt,
-                    modified_at = metadata.ModifiedAt,
-                    storage_provider = metadata.StorageProvider,
-                    etag = metadata.ETag,
-                    supports_range_requests = metadata.SupportsRangeRequests,
-                    additional_metadata = metadata.AdditionalMetadata
-                });
-            }, nameof(GetFileMetadata), fileId);
+            return Ok(new
+            {
+                file_name = metadata.FileName,
+                content_type = metadata.ContentType,
+                size_bytes = metadata.SizeBytes,
+                created_at = metadata.CreatedAt,
+                modified_at = metadata.ModifiedAt,
+                storage_provider = metadata.StorageProvider,
+                etag = metadata.ETag,
+                supports_range_requests = metadata.SupportsRangeRequests,
+                additional_metadata = metadata.AdditionalMetadata
+            });
         }
 
         /// <summary>
@@ -128,46 +124,43 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="request">The URL generation request.</param>
         /// <returns>A temporary download URL.</returns>
         [HttpPost("generate-url")]
-        public Task<IActionResult> GenerateDownloadUrl([FromBody] GenerateUrlRequest request)
+        public async Task<IActionResult> GenerateDownloadUrl([FromBody] GenerateUrlRequest request)
         {
-            return ExecuteAsync(async () =>
+            if (string.IsNullOrWhiteSpace(request.FileId))
             {
-                if (string.IsNullOrWhiteSpace(request.FileId))
-                {
-                    return BadRequest(new ErrorResponseDto(new ErrorDetailsDto("File ID is required", "invalid_request_error")));
-                }
+                return BadRequest(new ErrorResponseDto(new ErrorDetailsDto("File ID is required", "invalid_request_error")));
+            }
 
-                var virtualKeyId = GetVirtualKeyId();
-                Logger.LogInformation("Download URL generation requested by Virtual Key {VirtualKeyId} for {FileId}, expiration: {ExpirationMinutes}m",
-                    virtualKeyId, LoggingSanitizer.S(request.FileId), request.ExpirationMinutes ?? 60);
+            var virtualKeyId = GetVirtualKeyId();
+            Logger.LogInformation("Download URL generation requested by Virtual Key {VirtualKeyId} for {FileId}, expiration: {ExpirationMinutes}m",
+                virtualKeyId, LoggingSanitizer.S(request.FileId), request.ExpirationMinutes ?? 60);
 
-                // Validate ownership
-                if (!await ValidateFileOwnership(request.FileId, virtualKeyId))
-                {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
-                }
+            // Validate ownership
+            if (!await ValidateFileOwnership(request.FileId, virtualKeyId))
+            {
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found", "not_found")));
+            }
 
-                var expirationMinutes = request.ExpirationMinutes ?? 60; // Default 1 hour
-                if (expirationMinutes < 1 || expirationMinutes > 10080) // Max 1 week
-                {
-                    return BadRequest(new ErrorResponseDto(new ErrorDetailsDto("Expiration must be between 1 minute and 1 week", "invalid_request_error")));
-                }
+            var expirationMinutes = request.ExpirationMinutes ?? 60; // Default 1 hour
+            if (expirationMinutes < 1 || expirationMinutes > 10080) // Max 1 week
+            {
+                return BadRequest(new ErrorResponseDto(new ErrorDetailsDto("Expiration must be between 1 minute and 1 week", "invalid_request_error")));
+            }
 
-                var expiration = TimeSpan.FromMinutes(expirationMinutes);
-                var url = await _fileRetrievalService.GetDownloadUrlAsync(request.FileId, expiration);
+            var expiration = TimeSpan.FromMinutes(expirationMinutes);
+            var url = await _fileRetrievalService.GetDownloadUrlAsync(request.FileId, expiration);
 
-                if (string.IsNullOrEmpty(url))
-                {
-                    return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found or URL generation failed", "not_found")));
-                }
+            if (string.IsNullOrEmpty(url))
+            {
+                return NotFound(new ErrorResponseDto(new ErrorDetailsDto("File not found or URL generation failed", "not_found")));
+            }
 
-                return Ok(new
-                {
-                    url = url,
-                    expires_at = DateTime.UtcNow.Add(expiration),
-                    expiration_minutes = expirationMinutes
-                });
-            }, nameof(GenerateDownloadUrl), request.FileId);
+            return Ok(new
+            {
+                url = url,
+                expires_at = DateTime.UtcNow.Add(expiration),
+                expiration_minutes = expirationMinutes
+            });
         }
 
         /// <summary>
@@ -176,36 +169,33 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="fileId">The file identifier.</param>
         /// <returns>200 OK if exists, 404 if not.</returns>
         [HttpHead("{**fileId}")]
-        public Task<IActionResult> CheckFileExists(string fileId)
+        public async Task<IActionResult> CheckFileExists(string fileId)
         {
-            return ExecuteAsync(async () =>
+            // Validate ownership
+            var virtualKeyId = GetVirtualKeyId();
+            if (!await ValidateFileOwnership(fileId, virtualKeyId))
             {
-                // Validate ownership
-                var virtualKeyId = GetVirtualKeyId();
-                if (!await ValidateFileOwnership(fileId, virtualKeyId))
-                {
-                    return NotFound();
-                }
+                return NotFound();
+            }
 
-                var exists = await _fileRetrievalService.FileExistsAsync(fileId);
-                if (!exists)
-                {
-                    return NotFound();
-                }
+            var exists = await _fileRetrievalService.FileExistsAsync(fileId);
+            if (!exists)
+            {
+                return NotFound();
+            }
 
-                var metadata = await _fileRetrievalService.GetFileMetadataAsync(fileId);
-                if (metadata != null)
+            var metadata = await _fileRetrievalService.GetFileMetadataAsync(fileId);
+            if (metadata != null)
+            {
+                Response.Headers["Content-Type"] = metadata.ContentType;
+                Response.Headers["Content-Length"] = metadata.SizeBytes.ToString();
+                if (!string.IsNullOrEmpty(metadata.ETag))
                 {
-                    Response.Headers["Content-Type"] = metadata.ContentType;
-                    Response.Headers["Content-Length"] = metadata.SizeBytes.ToString();
-                    if (!string.IsNullOrEmpty(metadata.ETag))
-                    {
-                        Response.Headers["ETag"] = metadata.ETag;
-                    }
+                    Response.Headers["ETag"] = metadata.ETag;
                 }
+            }
 
-                return Ok();
-            }, nameof(CheckFileExists), fileId);
+            return Ok();
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Gateway/Controllers/EmbeddingsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/EmbeddingsController.cs
@@ -11,6 +11,7 @@ using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ConduitLLM.Gateway.Authorization;
+using ConduitLLM.Gateway.Filters;
 
 namespace ConduitLLM.Gateway.Controllers
 {
@@ -22,6 +23,7 @@ namespace ConduitLLM.Gateway.Controllers
     [Authorize(AuthenticationSchemes = "VirtualKey")]
     [RequireBalance]
     [Tags("Embeddings")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class EmbeddingsController : GatewayControllerBase
     {
         private readonly Conduit _conduit;
@@ -67,35 +69,28 @@ namespace ConduitLLM.Gateway.Controllers
             using var activity = GatewayRequestMetrics.StartEmbeddingsActivity(request.Model);
             var sw = Stopwatch.StartNew();
 
-            return await ExecuteAsync(
-                async () =>
+            Logger.LogInformation("Processing embeddings request for model: {Model}", LoggingSanitizer.S(request.Model));
+
+            // Get provider info for usage tracking
+            try
+            {
+                var modelMapping = await _modelMappingService.GetMappingByModelAliasAsync(request.Model);
+                if (modelMapping != null)
                 {
-                    Logger.LogInformation("Processing embeddings request for model: {Model}", LoggingSanitizer.S(request.Model));
+                    HttpContext.Items["ProviderId"] = modelMapping.ProviderId;
+                    HttpContext.Items["ProviderType"] = modelMapping.Provider?.ProviderType;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to get provider info for model {Model}", request.Model);
+            }
 
-                    // Get provider info for usage tracking
-                    try
-                    {
-                        var modelMapping = await _modelMappingService.GetMappingByModelAliasAsync(request.Model);
-                        if (modelMapping != null)
-                        {
-                            HttpContext.Items["ProviderId"] = modelMapping.ProviderId;
-                            HttpContext.Items["ProviderType"] = modelMapping.Provider?.ProviderType;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning(ex, "Failed to get provider info for model {Model}", request.Model);
-                    }
-
-                    // Get the client for the specified model and create embeddings
-                    var client = await _conduit.GetClientAsync(request.Model, cancellationToken);
-                    var result = await client.CreateEmbeddingAsync(request, cancellationToken: cancellationToken);
-                    GatewayOpsMetrics.RecordLlmOperation("embedding", request.Model, "success", sw.Elapsed.TotalSeconds);
-                    return result;
-                },
-                result => Ok(result),
-                "CreateEmbedding",
-                request.Model);
+            // Get the client for the specified model and create embeddings
+            var client = await _conduit.GetClientAsync(request.Model, cancellationToken);
+            var result = await client.CreateEmbeddingAsync(request, cancellationToken: cancellationToken);
+            GatewayOpsMetrics.RecordLlmOperation("embedding", request.Model, "success", sw.Elapsed.TotalSeconds);
+            return Ok(result);
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Controllers/FunctionsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/FunctionsController.cs
@@ -3,6 +3,7 @@ using ConduitLLM.Core.Controllers;
 using ConduitLLM.Functions.Interfaces;
 using ConduitLLM.Functions.Enums;
 using ConduitLLM.Gateway.Authorization;
+using ConduitLLM.Gateway.Filters;
 using MassTransit;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -17,6 +18,7 @@ namespace ConduitLLM.Gateway.Controllers;
 [Authorize]
 [RequireBalance]
 [Tags("Functions")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class FunctionsController : GatewayControllerBase
 {
     private readonly IFunctionExecutionService _executionService;

--- a/Services/ConduitLLM.Gateway/Controllers/MediaController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/MediaController.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Gateway.Filters;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/media")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class MediaController : GatewayControllerBase
     {
         private readonly IMediaStorageService _storageService;
@@ -36,95 +38,91 @@ namespace ConduitLLM.Gateway.Controllers
         [Authorize]
         [Consumes("multipart/form-data")]
         [RequestSizeLimit(524288000)] // 500MB limit
-        public Task<IActionResult> UploadMedia(
+        public async Task<IActionResult> UploadMedia(
             IFormFile file,
             [FromForm] string? mediaType = null)
         {
-            return ExecuteAsync(async () =>
+            // Validate file
+            if (file == null || file.Length == 0)
             {
-                // Validate file
-                if (file == null || file.Length == 0)
+                return OpenAIError(400, "No file provided or file is empty", "invalid_request");
+            }
+
+            // Validate file extension
+            var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+            var allowedImageExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg" };
+            var allowedVideoExtensions = new[] { ".mp4", ".webm", ".mov", ".avi", ".mkv", ".flv", ".wmv", ".m4v" };
+            var allowedAudioExtensions = new[] { ".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac" };
+
+            // Determine media type from extension if not provided
+            MediaType determinedMediaType;
+            if (!string.IsNullOrEmpty(mediaType))
+            {
+                if (!Enum.TryParse<MediaType>(mediaType, true, out determinedMediaType))
                 {
-                    return OpenAIError(400, "No file provided or file is empty", "invalid_request");
+                    return OpenAIError(400, "Invalid media type. Must be Image, Video, or Audio", "invalid_parameter");
                 }
+            }
+            else if (allowedImageExtensions.Contains(extension))
+            {
+                determinedMediaType = MediaType.Image;
+            }
+            else if (allowedVideoExtensions.Contains(extension))
+            {
+                determinedMediaType = MediaType.Video;
+            }
+            else if (allowedAudioExtensions.Contains(extension))
+            {
+                determinedMediaType = MediaType.Audio;
+            }
+            else
+            {
+                return OpenAIError(400, $"Unsupported file extension: {extension}", "invalid_parameter");
+            }
 
-                // Validate file extension
-                var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
-                var allowedImageExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg" };
-                var allowedVideoExtensions = new[] { ".mp4", ".webm", ".mov", ".avi", ".mkv", ".flv", ".wmv", ".m4v" };
-                var allowedAudioExtensions = new[] { ".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac" };
+            // Validate file size based on type
+            var maxSizeBytes = determinedMediaType switch
+            {
+                MediaType.Image => 104857600L, // 100MB for images
+                MediaType.Video => 524288000L, // 500MB for videos
+                MediaType.Audio => 209715200L, // 200MB for audio
+                _ => 104857600L // Default 100MB
+            };
 
-                // Determine media type from extension if not provided
-                MediaType determinedMediaType;
-                if (!string.IsNullOrEmpty(mediaType))
-                {
-                    if (!Enum.TryParse<MediaType>(mediaType, true, out determinedMediaType))
-                    {
-                        return OpenAIError(400, "Invalid media type. Must be Image, Video, or Audio", "invalid_parameter");
-                    }
-                }
-                else if (allowedImageExtensions.Contains(extension))
-                {
-                    determinedMediaType = MediaType.Image;
-                }
-                else if (allowedVideoExtensions.Contains(extension))
-                {
-                    determinedMediaType = MediaType.Video;
-                }
-                else if (allowedAudioExtensions.Contains(extension))
-                {
-                    determinedMediaType = MediaType.Audio;
-                }
-                else
-                {
-                    return OpenAIError(400, $"Unsupported file extension: {extension}", "invalid_parameter");
-                }
+            if (file.Length > maxSizeBytes)
+            {
+                var maxSizeMB = maxSizeBytes / (1024 * 1024);
+                return OpenAIError(400, $"File size exceeds maximum allowed size of {maxSizeMB}MB for {determinedMediaType}", "invalid_request");
+            }
 
-                // Validate file size based on type
-                var maxSizeBytes = determinedMediaType switch
-                {
-                    MediaType.Image => 104857600L, // 100MB for images
-                    MediaType.Video => 524288000L, // 500MB for videos
-                    MediaType.Audio => 209715200L, // 200MB for audio
-                    _ => 104857600L // Default 100MB
-                };
+            // Create metadata
+            var metadata = new MediaMetadata
+            {
+                MediaType = determinedMediaType,
+                ContentType = file.ContentType ?? GetContentTypeFromExtension(extension),
+                FileName = file.FileName
+            };
 
-                if (file.Length > maxSizeBytes)
-                {
-                    var maxSizeMB = maxSizeBytes / (1024 * 1024);
-                    return OpenAIError(400, $"File size exceeds maximum allowed size of {maxSizeMB}MB for {determinedMediaType}", "invalid_request");
-                }
+            // Upload file using storage service
+            using var stream = file.OpenReadStream();
+            var result = await _storageService.StoreAsync(stream, metadata);
 
-                // Create metadata
-                var metadata = new MediaMetadata
-                {
-                    MediaType = determinedMediaType,
-                    ContentType = file.ContentType ?? GetContentTypeFromExtension(extension),
-                    FileName = file.FileName
-                };
+            Logger.LogInformation("Media uploaded successfully. Type: {MediaType}, Size: {Size} bytes, Key: {StorageKey}",
+                determinedMediaType, file.Length, result.StorageKey);
 
-                // Upload file using storage service
-                using var stream = file.OpenReadStream();
-                var result = await _storageService.StoreAsync(stream, metadata);
-
-                Logger.LogInformation("Media uploaded successfully. Type: {MediaType}, Size: {Size} bytes, Key: {StorageKey}",
-                    determinedMediaType, file.Length, result.StorageKey);
-
-                // Return result with full URL
-                var baseUrl = $"{Request.Scheme}://{Request.Host}";
-                return Ok(new
-                {
-                    success = true,
-                    storageKey = result.StorageKey,
-                    url = result.Url,
-                    directUrl = $"{baseUrl}/v1/media/{result.StorageKey}",
-                    contentType = metadata.ContentType,
-                    mediaType = determinedMediaType.ToString(),
-                    fileName = file.FileName,
-                    sizeBytes = file.Length
-                });
-            },
-            "UploadMedia");
+            // Return result with full URL
+            var baseUrl = $"{Request.Scheme}://{Request.Host}";
+            return Ok(new
+            {
+                success = true,
+                storageKey = result.StorageKey,
+                url = result.Url,
+                directUrl = $"{baseUrl}/v1/media/{result.StorageKey}",
+                contentType = metadata.ContentType,
+                mediaType = determinedMediaType.ToString(),
+                fileName = file.FileName,
+                sizeBytes = file.Length
+            });
         }
 
         /// <summary>
@@ -165,54 +163,49 @@ namespace ConduitLLM.Gateway.Controllers
         /// <returns>The media file.</returns>
         [HttpGet("{**storageKey}")]
         [AllowAnonymous] // Media URLs should work without auth
-        public Task<IActionResult> GetMedia(string storageKey)
+        public async Task<IActionResult> GetMedia(string storageKey)
         {
-            return ExecuteAsync(async () =>
+            // Validate storage key
+            if (string.IsNullOrWhiteSpace(storageKey))
             {
-                // Validate storage key
-                if (string.IsNullOrWhiteSpace(storageKey))
-                {
-                    return OpenAIError(400, "Invalid storage key", "invalid_parameter");
-                }
+                return OpenAIError(400, "Invalid storage key", "invalid_parameter");
+            }
 
-                // Get media info
-                var mediaInfo = await _storageService.GetInfoAsync(storageKey);
-                if (mediaInfo == null)
-                {
-                    return NotFound();
-                }
+            // Get media info
+            var mediaInfo = await _storageService.GetInfoAsync(storageKey);
+            if (mediaInfo == null)
+            {
+                return NotFound();
+            }
 
-                // Check if this is a video and if range is requested
-                if (mediaInfo.MediaType == MediaType.Video && Request.Headers.ContainsKey(HeaderNames.Range))
-                {
-                    return await HandleVideoRangeRequest(storageKey, mediaInfo);
-                }
+            // Check if this is a video and if range is requested
+            if (mediaInfo.MediaType == MediaType.Video && Request.Headers.ContainsKey(HeaderNames.Range))
+            {
+                return await HandleVideoRangeRequest(storageKey, mediaInfo);
+            }
 
-                // Get media stream for non-video or non-range requests
-                var stream = await _storageService.GetStreamAsync(storageKey);
-                if (stream == null)
-                {
-                    return NotFound();
-                }
+            // Get media stream for non-video or non-range requests
+            var stream = await _storageService.GetStreamAsync(storageKey);
+            if (stream == null)
+            {
+                return NotFound();
+            }
 
-                // Set cache headers for performance
-                Response.Headers["Cache-Control"] = "public, max-age=3600"; // 1 hour
-                Response.Headers["ETag"] = $"\"{storageKey}\"";
+            // Set cache headers for performance
+            Response.Headers["Cache-Control"] = "public, max-age=3600"; // 1 hour
+            Response.Headers["ETag"] = $"\"{storageKey}\"";
 
-                // Add CORS headers for video playback
-                if (mediaInfo.MediaType == MediaType.Video)
-                {
-                    Response.Headers["Accept-Ranges"] = "bytes";
-                    Response.Headers["Access-Control-Allow-Origin"] = "*";
-                    Response.Headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS";
-                    Response.Headers["Access-Control-Allow-Headers"] = "Range";
-                }
+            // Add CORS headers for video playback
+            if (mediaInfo.MediaType == MediaType.Video)
+            {
+                Response.Headers["Accept-Ranges"] = "bytes";
+                Response.Headers["Access-Control-Allow-Origin"] = "*";
+                Response.Headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS";
+                Response.Headers["Access-Control-Allow-Headers"] = "Range";
+            }
 
-                // Return file with proper content type
-                return File(stream, mediaInfo.ContentType, enableRangeProcessing: true);
-            },
-            "GetMedia",
-            storageKey);
+            // Return file with proper content type
+            return File(stream, mediaInfo.ContentType, enableRangeProcessing: true);
         }
 
         /// <summary>
@@ -221,20 +214,15 @@ namespace ConduitLLM.Gateway.Controllers
         /// <param name="storageKey">The unique storage key.</param>
         /// <returns>Media metadata.</returns>
         [HttpGet("info/{**storageKey}")]
-        public Task<IActionResult> GetMediaInfo(string storageKey)
+        public async Task<IActionResult> GetMediaInfo(string storageKey)
         {
-            return ExecuteAsync(async () =>
+            var mediaInfo = await _storageService.GetInfoAsync(storageKey);
+            if (mediaInfo == null)
             {
-                var mediaInfo = await _storageService.GetInfoAsync(storageKey);
-                if (mediaInfo == null)
-                {
-                    return NotFound();
-                }
+                return NotFound();
+            }
 
-                return Ok(mediaInfo);
-            },
-            "GetMediaInfo",
-            storageKey);
+            return Ok(mediaInfo);
         }
 
         /// <summary>
@@ -244,27 +232,22 @@ namespace ConduitLLM.Gateway.Controllers
         /// <returns>True if the media exists.</returns>
         [HttpHead("{**storageKey}")]
         [AllowAnonymous]
-        public Task<IActionResult> CheckMediaExists(string storageKey)
+        public async Task<IActionResult> CheckMediaExists(string storageKey)
         {
-            return ExecuteAsync(async () =>
+            var exists = await _storageService.ExistsAsync(storageKey);
+            if (!exists)
             {
-                var exists = await _storageService.ExistsAsync(storageKey);
-                if (!exists)
-                {
-                    return NotFound();
-                }
+                return NotFound();
+            }
 
-                var mediaInfo = await _storageService.GetInfoAsync(storageKey);
-                if (mediaInfo != null)
-                {
-                    Response.Headers["Content-Type"] = mediaInfo.ContentType;
-                    Response.Headers["Content-Length"] = mediaInfo.SizeBytes.ToString();
-                }
+            var mediaInfo = await _storageService.GetInfoAsync(storageKey);
+            if (mediaInfo != null)
+            {
+                Response.Headers["Content-Type"] = mediaInfo.ContentType;
+                Response.Headers["Content-Length"] = mediaInfo.SizeBytes.ToString();
+            }
 
-                return Ok();
-            },
-            "CheckMediaExists",
-            storageKey);
+            return Ok();
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Gateway/Controllers/ModelsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/ModelsController.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Gateway.Filters;
 using ConduitLLM.Gateway.Services;
 
 using Microsoft.AspNetCore.Authorization;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Gateway.Controllers
     [Route("v1")]
     [Authorize(Policy = "VirtualKeyAuthentication")]
     [Tags("Models")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ModelsController : GatewayControllerBase
     {
         private readonly IModelMetadataService _metadataService;
@@ -41,53 +43,48 @@ namespace ConduitLLM.Gateway.Controllers
         [HttpGet("models")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ListModels(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> ListModels(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            Logger.LogInformation("Getting available models");
+
+            // Get model mappings using paginated repository method
+            // Use max page size; most deployments have <100 model mappings
+            var allMappings = new List<Configuration.Entities.ModelProviderMapping>();
+            var pageNumber = 1;
+            const int pageSize = 100;
+
+            // Fetch all pages to maintain OpenAI API compatibility (no pagination in response)
+            while (true)
+            {
+                var (mappings, totalCount) = await _modelMappingRepository.GetPaginatedAsync(pageNumber, pageSize, cancellationToken);
+                allMappings.AddRange(mappings);
+
+                if (allMappings.Count >= totalCount || mappings.Count == 0)
+                    break;
+
+                pageNumber++;
+            }
+
+            // Convert to OpenAI format using model aliases
+            var basicModelData = allMappings
+                .Select(m => m.ModelAlias)
+                .Distinct()
+                .Select(alias => new
                 {
-                    Logger.LogInformation("Getting available models");
+                    id = alias,
+                    @object = "model"
+                }).ToList();
 
-                    // Get model mappings using paginated repository method
-                    // Use max page size; most deployments have <100 model mappings
-                    var allMappings = new List<Configuration.Entities.ModelProviderMapping>();
-                    var pageNumber = 1;
-                    const int pageSize = 100;
+            Logger.LogDebug("Returning {ModelCount} available models", basicModelData.Count);
 
-                    // Fetch all pages to maintain OpenAI API compatibility (no pagination in response)
-                    while (true)
-                    {
-                        var (mappings, totalCount) = await _modelMappingRepository.GetPaginatedAsync(pageNumber, pageSize, cancellationToken);
-                        allMappings.AddRange(mappings);
+            // Create the response envelope
+            var response = new
+            {
+                data = basicModelData,
+                @object = "list"
+            };
 
-                        if (allMappings.Count >= totalCount || mappings.Count == 0)
-                            break;
-
-                        pageNumber++;
-                    }
-
-                    // Convert to OpenAI format using model aliases
-                    var basicModelData = allMappings
-                        .Select(m => m.ModelAlias)
-                        .Distinct()
-                        .Select(alias => new
-                        {
-                            id = alias,
-                            @object = "model"
-                        }).ToList();
-
-                    Logger.LogDebug("Returning {ModelCount} available models", basicModelData.Count);
-
-                    // Create the response envelope
-                    var response = new
-                    {
-                        data = basicModelData,
-                        @object = "list"
-                    };
-
-                    return Ok(response);
-                },
-                "ListModels");
+            return Ok(response);
         }
 
         /// <summary>
@@ -99,38 +96,32 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelMetadata(string modelId)
+        public async Task<IActionResult> GetModelMetadata(string modelId)
         {
-            return ExecuteAsync(
-                async () =>
+            Logger.LogInformation("Getting metadata for model {ModelId}", modelId);
+
+            var metadata = await _metadataService.GetModelMetadataAsync(modelId);
+
+            if (metadata == null)
+            {
+                return NotFound(new OpenAIErrorResponse
                 {
-                    Logger.LogInformation("Getting metadata for model {ModelId}", modelId);
-
-                    var metadata = await _metadataService.GetModelMetadataAsync(modelId);
-
-                    if (metadata == null)
+                    Error = new OpenAIError
                     {
-                        return NotFound(new OpenAIErrorResponse
-                        {
-                            Error = new OpenAIError
-                            {
-                                Message = $"No metadata found for model '{modelId}'",
-                                Type = "invalid_request_error",
-                                Code = "model_not_found"
-                            }
-                        });
+                        Message = $"No metadata found for model '{modelId}'",
+                        Type = "invalid_request_error",
+                        Code = "model_not_found"
                     }
+                });
+            }
 
-                    var response = new
-                    {
-                        modelId = modelId,
-                        metadata = metadata
-                    };
+            var response = new
+            {
+                modelId = modelId,
+                metadata = metadata
+            };
 
-                    return Ok(response);
-                },
-                "GetModelMetadata",
-                modelId);
+            return Ok(response);
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Controllers/ProviderModelsController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/ProviderModelsController.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Configuration;
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Gateway.Filters;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -12,6 +13,7 @@ namespace ConduitLLM.Gateway.Controllers
     /// </summary>
     [ApiController]
     [Route("api/provider-models")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ProviderModelsController : GatewayControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -39,122 +41,119 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(OpenAIErrorResponse), 404)]
         public async Task<IActionResult> GetProviderModels(int providerId)
         {
-            return await ExecuteAsync(async () =>
+            Logger.LogInformation("Getting compatible models for provider {ProviderId}", providerId);
+
+            await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
+
+            // Get the provider to determine its type
+            var provider = await dbContext.Providers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Id == providerId);
+
+            if (provider == null)
             {
-                Logger.LogInformation("Getting compatible models for provider {ProviderId}", providerId);
-
-                await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
-
-                // Get the provider to determine its type
-                var provider = await dbContext.Providers
-                    .AsNoTracking()
-                    .FirstOrDefaultAsync(p => p.Id == providerId);
-
-                if (provider == null)
+                Logger.LogWarning("Provider with ID {ProviderId} not found", providerId);
+                return NotFound(new OpenAIErrorResponse
                 {
-                    Logger.LogWarning("Provider with ID {ProviderId} not found", providerId);
-                    return NotFound(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = $"Provider with ID {providerId} not found",
-                            Type = "not_found_error",
-                            Code = "not_found"
-                        }
-                    });
-                }
-
-                // Get all models that have the appropriate capabilities for this provider type
-                // For now, we'll return model identifiers that are commonly used with this provider type
-                var query = dbContext.Models
-                    .Include(m => m.Identifiers)
-                    .Where(m => m.IsActive);
-
-                // Filter models based on provider type capabilities
-                switch (provider.ProviderType)
-                {
-                    case ProviderType.OpenAI:
-                    case ProviderType.OpenAICompatible:
-                        query = query.Where(m => m.SupportsChat ||
-                                                 m.SupportsImageGeneration ||
-                                                 m.SupportsEmbeddings);
-                        break;
-
-                    case ProviderType.Replicate:
-                        // Replicate supports various model types including video
-                        query = query.Where(m => m.SupportsImageGeneration ||
-                                                 m.SupportsVideoGeneration ||
-                                                 m.SupportsChat);
-                        break;
-
-
-                    case ProviderType.Groq:
-                    case ProviderType.Cerebras:
-                    case ProviderType.SambaNova:
-                    case ProviderType.Fireworks:
-                        // Fast inference providers typically support chat models
-                        query = query.Where(m => m.SupportsChat);
-                        break;
-
-                    default:
-                        // For other providers, return all active models
-                        break;
-                }
-
-                var models = await query
-                    .AsNoTracking()
-                    .ToListAsync();
-
-                // Get the model identifiers that are most commonly used
-                // Prefer identifiers that match the provider type if available
-                var modelIdentifiers = new List<string>();
-
-                // Map provider type to enum for comparison
-                var providerType = provider.ProviderType;
-
-                foreach (var model in models)
-                {
-                    // First, check if there's a provider-specific identifier
-                    var providerSpecificId = model.Identifiers
-                        .FirstOrDefault(i => i.Provider.HasValue &&
-                                           i.Provider.Value == providerType);
-
-                    if (providerSpecificId != null)
-                    {
-                        modelIdentifiers.Add(providerSpecificId.Identifier);
+                        Message = $"Provider with ID {providerId} not found",
+                        Type = "not_found_error",
+                        Code = "not_found"
                     }
-                    else if (model.Identifiers.Any())
+                });
+            }
+
+            // Get all models that have the appropriate capabilities for this provider type
+            // For now, we'll return model identifiers that are commonly used with this provider type
+            var query = dbContext.Models
+                .Include(m => m.Identifiers)
+                .Where(m => m.IsActive);
+
+            // Filter models based on provider type capabilities
+            switch (provider.ProviderType)
+            {
+                case ProviderType.OpenAI:
+                case ProviderType.OpenAICompatible:
+                    query = query.Where(m => m.SupportsChat ||
+                                             m.SupportsImageGeneration ||
+                                             m.SupportsEmbeddings);
+                    break;
+
+                case ProviderType.Replicate:
+                    // Replicate supports various model types including video
+                    query = query.Where(m => m.SupportsImageGeneration ||
+                                             m.SupportsVideoGeneration ||
+                                             m.SupportsChat);
+                    break;
+
+
+                case ProviderType.Groq:
+                case ProviderType.Cerebras:
+                case ProviderType.SambaNova:
+                case ProviderType.Fireworks:
+                    // Fast inference providers typically support chat models
+                    query = query.Where(m => m.SupportsChat);
+                    break;
+
+                default:
+                    // For other providers, return all active models
+                    break;
+            }
+
+            var models = await query
+                .AsNoTracking()
+                .ToListAsync();
+
+            // Get the model identifiers that are most commonly used
+            // Prefer identifiers that match the provider type if available
+            var modelIdentifiers = new List<string>();
+
+            // Map provider type to enum for comparison
+            var providerType = provider.ProviderType;
+
+            foreach (var model in models)
+            {
+                // First, check if there's a provider-specific identifier
+                var providerSpecificId = model.Identifiers
+                    .FirstOrDefault(i => i.Provider.HasValue &&
+                                       i.Provider.Value == providerType);
+
+                if (providerSpecificId != null)
+                {
+                    modelIdentifiers.Add(providerSpecificId.Identifier);
+                }
+                else if (model.Identifiers.Any())
+                {
+                    // Prefer primary identifier if available
+                    var primaryId = model.Identifiers.FirstOrDefault(i => i.IsPrimary);
+                    if (primaryId != null)
                     {
-                        // Prefer primary identifier if available
-                        var primaryId = model.Identifiers.FirstOrDefault(i => i.IsPrimary);
-                        if (primaryId != null)
-                        {
-                            modelIdentifiers.Add(primaryId.Identifier);
-                        }
-                        else
-                        {
-                            // Use the first available identifier
-                            modelIdentifiers.Add(model.Identifiers.First().Identifier);
-                        }
+                        modelIdentifiers.Add(primaryId.Identifier);
                     }
                     else
                     {
-                        // Fall back to the model name
-                        modelIdentifiers.Add(model.Name.ToLowerInvariant().Replace(" ", "-"));
+                        // Use the first available identifier
+                        modelIdentifiers.Add(model.Identifiers.First().Identifier);
                     }
                 }
+                else
+                {
+                    // Fall back to the model name
+                    modelIdentifiers.Add(model.Name.ToLowerInvariant().Replace(" ", "-"));
+                }
+            }
 
-                // Sort alphabetically for better UX
-                var sortedIdentifiers = modelIdentifiers
-                    .Distinct()
-                    .OrderBy(m => m, StringComparer.OrdinalIgnoreCase)
-                    .ToList();
+            // Sort alphabetically for better UX
+            var sortedIdentifiers = modelIdentifiers
+                .Distinct()
+                .OrderBy(m => m, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
-                Logger.LogInformation("Found {ModelsCount} compatible models for provider {ProviderId} (type: {ProviderType})",
-                    sortedIdentifiers.Count, providerId, provider.ProviderType);
+            Logger.LogInformation("Found {ModelsCount} compatible models for provider {ProviderId} (type: {ProviderType})",
+                sortedIdentifiers.Count, providerId, provider.ProviderType);
 
-                return Ok(sortedIdentifiers);
-            }, "GetProviderModels", providerId);
+            return Ok(sortedIdentifiers);
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Controllers/TasksController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/TasksController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Gateway.Filters;
 using Microsoft.AspNetCore.Authorization;
 
 namespace ConduitLLM.Gateway.Controllers
@@ -12,6 +13,7 @@ namespace ConduitLLM.Gateway.Controllers
     [ApiController]
     [Route("v1/tasks")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class TasksController : GatewayControllerBase
     {
         private readonly IAsyncTaskService _taskService;
@@ -35,27 +37,24 @@ namespace ConduitLLM.Gateway.Controllers
         [HttpGet("{taskId}")]
         public async Task<IActionResult> GetTaskStatus(string taskId)
         {
-            return await ExecuteAsync(async () =>
+            Logger.LogDebug("Getting status for task {TaskId}", taskId);
+            try
             {
-                Logger.LogDebug("Getting status for task {TaskId}", taskId);
-                try
+                var status = await _taskService.GetTaskStatusAsync(taskId);
+                return Ok(status);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return NotFound(new OpenAIErrorResponse
                 {
-                    var status = await _taskService.GetTaskStatusAsync(taskId);
-                    return Ok(status);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    return NotFound(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = ex.Message,
-                            Type = "not_found_error",
-                            Code = "not_found"
-                        }
-                    });
-                }
-            }, "GetTaskStatus", taskId);
+                        Message = ex.Message,
+                        Type = "not_found_error",
+                        Code = "not_found"
+                    }
+                });
+            }
         }
 
         /// <summary>
@@ -66,27 +65,24 @@ namespace ConduitLLM.Gateway.Controllers
         [HttpPost("{taskId}/cancel")]
         public async Task<IActionResult> CancelTask(string taskId)
         {
-            return await ExecuteAsync(async () =>
+            try
             {
-                try
+                await _taskService.CancelTaskAsync(taskId);
+                Logger.LogInformation("Task {TaskId} cancelled successfully", taskId);
+                return NoContent();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return NotFound(new OpenAIErrorResponse
                 {
-                    await _taskService.CancelTaskAsync(taskId);
-                    Logger.LogInformation("Task {TaskId} cancelled successfully", taskId);
-                    return NoContent();
-                }
-                catch (InvalidOperationException ex)
-                {
-                    return NotFound(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = ex.Message,
-                            Type = "not_found_error",
-                            Code = "not_found"
-                        }
-                    });
-                }
-            }, "CancelTask", taskId);
+                        Message = ex.Message,
+                        Type = "not_found_error",
+                        Code = "not_found"
+                    }
+                });
+            }
         }
 
         /// <summary>
@@ -99,49 +95,46 @@ namespace ConduitLLM.Gateway.Controllers
         [HttpGet("{taskId}/poll")]
         public async Task<IActionResult> PollTask(string taskId, [FromQuery] int timeout = 300, [FromQuery] int interval = 2)
         {
-            return await ExecuteAsync(async () =>
+            // Validate and clamp parameters
+            timeout = Math.Clamp(timeout, 1, 600); // Max 10 minutes
+            interval = Math.Max(interval, 1); // Min 1 second
+
+            Logger.LogDebug("Polling task {TaskId} with timeout {TimeoutSeconds}s, interval {IntervalSeconds}s",
+                taskId, timeout, interval);
+
+            try
             {
-                // Validate and clamp parameters
-                timeout = Math.Clamp(timeout, 1, 600); // Max 10 minutes
-                interval = Math.Max(interval, 1); // Min 1 second
+                var status = await _taskService.PollTaskUntilCompletedAsync(
+                    taskId,
+                    TimeSpan.FromSeconds(interval),
+                    TimeSpan.FromSeconds(timeout));
 
-                Logger.LogDebug("Polling task {TaskId} with timeout {TimeoutSeconds}s, interval {IntervalSeconds}s",
-                    taskId, timeout, interval);
-
-                try
+                return Ok(status);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return NotFound(new OpenAIErrorResponse
                 {
-                    var status = await _taskService.PollTaskUntilCompletedAsync(
-                        taskId,
-                        TimeSpan.FromSeconds(interval),
-                        TimeSpan.FromSeconds(timeout));
-
-                    return Ok(status);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    return NotFound(new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = ex.Message,
-                            Type = "not_found_error",
-                            Code = "not_found"
-                        }
-                    });
-                }
-                catch (OperationCanceledException)
+                        Message = ex.Message,
+                        Type = "not_found_error",
+                        Code = "not_found"
+                    }
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(408, new OpenAIErrorResponse
                 {
-                    return StatusCode(408, new OpenAIErrorResponse
+                    Error = new OpenAIError
                     {
-                        Error = new OpenAIError
-                        {
-                            Message = "Task polling timed out",
-                            Type = "timeout",
-                            Code = "timeout"
-                        }
-                    });
-                }
-            }, "PollTask", taskId);
+                        Message = "Task polling timed out",
+                        Type = "timeout",
+                        Code = "timeout"
+                    }
+                });
+            }
         }
 
     }

--- a/Services/ConduitLLM.Gateway/Controllers/VideosController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/VideosController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using MassTransit;
 using ConduitLLM.Gateway.Authorization;
 using ConduitLLM.Gateway.Constants;
+using ConduitLLM.Gateway.Filters;
 using ConduitLLM.Gateway.UsageTracking;
 using ConduitLLM.Core.Controllers;
 using ConduitLLM.Core.Events;
@@ -22,6 +23,7 @@ namespace ConduitLLM.Gateway.Controllers
     [Authorize(AuthenticationSchemes = "VirtualKey")]
     [RequireBalance]
     [Tags("Videos")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class VideosController : GatewayControllerBase
     {
         private readonly IAsyncTaskService _taskService;
@@ -57,128 +59,123 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(OpenAIErrorResponse), 403)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 429)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 500)]
-        public Task<IActionResult> GenerateVideoAsync(
+        public async Task<IActionResult> GenerateVideoAsync(
             [FromBody][Required] VideoGenerationRequest request,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(async () =>
+            var virtualKey = CurrentVirtualKey;
+            if (string.IsNullOrEmpty(virtualKey) || CurrentVirtualKeyId == null)
             {
-                var virtualKey = CurrentVirtualKey;
-                if (string.IsNullOrEmpty(virtualKey) || CurrentVirtualKeyId == null)
-                {
-                    return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
-                }
-                var virtualKeyId = CurrentVirtualKeyId.Value;
+                return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
+            }
+            var virtualKeyId = CurrentVirtualKeyId.Value;
 
-                // Validate the request
-                if (string.IsNullOrWhiteSpace(request.Prompt))
-                {
-                    return OpenAIError(400, "Prompt is required", "missing_parameter");
-                }
-                if (string.IsNullOrWhiteSpace(request.Model))
-                {
-                    return OpenAIError(400, "Model is required", "missing_parameter");
-                }
-                if (request.Duration.HasValue && (request.Duration.Value < 1 || request.Duration.Value > 60))
-                {
-                    return OpenAIError(400, "Duration must be between 1 and 60 seconds", "invalid_value");
-                }
-                if (request.Fps.HasValue && (request.Fps.Value < 1 || request.Fps.Value > 120))
-                {
-                    return OpenAIError(400, "FPS must be between 1 and 120", "invalid_value");
-                }
+            // Validate the request
+            if (string.IsNullOrWhiteSpace(request.Prompt))
+            {
+                return OpenAIError(400, "Prompt is required", "missing_parameter");
+            }
+            if (string.IsNullOrWhiteSpace(request.Model))
+            {
+                return OpenAIError(400, "Model is required", "missing_parameter");
+            }
+            if (request.Duration.HasValue && (request.Duration.Value < 1 || request.Duration.Value > 60))
+            {
+                return OpenAIError(400, "Duration must be between 1 and 60 seconds", "invalid_value");
+            }
+            if (request.Fps.HasValue && (request.Fps.Value < 1 || request.Fps.Value > 120))
+            {
+                return OpenAIError(400, "FPS must be between 1 and 120", "invalid_value");
+            }
 
-                // Store video request parameters for usage tracking and pricing
-                StoreVideoRequestParameters(request);
+            // Store video request parameters for usage tracking and pricing
+            StoreVideoRequestParameters(request);
 
-                // Get provider info for usage tracking
-                try
+            // Get provider info for usage tracking
+            try
+            {
+                var modelMapping = await _modelMappingService.GetMappingByModelAliasAsync(request.Model);
+                if (modelMapping != null)
                 {
-                    var modelMapping = await _modelMappingService.GetMappingByModelAliasAsync(request.Model);
-                    if (modelMapping != null)
+                    HttpContext.Items["ProviderId"] = modelMapping.ProviderId;
+                    HttpContext.Items["ProviderType"] = modelMapping.Provider?.ProviderType;
+
+                    // Store ModelCostId for direct cost lookup (preferred over string matching)
+                    if (modelMapping.ModelProviderTypeAssociation?.ModelCostId != null)
                     {
-                        HttpContext.Items["ProviderId"] = modelMapping.ProviderId;
-                        HttpContext.Items["ProviderType"] = modelMapping.Provider?.ProviderType;
-
-                        // Store ModelCostId for direct cost lookup (preferred over string matching)
-                        if (modelMapping.ModelProviderTypeAssociation?.ModelCostId != null)
-                        {
-                            HttpContext.Items[HttpContextKeys.ModelCostId] = modelMapping.ModelProviderTypeAssociation.ModelCostId;
-                        }
+                        HttpContext.Items[HttpContextKeys.ModelCostId] = modelMapping.ModelProviderTypeAssociation.ModelCostId;
                     }
                 }
-                catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to get provider info for model {Model}", request.Model);
+            }
+
+            // Create a linked cancellation token that can be controlled independently
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            // Build task metadata. The orchestrator reads ExtensionData["VirtualKey"] for re-validation
+            // and ExtensionData["Request"] to reconstruct the original request when consuming the event.
+            var taskMetadata = new TaskMetadata(virtualKeyId)
+            {
+                Model = request.Model,
+                Prompt = request.Prompt,
+                ExtensionData = new Dictionary<string, object>
                 {
-                    Logger.LogWarning(ex, "Failed to get provider info for model {Model}", request.Model);
+                    ["VirtualKey"] = virtualKey,
+                    ["Request"] = request
                 }
+            };
 
-                // Create a linked cancellation token that can be controlled independently
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var taskId = await _taskService.CreateTaskAsync("video_generation", virtualKeyId, taskMetadata, cts.Token);
 
-                // Build task metadata. The orchestrator reads ExtensionData["VirtualKey"] for re-validation
-                // and ExtensionData["Request"] to reconstruct the original request when consuming the event.
-                var taskMetadata = new TaskMetadata(virtualKeyId)
+            // Register the task for cancellation
+            _taskRegistry.RegisterTask(taskId, cts);
+
+            // Convert ExtensionData to provider options for the event payload
+            Dictionary<string, object>? providerOptions = null;
+            if (request.ExtensionData != null && request.ExtensionData.Count > 0)
+            {
+                providerOptions = new Dictionary<string, object>();
+                foreach (var kvp in request.ExtensionData)
                 {
-                    Model = request.Model,
-                    Prompt = request.Prompt,
-                    ExtensionData = new Dictionary<string, object>
-                    {
-                        ["VirtualKey"] = virtualKey,
-                        ["Request"] = request
-                    }
-                };
-
-                var taskId = await _taskService.CreateTaskAsync("video_generation", virtualKeyId, taskMetadata, cts.Token);
-
-                // Register the task for cancellation
-                _taskRegistry.RegisterTask(taskId, cts);
-
-                // Convert ExtensionData to provider options for the event payload
-                Dictionary<string, object>? providerOptions = null;
-                if (request.ExtensionData != null && request.ExtensionData.Count > 0)
-                {
-                    providerOptions = new Dictionary<string, object>();
-                    foreach (var kvp in request.ExtensionData)
-                    {
-                        providerOptions[kvp.Key] = kvp.Value.ToString();
-                    }
+                    providerOptions[kvp.Key] = kvp.Value.ToString();
                 }
+            }
 
-                PublishEventFireAndForget(new VideoGenerationRequested
+            PublishEventFireAndForget(new VideoGenerationRequested
+            {
+                RequestId = taskId,
+                Model = request.Model,
+                Prompt = request.Prompt,
+                VirtualKeyId = virtualKeyId.ToString(),
+                IsAsync = true,
+                RequestedAt = DateTime.UtcNow,
+                CorrelationId = taskId,
+                WebhookUrl = request.WebhookUrl,
+                WebhookHeaders = request.WebhookHeaders,
+                Parameters = new VideoGenerationParameters
                 {
-                    RequestId = taskId,
-                    Model = request.Model,
-                    Prompt = request.Prompt,
-                    VirtualKeyId = virtualKeyId.ToString(),
-                    IsAsync = true,
-                    RequestedAt = DateTime.UtcNow,
-                    CorrelationId = taskId,
-                    WebhookUrl = request.WebhookUrl,
-                    WebhookHeaders = request.WebhookHeaders,
-                    Parameters = new VideoGenerationParameters
-                    {
-                        Size = request.Size,
-                        Duration = request.Duration,
-                        Fps = request.Fps,
-                        Style = request.Style,
-                        ResponseFormat = request.ResponseFormat,
-                        ProviderOptions = providerOptions
-                    }
-                }, "create async video generation", new { TaskId = taskId, Model = request.Model });
+                    Size = request.Size,
+                    Duration = request.Duration,
+                    Fps = request.Fps,
+                    Style = request.Style,
+                    ResponseFormat = request.ResponseFormat,
+                    ProviderOptions = providerOptions
+                }
+            }, "create async video generation", new { TaskId = taskId, Model = request.Model });
 
-                var taskResponse = new VideoGenerationTaskResponse
-                {
-                    TaskId = taskId,
-                    Status = TaskStateConstants.Pending,
-                    CreatedAt = DateTimeOffset.UtcNow,
-                    EstimatedCompletionTime = DateTimeOffset.UtcNow.AddSeconds(60),
-                    CheckStatusUrl = $"/v1/videos/generations/tasks/{taskId}"
-                };
+            var taskResponse = new VideoGenerationTaskResponse
+            {
+                TaskId = taskId,
+                Status = TaskStateConstants.Pending,
+                CreatedAt = DateTimeOffset.UtcNow,
+                EstimatedCompletionTime = DateTimeOffset.UtcNow.AddSeconds(60),
+                CheckStatusUrl = $"/v1/videos/generations/tasks/{taskId}"
+            };
 
-                return Accepted(taskResponse);
-            },
-            "GenerateVideoAsync",
-            request.Model);
+            return Accepted(taskResponse);
         }
 
         /// <summary>
@@ -189,56 +186,51 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(OpenAIErrorResponse), 401)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 404)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 500)]
-        public Task<IActionResult> GetTaskStatus(
+        public async Task<IActionResult> GetTaskStatus(
             [FromRoute][Required] string taskId,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(async () =>
+            if (CurrentVirtualKeyId == null)
             {
-                if (CurrentVirtualKeyId == null)
-                {
-                    return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
-                }
-                var virtualKeyId = CurrentVirtualKeyId.Value;
+                return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
+            }
+            var virtualKeyId = CurrentVirtualKeyId.Value;
 
-                var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
-                if (taskStatus == null)
-                {
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
+            if (taskStatus == null)
+            {
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Validate task ownership for security
-                if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
-                {
-                    // Return 404 instead of 403 to prevent information disclosure
-                    Logger.LogWarning("Virtual key {VirtualKeyId} attempted to access task {TaskId} owned by {OwnerKeyId}",
-                        virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            // Validate task ownership for security
+            if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
+            {
+                // Return 404 instead of 403 to prevent information disclosure
+                Logger.LogWarning("Virtual key {VirtualKeyId} attempted to access task {TaskId} owned by {OwnerKeyId}",
+                    virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Map internal task status to API response
-                var response = new VideoGenerationTaskStatus
-                {
-                    TaskId = taskId,
-                    Status = TaskStateConstants.FromTaskState(taskStatus.State),
-                    Progress = taskStatus.Progress,
-                    CreatedAt = taskStatus.CreatedAt,
-                    UpdatedAt = taskStatus.UpdatedAt,
-                    CompletedAt = taskStatus.CompletedAt,
-                    Error = taskStatus.Error,
-                    ResultRaw = taskStatus.Result?.ToString()
-                };
+            // Map internal task status to API response
+            var response = new VideoGenerationTaskStatus
+            {
+                TaskId = taskId,
+                Status = TaskStateConstants.FromTaskState(taskStatus.State),
+                Progress = taskStatus.Progress,
+                CreatedAt = taskStatus.CreatedAt,
+                UpdatedAt = taskStatus.UpdatedAt,
+                CompletedAt = taskStatus.CompletedAt,
+                Error = taskStatus.Error,
+                ResultRaw = taskStatus.Result?.ToString()
+            };
 
-                // If completed, deserialize the stored result into a typed VideoGenerationResponse.
-                if (taskStatus.State == TaskState.Completed && taskStatus.Result != null)
-                {
-                    response.Result = DeserializeVideoResult(taskStatus.Result, taskId);
-                }
+            // If completed, deserialize the stored result into a typed VideoGenerationResponse.
+            if (taskStatus.State == TaskState.Completed && taskStatus.Result != null)
+            {
+                response.Result = DeserializeVideoResult(taskStatus.Result, taskId);
+            }
 
-                return Ok(response);
-            },
-            "GetTaskStatus",
-            taskId);
+            return Ok(response);
         }
 
         /// <summary>
@@ -250,74 +242,69 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(OpenAIErrorResponse), 401)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 404)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 500)]
-        public Task<IActionResult> RetryTask(
+        public async Task<IActionResult> RetryTask(
             [FromRoute][Required] string taskId,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(async () =>
+            if (CurrentVirtualKeyId == null)
             {
-                if (CurrentVirtualKeyId == null)
-                {
-                    return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
-                }
-                var virtualKeyId = CurrentVirtualKeyId.Value;
+                return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
+            }
+            var virtualKeyId = CurrentVirtualKeyId.Value;
 
-                var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
-                if (taskStatus == null)
-                {
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
+            if (taskStatus == null)
+            {
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Validate task ownership for security
-                if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
-                {
-                    Logger.LogWarning("Virtual key {VirtualKeyId} attempted to retry task {TaskId} owned by {OwnerKeyId}",
-                        virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            // Validate task ownership for security
+            if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
+            {
+                Logger.LogWarning("Virtual key {VirtualKeyId} attempted to retry task {TaskId} owned by {OwnerKeyId}",
+                    virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Validate task can be retried
-                if (taskStatus.State != TaskState.Failed)
-                {
-                    return OpenAIError(400, $"Only failed tasks can be retried. Current state: {taskStatus.State}", "invalid_operation");
-                }
+            // Validate task can be retried
+            if (taskStatus.State != TaskState.Failed)
+            {
+                return OpenAIError(400, $"Only failed tasks can be retried. Current state: {taskStatus.State}", "invalid_operation");
+            }
 
-                if (!taskStatus.IsRetryable)
-                {
-                    return OpenAIError(400, "This task has been marked as non-retryable", "invalid_operation");
-                }
+            if (!taskStatus.IsRetryable)
+            {
+                return OpenAIError(400, "This task has been marked as non-retryable", "invalid_operation");
+            }
 
-                if (taskStatus.RetryCount >= taskStatus.MaxRetries)
-                {
-                    return OpenAIError(400, $"Task has already been retried {taskStatus.RetryCount} times (max: {taskStatus.MaxRetries})", "invalid_operation");
-                }
+            if (taskStatus.RetryCount >= taskStatus.MaxRetries)
+            {
+                return OpenAIError(400, $"Task has already been retried {taskStatus.RetryCount} times (max: {taskStatus.MaxRetries})", "invalid_operation");
+            }
 
-                // Reset task for retry
-                await _taskService.UpdateTaskStatusAsync(
-                    taskId,
-                    TaskState.Pending,
-                    error: $"Manual retry requested (attempt {taskStatus.RetryCount + 1}/{taskStatus.MaxRetries})",
-                    cancellationToken: cancellationToken);
+            // Reset task for retry
+            await _taskService.UpdateTaskStatusAsync(
+                taskId,
+                TaskState.Pending,
+                error: $"Manual retry requested (attempt {taskStatus.RetryCount + 1}/{taskStatus.MaxRetries})",
+                cancellationToken: cancellationToken);
 
-                Logger.LogInformation("Manual retry requested for task {TaskId} by virtual key {VirtualKeyId}",
-                    taskId, virtualKeyId);
+            Logger.LogInformation("Manual retry requested for task {TaskId} by virtual key {VirtualKeyId}",
+                taskId, virtualKeyId);
 
-                // Return updated status
-                var updatedStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
-                var response = new VideoGenerationTaskStatus
-                {
-                    TaskId = taskId,
-                    Status = updatedStatus != null ? TaskStateConstants.FromTaskState(updatedStatus.State) : TaskStateConstants.Pending,
-                    Progress = updatedStatus?.Progress ?? 0,
-                    CreatedAt = updatedStatus?.CreatedAt ?? DateTimeOffset.UtcNow,
-                    UpdatedAt = updatedStatus?.UpdatedAt ?? DateTimeOffset.UtcNow,
-                    Error = $"Retry {updatedStatus?.RetryCount ?? 0}/{updatedStatus?.MaxRetries ?? 3} scheduled"
-                };
+            // Return updated status
+            var updatedStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
+            var response = new VideoGenerationTaskStatus
+            {
+                TaskId = taskId,
+                Status = updatedStatus != null ? TaskStateConstants.FromTaskState(updatedStatus.State) : TaskStateConstants.Pending,
+                Progress = updatedStatus?.Progress ?? 0,
+                CreatedAt = updatedStatus?.CreatedAt ?? DateTimeOffset.UtcNow,
+                UpdatedAt = updatedStatus?.UpdatedAt ?? DateTimeOffset.UtcNow,
+                Error = $"Retry {updatedStatus?.RetryCount ?? 0}/{updatedStatus?.MaxRetries ?? 3} scheduled"
+            };
 
-                return Ok(response);
-            },
-            "RetryTask",
-            taskId);
+            return Ok(response);
         }
 
         /// <summary>
@@ -329,60 +316,55 @@ namespace ConduitLLM.Gateway.Controllers
         [ProducesResponseType(typeof(OpenAIErrorResponse), 404)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 409)]
         [ProducesResponseType(typeof(OpenAIErrorResponse), 500)]
-        public Task<IActionResult> CancelTask(
+        public async Task<IActionResult> CancelTask(
             [FromRoute][Required] string taskId,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(async () =>
+            if (CurrentVirtualKeyId == null)
             {
-                if (CurrentVirtualKeyId == null)
-                {
-                    return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
-                }
-                var virtualKeyId = CurrentVirtualKeyId.Value;
+                return OpenAIError(401, "Virtual key not found in request context", "unauthorized");
+            }
+            var virtualKeyId = CurrentVirtualKeyId.Value;
 
-                var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
-                if (taskStatus == null)
-                {
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            var taskStatus = await _taskService.GetTaskStatusAsync(taskId, cancellationToken);
+            if (taskStatus == null)
+            {
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Validate task ownership for security
-                if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
-                {
-                    Logger.LogWarning("Virtual key {VirtualKeyId} attempted to cancel task {TaskId} owned by {OwnerKeyId}",
-                        virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
-                    return OpenAIError(404, "The requested task was not found", "not_found");
-                }
+            // Validate task ownership for security
+            if (taskStatus.Metadata?.VirtualKeyId != virtualKeyId)
+            {
+                Logger.LogWarning("Virtual key {VirtualKeyId} attempted to cancel task {TaskId} owned by {OwnerKeyId}",
+                    virtualKeyId, taskId, taskStatus.Metadata?.VirtualKeyId);
+                return OpenAIError(404, "The requested task was not found", "not_found");
+            }
 
-                // Check if task can be cancelled
-                if (taskStatus.State == TaskState.Completed || taskStatus.State == TaskState.Failed)
-                {
-                    return OpenAIError(409, $"Task is already {taskStatus.State.ToString().ToLowerInvariant()} and cannot be cancelled", "invalid_operation");
-                }
+            // Check if task can be cancelled
+            if (taskStatus.State == TaskState.Completed || taskStatus.State == TaskState.Failed)
+            {
+                return OpenAIError(409, $"Task is already {taskStatus.State.ToString().ToLowerInvariant()} and cannot be cancelled", "invalid_operation");
+            }
 
-                // Try to cancel via the registry first (signals any in-flight provider call)
-                var registryCancelled = _taskRegistry.TryCancel(taskId);
-                if (registryCancelled)
-                {
-                    Logger.LogInformation("Cancelled task {TaskId} via registry", taskId);
-                }
+            // Try to cancel via the registry first (signals any in-flight provider call)
+            var registryCancelled = _taskRegistry.TryCancel(taskId);
+            if (registryCancelled)
+            {
+                Logger.LogInformation("Cancelled task {TaskId} via registry", taskId);
+            }
 
-                // Mark the task as cancelled and notify consumers via event
-                await _taskService.CancelTaskAsync(taskId, cancellationToken);
+            // Mark the task as cancelled and notify consumers via event
+            await _taskService.CancelTaskAsync(taskId, cancellationToken);
 
-                PublishEventFireAndForget(new VideoGenerationCancelled
-                {
-                    RequestId = taskId,
-                    CancelledAt = DateTime.UtcNow,
-                    CorrelationId = taskId,
-                    Reason = "User requested cancellation"
-                }, "cancel video generation", new { TaskId = taskId });
+            PublishEventFireAndForget(new VideoGenerationCancelled
+            {
+                RequestId = taskId,
+                CancelledAt = DateTime.UtcNow,
+                CorrelationId = taskId,
+                Reason = "User requested cancellation"
+            }, "cancel video generation", new { TaskId = taskId });
 
-                return NoContent();
-            },
-            "CancelTask",
-            taskId);
+            return NoContent();
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Gateway/Filters/OperationLoggingFilter.cs
+++ b/Services/ConduitLLM.Gateway/Filters/OperationLoggingFilter.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace ConduitLLM.Gateway.Filters
+{
+    /// <summary>
+    /// Logs successful completion of controller actions, replacing the per-action success
+    /// logging that previously lived inside <c>GatewayControllerBase.ExecuteAsync</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Logs at <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/> for mutations
+    /// (POST/PUT/PATCH/DELETE) and <see cref="Microsoft.Extensions.Logging.LogLevel.Debug"/> for
+    /// reads — matching the previous <c>LogOperationSuccess</c> behavior. The log category is the
+    /// concrete controller type, so existing per-controller log filtering keeps working.
+    /// </para>
+    /// <para>
+    /// Exceptions are intentionally ignored here: they propagate to the global
+    /// <c>OpenAIErrorMiddleware</c>, which owns exception-to-response mapping (OpenAI error format)
+    /// and error logging.
+    /// </para>
+    /// <para>
+    /// Applied per controller via <c>[ServiceFilter(typeof(OperationLoggingFilter))]</c> during the
+    /// incremental Tier 1a migration (issue #902). Once every Gateway controller is converted off the
+    /// <c>ExecuteAsync</c> wrappers, this can be promoted to a single global filter.
+    /// </para>
+    /// </remarks>
+    public sealed class OperationLoggingFilter : IAsyncActionFilter
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationLoggingFilter"/> class.
+        /// </summary>
+        /// <param name="loggerFactory">Factory used to create a logger categorized to the controller type.</param>
+        public OperationLoggingFilter(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        /// <inheritdoc/>
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            var executed = await next();
+
+            // Success only — exceptions are owned by the global exception middleware. Leave the
+            // exception unhandled so it continues to propagate there.
+            if (executed.Exception != null && !executed.ExceptionHandled)
+            {
+                return;
+            }
+
+            var descriptor = context.ActionDescriptor as ControllerActionDescriptor;
+            var actionName = descriptor?.ActionName ?? "Unknown";
+
+            var logger = descriptor?.ControllerTypeInfo.FullName is { } categoryName
+                ? _loggerFactory.CreateLogger(categoryName)
+                : _loggerFactory.CreateLogger<OperationLoggingFilter>();
+
+            var method = context.HttpContext.Request.Method;
+            var isMutation = method is "POST" or "PUT" or "PATCH" or "DELETE";
+
+            if (isMutation)
+            {
+                logger.LogInformation("{Action} completed successfully", actionName);
+            }
+            else
+            {
+                logger.LogDebug("{Action} completed successfully", actionName);
+            }
+        }
+    }
+}

--- a/Services/ConduitLLM.Gateway/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Gateway/Program.Monitoring.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Gateway.Extensions;
+using ConduitLLM.Gateway.Filters;
 
 public partial class Program
 {
@@ -8,6 +9,12 @@ public partial class Program
     {
         // Add Controller support
         builder.Services.AddControllers();
+
+        // Operation-logging action filter — replaces the per-action success logging that used to
+        // live in GatewayControllerBase.ExecuteAsync. Applied per controller via [ServiceFilter]
+        // during the incremental Tier 1a migration (#902); promote to a global filter once all
+        // Gateway controllers are converted.
+        builder.Services.AddScoped<OperationLoggingFilter>();
 
         // Add OpenAPI support with Scalar
         builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## What

The **Gateway counterpart** to the Admin Tier 1a rollout (#908 / #935) — issue #902. Converts all 11 wrapper-using Gateway controllers off the per-action `ExecuteAsync` wrappers from `GatewayControllerBase`, delegating error handling to the already-wired global `OpenAIErrorMiddleware`.

Branched off `dev`, **independent** of the Admin PRs (separate service, separate base class, its own filter).

## Changes

- **New `OperationLoggingFilter`** (`ConduitLLM.Gateway.Filters`) + DI registration in `Program.Monitoring.cs` — reproduces the per-action success logging (Information for mutations, Debug for reads, categorized to the controller type) that lived in `GatewayControllerBase.ExecuteAsync`.
- **11 controllers** each get a class-level `[ServiceFilter(typeof(OperationLoggingFilter))]` and are converted off the wrappers: `Auth`, `Embeddings`, `Functions`\*, `ProviderModels`, `Models`, `Tasks`, `BatchOperations`, `Downloads`, `Media`, `Videos`, `Discovery`.

\* `Functions` had **no** base wrappers — its `ExecuteAsync` matches were the injected `_executionService.ExecuteAsync(...)`; it receives the filter only.

## Why this preserves behavior

`GatewayControllerBase`'s wrappers map exceptions to **OpenAI-format** errors (`OpenAIErrorResponse`) via `ExceptionToResponseMapper`. The global `OpenAIErrorMiddleware` (wired at `Program.Middleware.cs:68`) does the **same** mapping — so thrown exceptions that now propagate produce identical responses. `GatewayControllerBase` has **no** `ExecuteWithNotFoundAsync`, so not-found handling was already inline (`NotFound(new OpenAIErrorResponse {...})` / `OpenAIError(...)`) and is preserved verbatim, along with file/range-streaming returns (`File(...)`, 416 handling), inner try/catch blocks, metrics, and `CurrentVirtualKey` usage.

## Scope note

The initial grep survey counted 32 wrappers, but ~4 were false positives (injected `*.ExecuteAsync(...)` service calls in `Functions` and `BatchOperations`); **~28 real base wrappers** were removed. Streaming controllers (`Chat`, `Completions`, `Images`, SignalR*) don't use the wrappers and were left untouched.

## Verification

- `dotnet build` (Gateway): **0 warnings, 0 errors**; zero remaining base-wrapper call sites.
- `dotnet test` (`ConduitLLM.Tests.Gateway`): **111/111 passing**. **No test changes needed** — Gateway controllers used inline error returns (not in-wrapper throws), so the unit-test contract is unchanged (unlike Admin).

## Follow-up (not in this PR)

Once both this and the Admin rollout land, a cleanup PR can promote both `OperationLoggingFilter`s to global registrations, consolidate them into a shared one, and delete the now-unused `ExecuteAsync` overloads from `GatewayControllerBase` and `AdminControllerBase`.

Part of #902. Epic: #901.
