### PR TITLE
refactor(admin): re-land Tier 1a rollout (30 controllers) into dev — corrective for #935

### DIFF
--- a/Services/ConduitLLM.Admin/Controllers/AnalyticsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/AnalyticsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Metrics;
 using ConduitLLM.Admin.Services;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class AnalyticsController : AdminControllerBase
 {
     private readonly IAnalyticsService _analyticsService;
@@ -53,7 +55,7 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(PagedResult<LogRequestDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetLogs(
+    public async Task<IActionResult> GetLogs(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
         [FromQuery] DateTime? startDate = null,
@@ -65,19 +67,17 @@ public class AnalyticsController : AdminControllerBase
         // Validate parameters
         if (page < 1)
         {
-            return Task.FromResult<IActionResult>(BadRequest("Page must be greater than or equal to 1"));
+            return BadRequest("Page must be greater than or equal to 1");
         }
 
         if (pageSize < 1 || pageSize > 100)
         {
-            return Task.FromResult<IActionResult>(BadRequest("Page size must be between 1 and 100"));
+            return BadRequest("Page size must be between 1 and 100");
         }
 
-        return ExecuteAsync(
-            () => _analyticsService.GetLogsAsync(
-                page, pageSize, startDate, endDate, model, virtualKeyId, status),
-            Ok,
-            "GetLogs");
+        var result = await _analyticsService.GetLogsAsync(
+            page, pageSize, startDate, endDate, model, virtualKeyId, status);
+        return Ok(result);
     }
 
     /// <summary>
@@ -89,14 +89,14 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(LogRequestDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetLogById(int id)
+    public async Task<IActionResult> GetLogById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _analyticsService.GetLogByIdAsync(id),
-            Ok,
-            "Log entry",
-            id,
-            "GetLogById");
+        var log = await _analyticsService.GetLogByIdAsync(id);
+        if (log == null)
+        {
+            return this.NotFoundEntity("Log entry", id);
+        }
+        return Ok(log);
     }
 
     /// <summary>
@@ -106,12 +106,10 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("logs/models")]
     [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetDistinctModels()
+    public async Task<IActionResult> GetDistinctModels()
     {
-        return ExecuteAsync(
-            () => _analyticsService.GetDistinctModelsAsync(),
-            Ok,
-            "GetDistinctModels");
+        var models = await _analyticsService.GetDistinctModelsAsync();
+        return Ok(models);
     }
 
     #endregion
@@ -129,20 +127,18 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(CostDashboardDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetCostSummary(
+    public async Task<IActionResult> GetCostSummary(
         [FromQuery] string timeframe = "daily",
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null)
     {
         if (ControllerErrorExtensions.ValidateTimeframe(timeframe) is { } timeframeError)
         {
-            return Task.FromResult(timeframeError);
+            return timeframeError;
         }
 
-        return ExecuteAsync(
-            () => _analyticsService.GetCostSummaryAsync(timeframe, startDate, endDate),
-            Ok,
-            "GetCostSummary");
+        var summary = await _analyticsService.GetCostSummaryAsync(timeframe, startDate, endDate);
+        return Ok(summary);
     }
 
     /// <summary>
@@ -156,20 +152,18 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(CostTrendDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetCostTrends(
+    public async Task<IActionResult> GetCostTrends(
         [FromQuery] string period = "daily",
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null)
     {
         if (ControllerErrorExtensions.ValidateTimeframe(period, "Period") is { } periodError)
         {
-            return Task.FromResult(periodError);
+            return periodError;
         }
 
-        return ExecuteAsync(
-            () => _analyticsService.GetCostTrendsAsync(period, startDate, endDate),
-            Ok,
-            "GetCostTrends");
+        var trends = await _analyticsService.GetCostTrendsAsync(period, startDate, endDate);
+        return Ok(trends);
     }
 
     /// <summary>
@@ -182,15 +176,13 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("costs/models")]
     [ProducesResponseType(typeof(ModelCostBreakdownDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetModelCosts(
+    public async Task<IActionResult> GetModelCosts(
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null,
         [FromQuery] int topN = 10)
     {
-        return ExecuteAsync(
-            () => _analyticsService.GetModelCostsAsync(startDate, endDate, topN),
-            Ok,
-            "GetModelCosts");
+        var modelCosts = await _analyticsService.GetModelCostsAsync(startDate, endDate, topN);
+        return Ok(modelCosts);
     }
 
     /// <summary>
@@ -203,15 +195,13 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("costs/virtualkeys")]
     [ProducesResponseType(typeof(VirtualKeyCostBreakdownDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetVirtualKeyCosts(
+    public async Task<IActionResult> GetVirtualKeyCosts(
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null,
         [FromQuery] int topN = 10)
     {
-        return ExecuteAsync(
-            () => _analyticsService.GetVirtualKeyCostsAsync(startDate, endDate, topN),
-            Ok,
-            "GetVirtualKeyCosts");
+        var virtualKeyCosts = await _analyticsService.GetVirtualKeyCostsAsync(startDate, endDate, topN);
+        return Ok(virtualKeyCosts);
     }
 
     #endregion
@@ -229,20 +219,18 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(AnalyticsSummaryDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAnalyticsSummary(
+    public async Task<IActionResult> GetAnalyticsSummary(
         [FromQuery] string timeframe = "daily",
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null)
     {
         if (ControllerErrorExtensions.ValidateTimeframe(timeframe) is { } timeframeError)
         {
-            return Task.FromResult(timeframeError);
+            return timeframeError;
         }
 
-        return ExecuteAsync(
-            () => _analyticsService.GetAnalyticsSummaryAsync(timeframe, startDate, endDate),
-            Ok,
-            "GetAnalyticsSummary");
+        var summary = await _analyticsService.GetAnalyticsSummaryAsync(timeframe, startDate, endDate);
+        return Ok(summary);
     }
 
     /// <summary>
@@ -255,16 +243,13 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("virtualkeys/{virtualKeyId:int}/usage")]
     [ProducesResponseType(typeof(UsageStatisticsDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetVirtualKeyUsage(
+    public async Task<IActionResult> GetVirtualKeyUsage(
         int virtualKeyId,
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null)
     {
-        return ExecuteAsync(
-            () => _analyticsService.GetVirtualKeyUsageAsync(virtualKeyId, startDate, endDate),
-            Ok,
-            "GetVirtualKeyUsage",
-            new { VirtualKeyId = virtualKeyId });
+        var usage = await _analyticsService.GetVirtualKeyUsageAsync(virtualKeyId, startDate, endDate);
+        return Ok(usage);
     }
 
     /// <summary>
@@ -280,7 +265,7 @@ public class AnalyticsController : AdminControllerBase
     [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> ExportAnalytics(
+    public async Task<IActionResult> ExportAnalytics(
         [FromQuery] string format = "csv",
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null,
@@ -290,24 +275,18 @@ public class AnalyticsController : AdminControllerBase
         // Validate format
         if (format.ToLower() != "csv" && format.ToLower() != "json")
         {
-            return Task.FromResult<IActionResult>(BadRequest("Format must be one of: csv, json"));
+            return BadRequest("Format must be one of: csv, json");
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                using var activity = AdminRequestMetrics.StartCsvActivity("export", "analytics");
-                var data = await _analyticsService.ExportAnalyticsAsync(format, startDate, endDate, model, virtualKeyId);
+        using var activity = AdminRequestMetrics.StartCsvActivity("export", "analytics");
+        var data = await _analyticsService.ExportAnalyticsAsync(format, startDate, endDate, model, virtualKeyId);
 
-                var contentType = format.ToLower() == "csv" ? "text/csv" : "application/json";
-                var fileName = $"analytics_{DateTime.UtcNow:yyyyMMdd_HHmmss}.{format.ToLower()}";
+        var contentType = format.ToLower() == "csv" ? "text/csv" : "application/json";
+        var fileName = $"analytics_{DateTime.UtcNow:yyyyMMdd_HHmmss}.{format.ToLower()}";
 
-                LogAdminAudit("Exported", "AnalyticsData", detail: $"Format: {format}, StartDate: {startDate:O}, EndDate: {endDate:O}");
-                AdminOperationsMetricsService.RecordCsvOperation("export", "analytics", "success");
-                return (IActionResult)File(data, contentType, fileName);
-            },
-            result => result,
-            "ExportAnalytics");
+        LogAdminAudit("Exported", "AnalyticsData", detail: $"Format: {format}, StartDate: {startDate:O}, EndDate: {endDate:O}");
+        AdminOperationsMetricsService.RecordCsvOperation("export", "analytics", "success");
+        return File(data, contentType, fileName);
     }
 
     #endregion
@@ -358,19 +337,13 @@ public class AnalyticsController : AdminControllerBase
     [HttpPost("cache/invalidate")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> InvalidateCache([FromQuery] string reason = "Manual invalidation")
+    public async Task<IActionResult> InvalidateCache([FromQuery] string reason = "Manual invalidation")
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // TODO: Implement cache invalidation logic
-                _analyticsMetrics?.RecordCacheInvalidation(reason, 0);
-                await Task.CompletedTask;
-                LogAdminAudit("Invalidated", "AnalyticsCache", detail: $"Reason: {reason}");
-                return new { message = "Cache invalidation initiated", reason };
-            },
-            result => Ok(result),
-            "InvalidateCache");
+        // TODO: Implement cache invalidation logic
+        _analyticsMetrics?.RecordCacheInvalidation(reason, 0);
+        await Task.CompletedTask;
+        LogAdminAudit("Invalidated", "AnalyticsCache", detail: $"Reason: {reason}");
+        return Ok(new { message = "Cache invalidation initiated", reason });
     }
 
     #endregion

--- a/Services/ConduitLLM.Admin/Controllers/AuthController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Models;
 using ConduitLLM.Admin.Services;
 
@@ -10,6 +11,7 @@ namespace ConduitLLM.Admin.Controllers
     /// </summary>
     [ApiController]
     [Route("api/admin/auth")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class AuthController : AdminControllerBase
     {
         private readonly IEphemeralMasterKeyService _ephemeralMasterKeyService;
@@ -39,20 +41,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(EphemeralMasterKeyResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GenerateEphemeralMasterKey()
+        public async Task<IActionResult> GenerateEphemeralMasterKey()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Create ephemeral master key
-                    var response = await _ephemeralMasterKeyService.CreateEphemeralMasterKeyAsync();
+            // Create ephemeral master key
+            var response = await _ephemeralMasterKeyService.CreateEphemeralMasterKeyAsync();
 
-                    LogAdminAudit("Generated", "EphemeralMasterKey", detail: $"TTL: {response.ExpiresInSeconds}s");
+            LogAdminAudit("Generated", "EphemeralMasterKey", detail: $"TTL: {response.ExpiresInSeconds}s");
 
-                    return response;
-                },
-                Ok,
-                "GenerateEphemeralMasterKey");
+            return Ok(response);
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/BatchSpendingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/BatchSpendingController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MassTransit;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration.Events;
 using ConduitLLM.Core.Extensions;
 
@@ -20,6 +21,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/batch-spending")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class BatchSpendingController : AdminControllerBase
     {
         private readonly IPublishEndpoint _publishEndpoint;
@@ -60,63 +62,57 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(object), 202)]
         [ProducesResponseType(400)]
         [ProducesResponseType(500)]
-        public Task<IActionResult> FlushPendingUpdates(
+        public async Task<IActionResult> FlushPendingUpdates(
             [FromQuery] string? reason = null,
             [FromQuery] FlushPriority priority = FlushPriority.Normal,
             [FromQuery] int? timeoutSeconds = null,
             [FromQuery] bool includeStatistics = true)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Generate unique request ID for tracking
-                    var requestId = Guid.NewGuid().ToString();
+            // Generate unique request ID for tracking
+            var requestId = Guid.NewGuid().ToString();
 
-                    Logger.LogInformation(
-                        "Admin requesting batch spend flush - RequestId: {RequestId}, Reason: {Reason}, Priority: {Priority}",
-                        requestId, reason ?? "Administrative operation", priority);
+            Logger.LogInformation(
+                "Admin requesting batch spend flush - RequestId: {RequestId}, Reason: {Reason}, Priority: {Priority}",
+                requestId, reason ?? "Administrative operation", priority);
 
-                    // Validate timeout parameter
-                    if (timeoutSeconds.HasValue && (timeoutSeconds.Value < 1 || timeoutSeconds.Value > 300))
-                    {
-                        throw new ArgumentException("Timeout must be between 1 and 300 seconds");
-                    }
+            // Validate timeout parameter
+            if (timeoutSeconds.HasValue && (timeoutSeconds.Value < 1 || timeoutSeconds.Value > 300))
+            {
+                throw new ArgumentException("Timeout must be between 1 and 300 seconds");
+            }
 
-                    // Create and publish flush request event
-                    var flushEvent = new BatchSpendFlushRequestedEvent
-                    {
-                        RequestId = requestId,
-                        RequestedBy = "Admin",
-                        RequestedAt = DateTime.UtcNow,
-                        Reason = reason ?? "Administrative flush operation",
-                        Source = "Admin API",
-                        Priority = priority,
-                        TimeoutSeconds = timeoutSeconds,
-                        IncludeStatistics = includeStatistics
-                    };
+            // Create and publish flush request event
+            var flushEvent = new BatchSpendFlushRequestedEvent
+            {
+                RequestId = requestId,
+                RequestedBy = "Admin",
+                RequestedAt = DateTime.UtcNow,
+                Reason = reason ?? "Administrative flush operation",
+                Source = "Admin API",
+                Priority = priority,
+                TimeoutSeconds = timeoutSeconds,
+                IncludeStatistics = includeStatistics
+            };
 
-                    // Publish event to Gateway API for processing
-                    await _publishEndpoint.Publish(flushEvent);
+            // Publish event to Gateway API for processing
+            await _publishEndpoint.Publish(flushEvent);
 
-                    LogAdminAudit("Flushed", "BatchSpending",
-                        detail: $"RequestId: {requestId}, Priority: {priority}, Reason: {LoggingSanitizer.S(reason ?? "Administrative flush operation")}");
+            LogAdminAudit("Flushed", "BatchSpending",
+                detail: $"RequestId: {requestId}, Priority: {priority}, Reason: {LoggingSanitizer.S(reason ?? "Administrative flush operation")}");
 
-                    // Return accepted response with tracking information
-                    return (object)new
-                    {
-                        success = true,
-                        message = "Batch spend flush request submitted successfully",
-                        requestId = requestId,
-                        requestedAt = flushEvent.RequestedAt,
-                        priority = priority.ToString(),
-                        estimatedProcessingTime = timeoutSeconds.HasValue
-                            ? $"Up to {timeoutSeconds} seconds"
-                            : "Based on service configuration",
-                        note = "This is an asynchronous operation. Monitor logs for completion status."
-                    };
-                },
-                result => Accepted(result),
-                "FlushPendingUpdates");
+            // Return accepted response with tracking information
+            return Accepted(new
+            {
+                success = true,
+                message = "Batch spend flush request submitted successfully",
+                requestId = requestId,
+                requestedAt = flushEvent.RequestedAt,
+                priority = priority.ToString(),
+                estimatedProcessingTime = timeoutSeconds.HasValue
+                    ? $"Up to {timeoutSeconds} seconds"
+                    : "Based on service configuration",
+                note = "This is an asynchronous operation. Monitor logs for completion status."
+            });
         }
 
         /// <summary>
@@ -133,36 +129,33 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>System status and configuration information</returns>
         [HttpGet("status")]
         [ProducesResponseType(typeof(object), 200)]
-        public Task<IActionResult> GetStatus()
+        public async Task<IActionResult> GetStatus()
         {
-            return ExecuteAsync(
-                () =>
-                {
-                    var isEventBusAvailable = IsEventPublishingEnabled;
+            var isEventBusAvailable = IsEventPublishingEnabled;
 
-                    return Task.FromResult(new
-                    {
-                        success = true,
-                        adminApiStatus = "healthy",
-                        eventBusAvailable = isEventBusAvailable,
-                        canPublishFlushRequests = isEventBusAvailable,
-                        supportedOperations = new[]
-                        {
-                            "flush - Trigger immediate batch spend processing",
-                            "status - Get system status information"
-                        },
-                        architecture = new
-                        {
-                            pattern = "Event-driven with MassTransit",
-                            adminRole = "Publishes BatchSpendFlushRequestedEvent",
-                            coreRole = "Consumes events and performs actual flush operations",
-                            decoupling = "Admin and Gateway APIs communicate via events only"
-                        },
-                        timestamp = DateTime.UtcNow
-                    });
+            var status = new
+            {
+                success = true,
+                adminApiStatus = "healthy",
+                eventBusAvailable = isEventBusAvailable,
+                canPublishFlushRequests = isEventBusAvailable,
+                supportedOperations = new[]
+                {
+                    "flush - Trigger immediate batch spend processing",
+                    "status - Get system status information"
                 },
-                Ok,
-                "GetStatus");
+                architecture = new
+                {
+                    pattern = "Event-driven with MassTransit",
+                    adminRole = "Publishes BatchSpendFlushRequestedEvent",
+                    coreRole = "Consumes events and performs actual flush operations",
+                    decoupling = "Admin and Gateway APIs communicate via events only"
+                },
+                timestamp = DateTime.UtcNow
+            };
+
+            await Task.CompletedTask;
+            return Ok(status);
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/BillingAuditController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/BillingAuditController.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -16,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/audit/billing")]
     [Authorize]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class BillingAuditController : AdminControllerBase
     {
         private readonly IBillingAuditService _billingAuditService;
@@ -69,47 +71,41 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("query")]
         [ProducesResponseType(typeof(BillingAuditResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> QueryAuditEvents([FromBody] BillingAuditQueryRequest request)
+        public async Task<IActionResult> QueryAuditEvents([FromBody] BillingAuditQueryRequest request)
         {
             if (ControllerErrorExtensions.ValidateDateRange(request.From, request.To) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
             if (request.PageSize > 1000)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Page size cannot exceed 1000"));
+                return BadRequest("Page size cannot exceed 1000");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = BillingAuditQueryDuration.WithLabels("query").NewTimer();
+            using var timer = BillingAuditQueryDuration.WithLabels("query").NewTimer();
 
-                    var (events, totalCount) = await _billingAuditService.GetAuditEventsAsync(
-                        request.From,
-                        request.To,
-                        request.EventType,
-                        request.VirtualKeyId,
-                        request.PageNumber,
-                        request.PageSize);
+            var (events, totalCount) = await _billingAuditService.GetAuditEventsAsync(
+                request.From,
+                request.To,
+                request.EventType,
+                request.VirtualKeyId,
+                request.PageNumber,
+                request.PageSize);
 
-                    var response = new BillingAuditResponse
-                    {
-                        Events = events.Select(e => MapToDto(e)).ToList(),
-                        TotalCount = totalCount,
-                        PageNumber = request.PageNumber,
-                        PageSize = request.PageSize
-                    };
+            var response = new BillingAuditResponse
+            {
+                Events = events.Select(e => MapToDto(e)).ToList(),
+                TotalCount = totalCount,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize
+            };
 
-                    Logger.LogDebug("Billing audit query returned {TotalCount} events (page {Page}/{PageSize})",
-                        totalCount, request.PageNumber, request.PageSize);
+            Logger.LogDebug("Billing audit query returned {TotalCount} events (page {Page}/{PageSize})",
+                totalCount, request.PageNumber, request.PageSize);
 
-                    BillingAuditQueries.WithLabels("query", "success").Inc();
-                    return response;
-                },
-                Ok,
-                "QueryAuditEvents");
+            BillingAuditQueries.WithLabels("query", "success").Inc();
+            return Ok(response);
         }
 
         /// <summary>
@@ -122,28 +118,22 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("summary")]
         [ProducesResponseType(typeof(BillingAuditSummary), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> GetSummary(
+        public async Task<IActionResult> GetSummary(
             [FromQuery] DateTime from,
             [FromQuery] DateTime to,
             [FromQuery] int? virtualKeyId = null)
         {
             if (ControllerErrorExtensions.ValidateDateRange(from, to) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = BillingAuditQueryDuration.WithLabels("summary").NewTimer();
+            using var timer = BillingAuditQueryDuration.WithLabels("summary").NewTimer();
 
-                    var summary = await _billingAuditService.GetAuditSummaryAsync(from, to, virtualKeyId);
+            var summary = await _billingAuditService.GetAuditSummaryAsync(from, to, virtualKeyId);
 
-                    BillingAuditQueries.WithLabels("summary", "success").Inc();
-                    return summary;
-                },
-                Ok,
-                "GetSummary");
+            BillingAuditQueries.WithLabels("summary", "success").Inc();
+            return Ok(summary);
         }
 
         /// <summary>
@@ -155,34 +145,28 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("anomalies")]
         [ProducesResponseType(typeof(List<BillingAnomaly>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> DetectAnomalies(
+        public async Task<IActionResult> DetectAnomalies(
             [FromQuery] DateTime from,
             [FromQuery] DateTime to)
         {
             if (ControllerErrorExtensions.ValidateDateRange(from, to) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = BillingAuditQueryDuration.WithLabels("anomalies").NewTimer();
+            using var timer = BillingAuditQueryDuration.WithLabels("anomalies").NewTimer();
 
-                    var anomalies = await _billingAuditService.DetectAnomaliesAsync(from, to);
+            var anomalies = await _billingAuditService.DetectAnomaliesAsync(from, to);
 
-                    // Update anomaly gauge metrics
-                    var anomalyGroups = anomalies.GroupBy(a => a.Severity ?? "unknown");
-                    foreach (var group in anomalyGroups)
-                    {
-                        BillingAnomaliesDetected.WithLabels(group.Key).Set(group.Count());
-                    }
+            // Update anomaly gauge metrics
+            var anomalyGroups = anomalies.GroupBy(a => a.Severity ?? "unknown");
+            foreach (var group in anomalyGroups)
+            {
+                BillingAnomaliesDetected.WithLabels(group.Key).Set(group.Count());
+            }
 
-                    BillingAuditQueries.WithLabels("anomalies", "success").Inc();
-                    return anomalies;
-                },
-                Ok,
-                "DetectAnomalies");
+            BillingAuditQueries.WithLabels("anomalies", "success").Inc();
+            return Ok(anomalies);
         }
 
         /// <summary>
@@ -194,27 +178,21 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("revenue-loss")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> GetRevenueLoss(
+        public async Task<IActionResult> GetRevenueLoss(
             [FromQuery] DateTime from,
             [FromQuery] DateTime to)
         {
             if (ControllerErrorExtensions.ValidateDateRange(from, to) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = BillingAuditQueryDuration.WithLabels("revenue-loss").NewTimer();
+            using var timer = BillingAuditQueryDuration.WithLabels("revenue-loss").NewTimer();
 
-                    var loss = await _billingAuditService.GetPotentialRevenueLossAsync(from, to);
+            var loss = await _billingAuditService.GetPotentialRevenueLossAsync(from, to);
 
-                    BillingAuditQueries.WithLabels("revenue-loss", "success").Inc();
-                    return new { potentialRevenueLoss = loss, currency = "USD" };
-                },
-                result => Ok(result),
-                "GetRevenueLoss");
+            BillingAuditQueries.WithLabels("revenue-loss", "success").Inc();
+            return Ok(new { potentialRevenueLoss = loss, currency = "USD" });
         }
 
         /// <summary>
@@ -225,51 +203,45 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("export")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> ExportAuditEvents([FromBody] BillingAuditExportRequest request)
+        public async Task<IActionResult> ExportAuditEvents([FromBody] BillingAuditExportRequest request)
         {
             if (ControllerErrorExtensions.ValidateDateRange(request.From, request.To) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = BillingAuditQueryDuration.WithLabels("export").NewTimer();
+            using var timer = BillingAuditQueryDuration.WithLabels("export").NewTimer();
 
-                    // Get all events for the period (no pagination for export)
-                    var (events, _) = await _billingAuditService.GetAuditEventsAsync(
-                        request.From,
-                        request.To,
-                        request.EventType,
-                        request.VirtualKeyId,
-                        pageNumber: 1,
-                        pageSize: int.MaxValue);
+            // Get all events for the period (no pagination for export)
+            var (events, _) = await _billingAuditService.GetAuditEventsAsync(
+                request.From,
+                request.To,
+                request.EventType,
+                request.VirtualKeyId,
+                pageNumber: 1,
+                pageSize: int.MaxValue);
 
-                    Logger.LogInformation("Exporting {EventCount} billing audit events as {Format} for period {From:O} to {To:O}",
-                        events.Count, request.Format, request.From, request.To);
+            Logger.LogInformation("Exporting {EventCount} billing audit events as {Format} for period {From:O} to {To:O}",
+                events.Count, request.Format, request.From, request.To);
 
-                    switch (request.Format)
-                    {
-                        case ExportFormat.Json:
-                            BillingAuditExports.WithLabels("json", "success").Inc();
-                            return ExportAsJson(events);
+            switch (request.Format)
+            {
+                case ExportFormat.Json:
+                    BillingAuditExports.WithLabels("json", "success").Inc();
+                    return ExportAsJson(events);
 
-                        case ExportFormat.Csv:
-                            BillingAuditExports.WithLabels("csv", "success").Inc();
-                            return ExportAsCsv(events);
+                case ExportFormat.Csv:
+                    BillingAuditExports.WithLabels("csv", "success").Inc();
+                    return ExportAsCsv(events);
 
-                        case ExportFormat.Excel:
-                            BillingAuditExports.WithLabels("excel", "not_implemented").Inc();
-                            return (IActionResult)BadRequest("Excel export not yet implemented");
+                case ExportFormat.Excel:
+                    BillingAuditExports.WithLabels("excel", "not_implemented").Inc();
+                    return BadRequest("Excel export not yet implemented");
 
-                        default:
-                            BillingAuditExports.WithLabels(request.Format.ToString(), "unsupported").Inc();
-                            return (IActionResult)BadRequest($"Unsupported export format: {request.Format}");
-                    }
-                },
-                result => result,
-                "ExportAuditEvents");
+                default:
+                    BillingAuditExports.WithLabels(request.Format.ToString(), "unsupported").Inc();
+                    return BadRequest($"Unsupported export format: {request.Format}");
+            }
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/ConfigurationController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ConfigurationController.cs
@@ -5,6 +5,7 @@ using ConduitLLM.Configuration.DTOs;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs.Cache;
 
@@ -16,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/config")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ConfigurationController : AdminControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -51,66 +53,60 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Routing configuration data.</returns>
         [HttpGet("routing")]
-        public Task<IActionResult> GetRoutingConfig(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetRoutingConfig(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            // Get model-to-provider mappings
+            var modelMappings = await dbContext.ModelProviderMappings
+                .Include(m => m.Provider)
+                .Select(m => new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-                    // Get model-to-provider mappings
-                    var modelMappings = await dbContext.ModelProviderMappings
-                        .Include(m => m.Provider)
-                        .Select(m => new
-                        {
-                            Id = m.Id,
-                            ModelAlias = m.ModelAlias,
-                            ProviderModelId = m.ProviderModelId,
-                            IsEnabled = m.IsEnabled,
-                            Provider = new
-                            {
-                                Id = m.Provider.Id,
-                                Name = m.Provider.ProviderName,
-                                Type = m.Provider.ProviderType,
-                                IsEnabled = m.Provider.IsEnabled
-                            }
-                        })
-                        .ToListAsync(cancellationToken);
-
-                    // Get load balancing configuration
-                    var loadBalancers = new List<object>
+                    Id = m.Id,
+                    ModelAlias = m.ModelAlias,
+                    ProviderModelId = m.ProviderModelId,
+                    IsEnabled = m.IsEnabled,
+                    Provider = new
                     {
-                        new
-                        {
-                            Id = "primary",
-                            Name = "Primary Load Balancer",
-                            Algorithm = _configuration["LoadBalancing:Algorithm"] ?? "round-robin",
-                            HealthCheckInterval = 30,
-                            FailoverThreshold = 3,
-                            Endpoints = await GetProviderEndpoints(dbContext, cancellationToken)
-                        }
-                    };
+                        Id = m.Provider.Id,
+                        Name = m.Provider.ProviderName,
+                        Type = m.Provider.ProviderType,
+                        IsEnabled = m.Provider.IsEnabled
+                    }
+                })
+                .ToListAsync(cancellationToken);
 
-                    // Get routing statistics
-                    var routingStats = await GetRoutingStatistics(dbContext, cancellationToken);
+            // Get load balancing configuration
+            var loadBalancers = new List<object>
+            {
+                new
+                {
+                    Id = "primary",
+                    Name = "Primary Load Balancer",
+                    Algorithm = _configuration["LoadBalancing:Algorithm"] ?? "round-robin",
+                    HealthCheckInterval = 30,
+                    FailoverThreshold = 3,
+                    Endpoints = await GetProviderEndpoints(dbContext, cancellationToken)
+                }
+            };
 
-                    return (object)new
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        RoutingRules = modelMappings,
-                        LoadBalancers = loadBalancers,
-                        Statistics = routingStats,
-                        Configuration = new
-                        {
-                            EnableFailover = _configuration.GetValue<bool>("Routing:EnableFailover", true),
-                            EnableLoadBalancing = _configuration.GetValue<bool>("Routing:EnableLoadBalancing", true),
-                            RequestTimeout = _configuration.GetValue<int>("Routing:RequestTimeoutSeconds", 30),
-                            CircuitBreakerThreshold = _configuration.GetValue<int>("Routing:CircuitBreakerThreshold", 5)
-                        }
-                    };
-                },
-                Ok,
-                "GetRoutingConfig");
+            // Get routing statistics
+            var routingStats = await GetRoutingStatistics(dbContext, cancellationToken);
+
+            return Ok(new
+            {
+                Timestamp = DateTime.UtcNow,
+                RoutingRules = modelMappings,
+                LoadBalancers = loadBalancers,
+                Statistics = routingStats,
+                Configuration = new
+                {
+                    EnableFailover = _configuration.GetValue<bool>("Routing:EnableFailover", true),
+                    EnableLoadBalancing = _configuration.GetValue<bool>("Routing:EnableLoadBalancing", true),
+                    RequestTimeout = _configuration.GetValue<int>("Routing:RequestTimeoutSeconds", 30),
+                    CircuitBreakerThreshold = _configuration.GetValue<int>("Routing:CircuitBreakerThreshold", 5)
+                }
+            });
         }
 
         private async Task<List<object>> GetProviderEndpoints(ConduitDbContext dbContext, CancellationToken cancellationToken)
@@ -166,12 +162,10 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>LLM cache control status.</returns>
         [HttpGet("caching/llm-status")]
         [ProducesResponseType(typeof(LLMCacheControlDto), 200)]
-        public Task<IActionResult> GetLLMCacheStatus(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetLLMCacheStatus(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                () => _llmCacheManagementService.GetLLMCacheStatusAsync(cancellationToken),
-                Ok,
-                "GetLLMCacheStatus");
+            var status = await _llmCacheManagementService.GetLLMCacheStatusAsync(cancellationToken);
+            return Ok(status);
         }
 
         /// <summary>
@@ -182,22 +176,16 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>Updated LLM cache control status.</returns>
         [HttpPost("caching/llm-toggle")]
         [ProducesResponseType(typeof(LLMCacheControlDto), 200)]
-        public Task<IActionResult> ToggleLLMCache([FromBody] ToggleLLMCacheRequest request, CancellationToken cancellationToken = default)
+        public async Task<IActionResult> ToggleLLMCache([FromBody] ToggleLLMCacheRequest request, CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var userName = User?.Identity?.Name ?? "Unknown";
-                    var result = await _llmCacheManagementService.ToggleLLMCacheAsync(
-                        request.Enabled,
-                        userName,
-                        request.Reason,
-                        cancellationToken);
-                    LogAdminAudit("Toggled", "LLMCache", detail: $"Enabled: {request.Enabled}, Reason: {LoggingSanitizer.S(request.Reason)}");
-                    return result;
-                },
-                Ok,
-                "ToggleLLMCache");
+            var userName = User?.Identity?.Name ?? "Unknown";
+            var result = await _llmCacheManagementService.ToggleLLMCacheAsync(
+                request.Enabled,
+                userName,
+                request.Reason,
+                cancellationToken);
+            LogAdminAudit("Toggled", "LLMCache", detail: $"Enabled: {request.Enabled}, Reason: {LoggingSanitizer.S(request.Reason)}");
+            return Ok(result);
         }
 
     }

--- a/Services/ConduitLLM.Admin/Controllers/FunctionConfigurationsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionConfigurationsController.cs
@@ -1,4 +1,6 @@
 using ConduitLLM.Core.Extensions;
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Core.Events;
@@ -15,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class FunctionConfigurationsController : AdminControllerBase
 {
     private readonly IFunctionConfigurationRepository _configurationRepository;
@@ -38,12 +41,10 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAllConfigurations()
+    public async Task<IActionResult> GetAllConfigurations()
     {
-        return ExecuteAsync(
-            () => _configurationRepository.GetAllUnboundedAsync(),
-            Ok,
-            "GetAllConfigurations");
+        var configurations = await _configurationRepository.GetAllUnboundedAsync();
+        return Ok(configurations);
     }
 
     /// <summary>
@@ -55,14 +56,14 @@ public class FunctionConfigurationsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetConfigurationById(int id)
+    public async Task<IActionResult> GetConfigurationById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _configurationRepository.GetByIdAsync(id),
-            Ok,
-            "FunctionConfiguration",
-            id,
-            "GetConfigurationById");
+        var configuration = await _configurationRepository.GetByIdAsync(id);
+        if (configuration == null)
+        {
+            return this.NotFoundEntity("FunctionConfiguration", id);
+        }
+        return Ok(configuration);
     }
 
     /// <summary>
@@ -73,18 +74,15 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpGet("provider/{providerType}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetConfigurationsByProvider(string providerType)
+    public async Task<IActionResult> GetConfigurationsByProvider(string providerType)
     {
         if (!Enum.TryParse<ConduitLLM.Functions.Enums.FunctionProviderType>(providerType, true, out var providerEnum))
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto($"Invalid provider type: {providerType}")));
+            return BadRequest(new ErrorResponseDto($"Invalid provider type: {providerType}"));
         }
 
-        return ExecuteAsync(
-            () => _configurationRepository.GetByProviderTypeAsync(providerEnum),
-            Ok,
-            "GetConfigurationsByProvider",
-            new { ProviderType = providerType });
+        var configurations = await _configurationRepository.GetByProviderTypeAsync(providerEnum);
+        return Ok(configurations);
     }
 
     /// <summary>
@@ -95,18 +93,15 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpGet("purpose/{purpose}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetConfigurationsByPurpose(string purpose)
+    public async Task<IActionResult> GetConfigurationsByPurpose(string purpose)
     {
         if (!Enum.TryParse<ConduitLLM.Functions.Enums.FunctionPurpose>(purpose, true, out var purposeEnum))
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto($"Invalid purpose: {purpose}")));
+            return BadRequest(new ErrorResponseDto($"Invalid purpose: {purpose}"));
         }
 
-        return ExecuteAsync(
-            () => _configurationRepository.GetByPurposeAsync(purposeEnum),
-            Ok,
-            "GetConfigurationsByPurpose",
-            new { Purpose = purpose });
+        var configurations = await _configurationRepository.GetByPurposeAsync(purposeEnum);
+        return Ok(configurations);
     }
 
     /// <summary>
@@ -118,49 +113,43 @@ public class FunctionConfigurationsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateConfiguration(
+    public async Task<IActionResult> CreateConfiguration(
         [FromBody] ConduitLLM.Functions.Entities.FunctionConfiguration configuration)
     {
         if (configuration == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function configuration data is required")));
+            return BadRequest(new ErrorResponseDto("Function configuration data is required"));
         }
 
-        return ExecuteAsync(
-            async () =>
+        int id = await _configurationRepository.CreateAsync(configuration);
+
+        // Fetch the created entity to return
+        var created = await _configurationRepository.GetByIdAsync(id);
+
+        // Audit log and publish event for cache invalidation
+        if (created != null)
+        {
+            LogAdminAudit("Created", "FunctionConfiguration", created.Id, $"Name: {LoggingSanitizer.S(created.ConfigurationName)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "create");
+            PublishEventFireAndForget(new FunctionConfigurationChanged
             {
-                int id = await _configurationRepository.CreateAsync(configuration);
+                FunctionConfigurationId = created.Id,
+                ConfigurationName = created.ConfigurationName,
+                ProviderType = created.ProviderType.ToString(),
+                Purpose = created.Purpose.ToString(),
+                ChangeType = "Created",
+                ChangedProperties = new[] { "Created" },
+                IsEnabledChanged = false,
+                CacheTtlChanged = false,
+                CorrelationId = Guid.NewGuid().ToString()
+            }, "create function configuration",
+            new { ConfigName = created.ConfigurationName, ConfigId = created.Id });
+        }
 
-                // Fetch the created entity to return
-                var created = await _configurationRepository.GetByIdAsync(id);
-
-                // Audit log and publish event for cache invalidation
-                if (created != null)
-                {
-                    LogAdminAudit("Created", "FunctionConfiguration", created.Id, $"Name: {LoggingSanitizer.S(created.ConfigurationName)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "create");
-                    PublishEventFireAndForget(new FunctionConfigurationChanged
-                    {
-                        FunctionConfigurationId = created.Id,
-                        ConfigurationName = created.ConfigurationName,
-                        ProviderType = created.ProviderType.ToString(),
-                        Purpose = created.Purpose.ToString(),
-                        ChangeType = "Created",
-                        ChangedProperties = new[] { "Created" },
-                        IsEnabledChanged = false,
-                        CacheTtlChanged = false,
-                        CorrelationId = Guid.NewGuid().ToString()
-                    }, "create function configuration",
-                    new { ConfigName = created.ConfigurationName, ConfigId = created.Id });
-                }
-
-                return (id, created);
-            },
-            result => CreatedAtAction(
-                nameof(GetConfigurationById),
-                new { id = result.id },
-                result.created),
-            "CreateConfiguration");
+        return CreatedAtAction(
+            nameof(GetConfigurationById),
+            new { id = id },
+            created);
     }
 
     /// <summary>
@@ -174,76 +163,74 @@ public class FunctionConfigurationsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateConfiguration(
+    public async Task<IActionResult> UpdateConfiguration(
         int id,
         [FromBody] ConduitLLM.Functions.Entities.FunctionConfiguration configuration)
     {
         if (configuration == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function configuration data is required")));
+            return BadRequest(new ErrorResponseDto("Function configuration data is required"));
         }
 
         if (id != configuration.Id)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("ID mismatch")));
+            return BadRequest(new ErrorResponseDto("ID mismatch"));
         }
 
-        return ExecuteWithNotFoundAsync(
-            () => _configurationRepository.GetByIdAsync(id),
-            async existing =>
+        var existing = await _configurationRepository.GetByIdAsync(id);
+        if (existing == null)
+        {
+            return this.NotFoundEntity("FunctionConfiguration", id);
+        }
+
+        // Detect changes for event publishing
+        bool isEnabledChanged = existing.IsEnabled != configuration.IsEnabled;
+        bool cacheTtlChanged = existing.CacheTtlMinutes != configuration.CacheTtlMinutes;
+        var changedProperties = new List<string>();
+        if (existing.ConfigurationName != configuration.ConfigurationName) changedProperties.Add("ConfigurationName");
+        if (existing.ProviderType != configuration.ProviderType) changedProperties.Add("ProviderType");
+        if (existing.Purpose != configuration.Purpose) changedProperties.Add("Purpose");
+        if (existing.IsEnabled != configuration.IsEnabled) changedProperties.Add("IsEnabled");
+        if (existing.BaseUrl != configuration.BaseUrl) changedProperties.Add("BaseUrl");
+        if (existing.TimeoutSeconds != configuration.TimeoutSeconds) changedProperties.Add("TimeoutSeconds");
+        if (existing.CacheTtlMinutes != configuration.CacheTtlMinutes) changedProperties.Add("CacheTtlMinutes");
+        if (existing.ProviderSettings != configuration.ProviderSettings) changedProperties.Add("ProviderSettings");
+        if (existing.ParameterSchema != configuration.ParameterSchema) changedProperties.Add("ParameterSchema");
+        if (existing.Description != configuration.Description) changedProperties.Add("Description");
+
+        await _configurationRepository.UpdateAsync(configuration);
+
+        // Fetch the updated entity to return
+        var updated = await _configurationRepository.GetByIdAsync(id);
+
+        if (updated == null)
+        {
+            return NotFound(new ErrorResponseDto("Function configuration not found after update"));
+        }
+
+        LogAdminAudit("Updated", "FunctionConfiguration", id,
+            changedProperties.Count > 0 ? $"Changed: {string.Join(", ", changedProperties)}" : null);
+        AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "update");
+
+        // Publish FunctionConfigurationChanged event for cache invalidation
+        if (changedProperties.Count > 0)
+        {
+            PublishEventFireAndForget(new FunctionConfigurationChanged
             {
-                // Detect changes for event publishing
-                bool isEnabledChanged = existing.IsEnabled != configuration.IsEnabled;
-                bool cacheTtlChanged = existing.CacheTtlMinutes != configuration.CacheTtlMinutes;
-                var changedProperties = new List<string>();
-                if (existing.ConfigurationName != configuration.ConfigurationName) changedProperties.Add("ConfigurationName");
-                if (existing.ProviderType != configuration.ProviderType) changedProperties.Add("ProviderType");
-                if (existing.Purpose != configuration.Purpose) changedProperties.Add("Purpose");
-                if (existing.IsEnabled != configuration.IsEnabled) changedProperties.Add("IsEnabled");
-                if (existing.BaseUrl != configuration.BaseUrl) changedProperties.Add("BaseUrl");
-                if (existing.TimeoutSeconds != configuration.TimeoutSeconds) changedProperties.Add("TimeoutSeconds");
-                if (existing.CacheTtlMinutes != configuration.CacheTtlMinutes) changedProperties.Add("CacheTtlMinutes");
-                if (existing.ProviderSettings != configuration.ProviderSettings) changedProperties.Add("ProviderSettings");
-                if (existing.ParameterSchema != configuration.ParameterSchema) changedProperties.Add("ParameterSchema");
-                if (existing.Description != configuration.Description) changedProperties.Add("Description");
+                FunctionConfigurationId = updated.Id,
+                ConfigurationName = updated.ConfigurationName,
+                ProviderType = updated.ProviderType.ToString(),
+                Purpose = updated.Purpose.ToString(),
+                ChangeType = "Updated",
+                ChangedProperties = changedProperties.ToArray(),
+                IsEnabledChanged = isEnabledChanged,
+                CacheTtlChanged = cacheTtlChanged,
+                CorrelationId = Guid.NewGuid().ToString()
+            }, "update function configuration",
+            new { ConfigName = updated.ConfigurationName, ConfigId = updated.Id, ChangedProps = string.Join(", ", changedProperties) });
+        }
 
-                await _configurationRepository.UpdateAsync(configuration);
-
-                // Fetch the updated entity to return
-                var updated = await _configurationRepository.GetByIdAsync(id);
-
-                if (updated == null)
-                {
-                    return NotFound(new ErrorResponseDto("Function configuration not found after update"));
-                }
-
-                LogAdminAudit("Updated", "FunctionConfiguration", id,
-                    changedProperties.Count > 0 ? $"Changed: {string.Join(", ", changedProperties)}" : null);
-                AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "update");
-
-                // Publish FunctionConfigurationChanged event for cache invalidation
-                if (changedProperties.Count > 0)
-                {
-                    PublishEventFireAndForget(new FunctionConfigurationChanged
-                    {
-                        FunctionConfigurationId = updated.Id,
-                        ConfigurationName = updated.ConfigurationName,
-                        ProviderType = updated.ProviderType.ToString(),
-                        Purpose = updated.Purpose.ToString(),
-                        ChangeType = "Updated",
-                        ChangedProperties = changedProperties.ToArray(),
-                        IsEnabledChanged = isEnabledChanged,
-                        CacheTtlChanged = cacheTtlChanged,
-                        CorrelationId = Guid.NewGuid().ToString()
-                    }, "update function configuration",
-                    new { ConfigName = updated.ConfigurationName, ConfigId = updated.Id, ChangedProps = string.Join(", ", changedProperties) });
-                }
-
-                return Ok(updated);
-            },
-            "FunctionConfiguration",
-            id,
-            "UpdateConfiguration");
+        return Ok(updated);
     }
 
     /// <summary>
@@ -255,35 +242,33 @@ public class FunctionConfigurationsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteConfiguration(int id)
+    public async Task<IActionResult> DeleteConfiguration(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _configurationRepository.GetByIdAsync(id),
-            async toDelete =>
-            {
-                await _configurationRepository.DeleteAsync(id);
-                LogAdminAudit("Deleted", "FunctionConfiguration", id, $"Name: {LoggingSanitizer.S(toDelete.ConfigurationName)}");
-                AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "delete");
+        var toDelete = await _configurationRepository.GetByIdAsync(id);
+        if (toDelete == null)
+        {
+            return this.NotFoundEntity("FunctionConfiguration", id);
+        }
 
-                // Publish FunctionConfigurationChanged event for cache invalidation
-                PublishEventFireAndForget(new FunctionConfigurationChanged
-                {
-                    FunctionConfigurationId = toDelete.Id,
-                    ConfigurationName = toDelete.ConfigurationName,
-                    ProviderType = toDelete.ProviderType.ToString(),
-                    Purpose = toDelete.Purpose.ToString(),
-                    ChangeType = "Deleted",
-                    ChangedProperties = new[] { "Deleted" },
-                    IsEnabledChanged = false,
-                    CacheTtlChanged = false,
-                    CorrelationId = Guid.NewGuid().ToString()
-                }, "delete function configuration",
-                new { ConfigName = toDelete.ConfigurationName, ConfigId = toDelete.Id });
+        await _configurationRepository.DeleteAsync(id);
+        LogAdminAudit("Deleted", "FunctionConfiguration", id, $"Name: {LoggingSanitizer.S(toDelete.ConfigurationName)}");
+        AdminOperationsMetricsService.RecordConfigurationChange("functionconfiguration", "delete");
 
-                return NoContent();
-            },
-            "FunctionConfiguration",
-            id,
-            "DeleteConfiguration");
+        // Publish FunctionConfigurationChanged event for cache invalidation
+        PublishEventFireAndForget(new FunctionConfigurationChanged
+        {
+            FunctionConfigurationId = toDelete.Id,
+            ConfigurationName = toDelete.ConfigurationName,
+            ProviderType = toDelete.ProviderType.ToString(),
+            Purpose = toDelete.Purpose.ToString(),
+            ChangeType = "Deleted",
+            ChangedProperties = new[] { "Deleted" },
+            IsEnabledChanged = false,
+            CacheTtlChanged = false,
+            CorrelationId = Guid.NewGuid().ToString()
+        }, "delete function configuration",
+        new { ConfigName = toDelete.ConfigurationName, ConfigId = toDelete.Id });
+
+        return NoContent();
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/FunctionCostsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionCostsController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Functions.DTOs;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class FunctionCostsController : AdminControllerBase
 {
     private readonly IFunctionCostService _functionCostService;
@@ -37,16 +39,10 @@ public class FunctionCostsController : AdminControllerBase
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAllFunctionCosts()
+    public async Task<IActionResult> GetAllFunctionCosts()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var functionCosts = await _functionCostService.ListCostsAsync();
-                return functionCosts.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetAllFunctionCosts");
+        var functionCosts = await _functionCostService.ListCostsAsync();
+        return Ok(functionCosts.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -58,18 +54,15 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetFunctionCostById(int id)
+    public async Task<IActionResult> GetFunctionCostById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            async () =>
-            {
-                var functionCost = await _functionCostService.GetCostByIdAsync(id);
-                return functionCost?.ToDto();
-            },
-            Ok,
-            "Function cost",
-            id,
-            "GetFunctionCostById");
+        var functionCost = await _functionCostService.GetCostByIdAsync(id);
+        var dto = functionCost?.ToDto();
+        if (dto == null)
+        {
+            return this.NotFoundEntity("Function cost", id);
+        }
+        return Ok(dto);
     }
 
     /// <summary>
@@ -81,19 +74,16 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetCostForConfiguration(int functionConfigurationId)
+    public async Task<IActionResult> GetCostForConfiguration(int functionConfigurationId)
     {
-        return ExecuteWithNotFoundAsync(
-            async () =>
-            {
-                var functionCost = await _functionCostService.GetCostForConfigurationAsync(
-                    functionConfigurationId);
-                return functionCost?.ToDto();
-            },
-            Ok,
-            "Function cost for configuration",
-            functionConfigurationId,
-            "GetCostForConfiguration");
+        var functionCost = await _functionCostService.GetCostForConfigurationAsync(
+            functionConfigurationId);
+        var dto = functionCost?.ToDto();
+        if (dto == null)
+        {
+            return this.NotFoundEntity("Function cost for configuration", functionConfigurationId);
+        }
+        return Ok(dto);
     }
 
     /// <summary>
@@ -105,32 +95,26 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateFunctionCost(
+    public async Task<IActionResult> CreateFunctionCost(
         [FromBody] CreateFunctionCostDto createDto)
     {
         if (createDto == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function cost data is required")));
+            return BadRequest(new ErrorResponseDto("Function cost data is required"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                var entity = MapToEntity(createDto);
-                int id = await _functionCostService.CreateCostAsync(entity);
+        var entity = MapToEntity(createDto);
+        int id = await _functionCostService.CreateCostAsync(entity);
 
-                // Fetch the created entity to return as DTO
-                var created = await _functionCostService.GetCostByIdAsync(id);
-                var dto = created?.ToDto();
+        // Fetch the created entity to return as DTO
+        var created = await _functionCostService.GetCostByIdAsync(id);
+        var dto = created?.ToDto();
 
-                LogAdminAudit("Created", "FunctionCost", id, $"CostName: {LoggingSanitizer.S(createDto.CostName)}");
-                return (id, dto);
-            },
-            result => CreatedAtAction(
-                nameof(GetFunctionCostById),
-                new { id = result.id },
-                result.dto),
-            "CreateFunctionCost");
+        LogAdminAudit("Created", "FunctionCost", id, $"CostName: {LoggingSanitizer.S(createDto.CostName)}");
+        return CreatedAtAction(
+            nameof(GetFunctionCostById),
+            new { id },
+            dto);
     }
 
     /// <summary>
@@ -144,42 +128,35 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateFunctionCost(
+    public async Task<IActionResult> UpdateFunctionCost(
         int id,
         [FromBody] UpdateFunctionCostDto updateDto)
     {
         if (updateDto == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function cost data is required")));
+            return BadRequest(new ErrorResponseDto("Function cost data is required"));
         }
 
         if (id != updateDto.Id)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("ID mismatch")));
+            return BadRequest(new ErrorResponseDto("ID mismatch"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                // Get existing entity to preserve fields not in update DTO
-                var existing = await _functionCostService.GetCostByIdAsync(id);
-                if (existing == null)
-                {
-                    throw new KeyNotFoundException();
-                }
+        // Get existing entity to preserve fields not in update DTO
+        var existing = await _functionCostService.GetCostByIdAsync(id);
+        if (existing == null)
+        {
+            throw new KeyNotFoundException();
+        }
 
-                // Map update DTO to entity, preserving ProviderType from existing
-                var entity = MapToEntity(updateDto, existing);
-                await _functionCostService.UpdateCostAsync(entity);
+        // Map update DTO to entity, preserving ProviderType from existing
+        var entity = MapToEntity(updateDto, existing);
+        await _functionCostService.UpdateCostAsync(entity);
 
-                // Fetch the updated entity to return
-                var updated = await _functionCostService.GetCostByIdAsync(id);
-                LogAdminAudit("Updated", "FunctionCost", id, $"CostName: {LoggingSanitizer.S(updateDto.CostName)}");
-                return updated?.ToDto();
-            },
-            dto => Ok(dto),
-            "UpdateFunctionCost",
-            new { Id = id });
+        // Fetch the updated entity to return
+        var updated = await _functionCostService.GetCostByIdAsync(id);
+        LogAdminAudit("Updated", "FunctionCost", id, $"CostName: {LoggingSanitizer.S(updateDto.CostName)}");
+        return Ok(updated?.ToDto());
     }
 
     /// <summary>
@@ -191,18 +168,12 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteFunctionCost(int id)
+    public async Task<IActionResult> DeleteFunctionCost(int id)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var existing = await _functionCostService.GetCostByIdAsync(id);
-                await _functionCostService.DeleteCostAsync(id);
-                LogAdminAudit("Deleted", "FunctionCost", id, existing != null ? $"CostName: {LoggingSanitizer.S(existing.CostName)}" : null);
-            },
-            NoContent(),
-            "DeleteFunctionCost",
-            new { Id = id });
+        var existing = await _functionCostService.GetCostByIdAsync(id);
+        await _functionCostService.DeleteCostAsync(id);
+        LogAdminAudit("Deleted", "FunctionCost", id, existing != null ? $"CostName: {LoggingSanitizer.S(existing.CostName)}" : null);
+        return NoContent();
     }
 
     /// <summary>
@@ -212,17 +183,11 @@ public class FunctionCostsController : AdminControllerBase
     [HttpPost("cache/clear")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> ClearCache()
+    public async Task<IActionResult> ClearCache()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                await _functionCostService.ClearCacheAsync();
-                LogAdminAudit("Cleared", "FunctionCostCache");
-                return new { message = "Function cost cache cleared successfully" };
-            },
-            Ok,
-            "ClearCache");
+        await _functionCostService.ClearCacheAsync();
+        LogAdminAudit("Cleared", "FunctionCostCache");
+        return Ok(new { message = "Function cost cache cleared successfully" });
     }
 
     // Mapping methods

--- a/Services/ConduitLLM.Admin/Controllers/FunctionCredentialsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionCredentialsController.cs
@@ -1,3 +1,5 @@
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Functions.Interfaces;
@@ -12,6 +14,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class FunctionCredentialsController : AdminControllerBase
 {
     private readonly IFunctionCredentialRepository _credentialRepository;
@@ -40,12 +43,10 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAllCredentials()
+    public async Task<IActionResult> GetAllCredentials()
     {
-        return ExecuteAsync(
-            () => _credentialRepository.GetAllUnboundedAsync(),
-            Ok,
-            "GetAllCredentials");
+        var credentials = await _credentialRepository.GetAllUnboundedAsync();
+        return Ok(credentials);
     }
 
     /// <summary>
@@ -57,25 +58,19 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetCredentialsByConfiguration(int functionConfigurationId)
+    public async Task<IActionResult> GetCredentialsByConfiguration(int functionConfigurationId)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // Get the configuration to determine its provider type
-                var configuration = await _configurationRepository.GetByIdAsync(functionConfigurationId);
-                if (configuration == null)
-                {
-                    throw new KeyNotFoundException();
-                }
+        // Get the configuration to determine its provider type
+        var configuration = await _configurationRepository.GetByIdAsync(functionConfigurationId);
+        if (configuration == null)
+        {
+            throw new KeyNotFoundException();
+        }
 
-                // Get credentials for this provider type
-                return await _credentialRepository.GetByProviderTypeAsync(
-                    configuration.ProviderType);
-            },
-            Ok,
-            "GetCredentialsByConfiguration",
-            new { FunctionConfigurationId = functionConfigurationId });
+        // Get credentials for this provider type
+        var credentials = await _credentialRepository.GetByProviderTypeAsync(
+            configuration.ProviderType);
+        return Ok(credentials);
     }
 
     /// <summary>
@@ -87,14 +82,14 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetCredentialById(int id)
+    public async Task<IActionResult> GetCredentialById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _credentialRepository.GetByIdAsync(id),
-            Ok,
-            "Function credential",
-            id,
-            "GetCredentialById");
+        var credential = await _credentialRepository.GetByIdAsync(id);
+        if (credential == null)
+        {
+            return this.NotFoundEntity("Function credential", id);
+        }
+        return Ok(credential);
     }
 
     /// <summary>
@@ -106,33 +101,24 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateCredential(
+    public async Task<IActionResult> CreateCredential(
         [FromBody] ConduitLLM.Functions.Entities.FunctionCredential credential)
     {
         if (credential == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function credential data is required")));
+            return BadRequest(new ErrorResponseDto("Function credential data is required"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                int id = await _credentialRepository.CreateAsync(credential);
+        int id = await _credentialRepository.CreateAsync(credential);
 
-                // Fetch the created entity to return
-                var created = await _credentialRepository.GetByIdAsync(id);
+        // Fetch the created entity to return
+        var created = await _credentialRepository.GetByIdAsync(id);
 
-                return (id, created);
-            },
-            result =>
-            {
-                LogAdminAudit("Created", "FunctionCredential", result.id, $"ProviderType: {credential.ProviderType}");
-                return CreatedAtAction(
-                    nameof(GetCredentialById),
-                    new { id = result.id },
-                    result.created);
-            },
-            "CreateCredential");
+        LogAdminAudit("Created", "FunctionCredential", id, $"ProviderType: {credential.ProviderType}");
+        return CreatedAtAction(
+            nameof(GetCredentialById),
+            new { id },
+            created);
     }
 
     /// <summary>
@@ -146,42 +132,32 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateCredential(
+    public async Task<IActionResult> UpdateCredential(
         int id,
         [FromBody] ConduitLLM.Functions.Entities.FunctionCredential credential)
     {
         if (credential == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Function credential data is required")));
+            return BadRequest(new ErrorResponseDto("Function credential data is required"));
         }
 
         if (id != credential.Id)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("ID mismatch")));
+            return BadRequest(new ErrorResponseDto("ID mismatch"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                await _credentialRepository.UpdateAsync(credential);
+        await _credentialRepository.UpdateAsync(credential);
 
-                // Fetch the updated entity to return
-                var updated = await _credentialRepository.GetByIdAsync(id);
+        // Fetch the updated entity to return
+        var updated = await _credentialRepository.GetByIdAsync(id);
 
-                if (updated == null)
-                {
-                    throw new KeyNotFoundException();
-                }
+        if (updated == null)
+        {
+            throw new KeyNotFoundException();
+        }
 
-                return updated;
-            },
-            result =>
-            {
-                LogAdminAudit("Updated", "FunctionCredential", id, $"ProviderType: {credential.ProviderType}");
-                return Ok(result);
-            },
-            "UpdateCredential",
-            new { Id = id });
+        LogAdminAudit("Updated", "FunctionCredential", id, $"ProviderType: {credential.ProviderType}");
+        return Ok(updated);
     }
 
     /// <summary>
@@ -193,18 +169,12 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteCredential(int id)
+    public async Task<IActionResult> DeleteCredential(int id)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var credential = await _credentialRepository.GetByIdAsync(id);
-                await _credentialRepository.DeleteAsync(id);
-                LogAdminAudit("Deleted", "FunctionCredential", id, credential != null ? $"ProviderType: {credential.ProviderType}" : null);
-            },
-            NoContent(),
-            "DeleteCredential",
-            new { Id = id });
+        var credential = await _credentialRepository.GetByIdAsync(id);
+        await _credentialRepository.DeleteAsync(id);
+        LogAdminAudit("Deleted", "FunctionCredential", id, credential != null ? $"ProviderType: {credential.ProviderType}" : null);
+        return NoContent();
     }
 
     /// <summary>
@@ -216,49 +186,43 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> TestCredential([FromBody] TestCredentialRequest testRequest)
+    public async Task<IActionResult> TestCredential([FromBody] TestCredentialRequest testRequest)
     {
         if (testRequest == null)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Test request data is required")));
+            return BadRequest(new ErrorResponseDto("Test request data is required"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                // Get the credential
-                var credential = await _credentialRepository.GetByIdAsync(testRequest.CredentialId);
-                if (credential == null)
-                {
-                    throw new KeyNotFoundException();
-                }
+        // Get the credential
+        var credential = await _credentialRepository.GetByIdAsync(testRequest.CredentialId);
+        if (credential == null)
+        {
+            throw new KeyNotFoundException();
+        }
 
-                // Get any configuration that uses this provider type (for client factory)
-                var configurations = await _configurationRepository.GetByProviderTypeAsync(credential.ProviderType);
-                var configuration = configurations.FirstOrDefault();
-                if (configuration == null)
-                {
-                    throw new KeyNotFoundException();
-                }
+        // Get any configuration that uses this provider type (for client factory)
+        var configurations = await _configurationRepository.GetByProviderTypeAsync(credential.ProviderType);
+        var configuration = configurations.FirstOrDefault();
+        if (configuration == null)
+        {
+            throw new KeyNotFoundException();
+        }
 
-                // Create client and test authentication
-                var client = await _clientFactory.GetClientAsync(
-                    credential.ProviderType,
-                    configuration.Id);
+        // Create client and test authentication
+        var client = await _clientFactory.GetClientAsync(
+            credential.ProviderType,
+            configuration.Id);
 
-                var authResult = await client.VerifyAuthenticationAsync(
-                    testRequest.ApiKeyOverride ?? credential.ApiKey);
+        var authResult = await client.VerifyAuthenticationAsync(
+            testRequest.ApiKeyOverride ?? credential.ApiKey);
 
-                return new
-                {
-                    success = authResult.IsSuccess,
-                    message = authResult.Message,
-                    details = authResult.Details,
-                    durationMs = authResult.ResponseTimeMs
-                };
-            },
-            Ok,
-            "TestCredential");
+        return Ok(new
+        {
+            success = authResult.IsSuccess,
+            message = authResult.Message,
+            details = authResult.Details,
+            durationMs = authResult.ResponseTimeMs
+        });
     }
 
     /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/FunctionExecutionsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionExecutionsController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Functions.DTOs;
@@ -16,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class FunctionExecutionsController : AdminControllerBase
 {
     private readonly IFunctionExecutionRepository _executionRepository;
@@ -40,18 +42,15 @@ public class FunctionExecutionsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetExecutionById(Guid id)
+    public async Task<IActionResult> GetExecutionById(Guid id)
     {
-        return ExecuteWithNotFoundAsync(
-            async () =>
-            {
-                var execution = await _executionRepository.GetByIdAsync(id);
-                return execution?.ToDto();
-            },
-            Ok,
-            "Function execution",
-            id,
-            "GetExecutionById");
+        var execution = await _executionRepository.GetByIdAsync(id);
+        if (execution == null)
+        {
+            return this.NotFoundEntity("Function execution", id);
+        }
+
+        return Ok(execution.ToDto());
     }
 
     /// <summary>
@@ -62,17 +61,10 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("virtualkey/{virtualKeyId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetExecutionsByVirtualKey(int virtualKeyId)
+    public async Task<IActionResult> GetExecutionsByVirtualKey(int virtualKeyId)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var executions = await _executionRepository.GetByVirtualKeyIdAsync(virtualKeyId);
-                return executions.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetExecutionsByVirtualKey",
-            new { VirtualKeyId = virtualKeyId });
+        var executions = await _executionRepository.GetByVirtualKeyIdAsync(virtualKeyId);
+        return Ok(executions.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -83,18 +75,11 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("configuration/{functionConfigurationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetExecutionsByConfiguration(int functionConfigurationId)
+    public async Task<IActionResult> GetExecutionsByConfiguration(int functionConfigurationId)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var executions = await _executionRepository.GetByFunctionConfigurationIdAsync(
-                    functionConfigurationId);
-                return executions.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetExecutionsByConfiguration",
-            new { FunctionConfigurationId = functionConfigurationId });
+        var executions = await _executionRepository.GetByFunctionConfigurationIdAsync(
+            functionConfigurationId);
+        return Ok(executions.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -106,22 +91,15 @@ public class FunctionExecutionsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetExecutionsByState(string state)
+    public async Task<IActionResult> GetExecutionsByState(string state)
     {
         if (!Enum.TryParse<ExecutionState>(state, true, out var stateEnum))
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto($"Invalid execution state: {state}")));
+            return BadRequest(new ErrorResponseDto($"Invalid execution state: {state}"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                var executions = await _executionRepository.GetByStateAsync(stateEnum);
-                return executions.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetExecutionsByState",
-            new { State = state });
+        var executions = await _executionRepository.GetByStateAsync(stateEnum);
+        return Ok(executions.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -131,16 +109,10 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("expired-leases")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetExpiredLeases()
+    public async Task<IActionResult> GetExpiredLeases()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var executions = await _executionRepository.GetExpiredLeasesAsync();
-                return executions.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetExpiredLeases");
+        var executions = await _executionRepository.GetExpiredLeasesAsync();
+        return Ok(executions.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -150,16 +122,10 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("ready-for-retry")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetReadyForRetry()
+    public async Task<IActionResult> GetReadyForRetry()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var executions = await _executionRepository.GetReadyForRetryAsync();
-                return executions.Select(e => e.ToDto()).ToList();
-            },
-            Ok,
-            "GetReadyForRetry");
+        var executions = await _executionRepository.GetReadyForRetryAsync();
+        return Ok(executions.Select(e => e.ToDto()).ToList());
     }
 
     /// <summary>
@@ -171,31 +137,24 @@ public class FunctionExecutionsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CleanupOldExecutions([FromQuery] int olderThanDays = 30)
+    public async Task<IActionResult> CleanupOldExecutions([FromQuery] int olderThanDays = 30)
     {
         if (olderThanDays < 1)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("olderThanDays must be at least 1")));
+            return BadRequest(new ErrorResponseDto("olderThanDays must be at least 1"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                var olderThan = DateTime.UtcNow.AddDays(-olderThanDays);
-                var deletedCount = await _executionRepository.DeleteOldExecutionsAsync(olderThan);
+        var olderThan = DateTime.UtcNow.AddDays(-olderThanDays);
+        var deletedCount = await _executionRepository.DeleteOldExecutionsAsync(olderThan);
 
-                LogAdminAudit("Cleanup", "FunctionExecution",
-                    detail: $"OlderThanDays: {olderThanDays}, DeletedCount: {deletedCount}");
+        LogAdminAudit("Cleanup", "FunctionExecution",
+            detail: $"OlderThanDays: {olderThanDays}, DeletedCount: {deletedCount}");
 
-                return new
-                {
-                    deletedCount,
-                    message = $"Deleted {deletedCount} executions older than {olderThanDays} days"
-                };
-            },
-            Ok,
-            "CleanupOldExecutions",
-            new { OlderThanDays = olderThanDays });
+        return Ok(new
+        {
+            deletedCount,
+            message = $"Deleted {deletedCount} executions older than {olderThanDays} days"
+        });
     }
 
 }

--- a/Services/ConduitLLM.Admin/Controllers/GlobalSettingsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/GlobalSettingsController.cs
@@ -1,4 +1,6 @@
 using ConduitLLM.Core.Extensions;
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
@@ -15,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class GlobalSettingsController : AdminControllerBase
     {
         private readonly IAdminGlobalSettingService _globalSettingService;
@@ -43,12 +46,10 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<GlobalSettingDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllSettings()
+        public async Task<IActionResult> GetAllSettings()
         {
-            return ExecuteAsync(
-                () => _globalSettingService.GetAllSettingsAsync(),
-                Ok,
-                "GetAllSettings");
+            var settings = await _globalSettingService.GetAllSettingsAsync();
+            return Ok(settings);
         }
 
         /// <summary>
@@ -60,14 +61,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetSettingById(int id)
+        public async Task<IActionResult> GetSettingById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _globalSettingService.GetSettingByIdAsync(id),
-                Ok,
-                "Global setting",
-                id,
-                "GetSettingById");
+            var setting = await _globalSettingService.GetSettingByIdAsync(id);
+            if (setting == null)
+            {
+                return this.NotFoundEntity("Global setting", id);
+            }
+            return Ok(setting);
         }
 
         /// <summary>
@@ -79,14 +80,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetSettingByKey(string key)
+        public async Task<IActionResult> GetSettingByKey(string key)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _globalSettingService.GetSettingByKeyAsync(key),
-                Ok,
-                "Global setting",
-                key,
-                "GetSettingByKey");
+            var setting = await _globalSettingService.GetSettingByKeyAsync(key);
+            if (setting == null)
+            {
+                return this.NotFoundEntity("Global setting", key);
+            }
+            return Ok(setting);
         }
 
         /// <summary>
@@ -98,17 +99,12 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateSetting([FromBody] CreateGlobalSettingDto setting)
+        public async Task<IActionResult> CreateSetting([FromBody] CreateGlobalSettingDto setting)
         {
-            return ExecuteAsync(
-                () => _globalSettingService.CreateSettingAsync(setting),
-                createdSetting =>
-                {
-                    LogAdminAudit("Created", "GlobalSetting", createdSetting.Id, $"Key: {LoggingSanitizer.S(setting.Key)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "create");
-                    return CreatedAtAction(nameof(GetSettingById), new { id = createdSetting.Id }, createdSetting);
-                },
-                "CreateSetting");
+            var createdSetting = await _globalSettingService.CreateSettingAsync(setting);
+            LogAdminAudit("Created", "GlobalSetting", createdSetting.Id, $"Key: {LoggingSanitizer.S(setting.Key)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "create");
+            return CreatedAtAction(nameof(GetSettingById), new { id = createdSetting.Id }, createdSetting);
         }
 
         /// <summary>
@@ -122,47 +118,42 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateSetting(int id, [FromBody] UpdateGlobalSettingDto setting)
+        public async Task<IActionResult> UpdateSetting(int id, [FromBody] UpdateGlobalSettingDto setting)
         {
             // Ensure ID in route matches ID in body
             if (id != setting.Id)
             {
-                return Task.FromResult<IActionResult>(BadRequest("ID in route must match ID in body"));
+                return BadRequest("ID in route must match ID in body");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Fetch pre-state for change tracking
-                    var preState = await _globalSettingService.GetSettingByIdAsync(id);
-                    if (preState == null)
-                        throw new KeyNotFoundException();
+            // Fetch pre-state for change tracking
+            var preState = await _globalSettingService.GetSettingByIdAsync(id);
+            if (preState == null)
+                throw new KeyNotFoundException();
 
-                    if (!await _globalSettingService.UpdateSettingAsync(setting))
-                        throw new KeyNotFoundException();
+            if (!await _globalSettingService.UpdateSettingAsync(setting))
+                throw new KeyNotFoundException();
 
-                    // Build change list from pre-state vs request
-                    var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+            // Build change list from pre-state vs request
+            var changes = new List<(string Property, string? OldValue, string? NewValue)>();
 
-                    if (setting.Value != null && preState.Value != setting.Value)
-                        changes.Add(("Value", preState.Value, setting.Value));
-                    if (setting.Description != null && preState.Description != setting.Description)
-                        changes.Add(("Description", preState.Description, setting.Description));
+            if (setting.Value != null && preState.Value != setting.Value)
+                changes.Add(("Value", preState.Value, setting.Value));
+            if (setting.Description != null && preState.Description != setting.Description)
+                changes.Add(("Description", preState.Description, setting.Description));
 
-                    if (changes.Count > 0)
-                    {
-                        LogAdminAuditWithChanges("GlobalSetting", id, changes,
-                            $"Key: {LoggingSanitizer.S(preState.Key)}");
-                    }
-                    else
-                    {
-                        LogAdminAudit("Updated", "GlobalSetting", id);
-                    }
-                    AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "update");
-                },
-                NoContent(),
-                "UpdateSetting",
-                new { Id = id });
+            if (changes.Count > 0)
+            {
+                LogAdminAuditWithChanges("GlobalSetting", id, changes,
+                    $"Key: {LoggingSanitizer.S(preState.Key)}");
+            }
+            else
+            {
+                LogAdminAudit("Updated", "GlobalSetting", id);
+            }
+            AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "update");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -174,19 +165,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateSettingByKey([FromBody] UpdateGlobalSettingByKeyDto setting)
+        public async Task<IActionResult> UpdateSettingByKey([FromBody] UpdateGlobalSettingByKeyDto setting)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _globalSettingService.UpdateSettingByKeyAsync(setting))
-                        throw new InvalidOperationException("Failed to update or create global setting");
-                    LogAdminAudit("Updated", "GlobalSetting", detail: $"Key: {LoggingSanitizer.S(setting.Key)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "update");
-                },
-                NoContent(),
-                "UpdateSettingByKey",
-                new { Key = setting.Key });
+            if (!await _globalSettingService.UpdateSettingByKeyAsync(setting))
+                throw new InvalidOperationException("Failed to update or create global setting");
+            LogAdminAudit("Updated", "GlobalSetting", detail: $"Key: {LoggingSanitizer.S(setting.Key)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "update");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -198,19 +184,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteSetting(int id)
+        public async Task<IActionResult> DeleteSetting(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _globalSettingService.DeleteSettingAsync(id))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("Deleted", "GlobalSetting", id);
-                    AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "delete");
-                },
-                NoContent(),
-                "DeleteSetting",
-                new { Id = id });
+            if (!await _globalSettingService.DeleteSettingAsync(id))
+                throw new KeyNotFoundException();
+            LogAdminAudit("Deleted", "GlobalSetting", id);
+            AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "delete");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -222,19 +203,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteSettingByKey(string key)
+        public async Task<IActionResult> DeleteSettingByKey(string key)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _globalSettingService.DeleteSettingByKeyAsync(key))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("Deleted", "GlobalSetting", detail: $"Key: {LoggingSanitizer.S(key)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "delete");
-                },
-                NoContent(),
-                "DeleteSettingByKey",
-                new { Key = key });
+            if (!await _globalSettingService.DeleteSettingByKeyAsync(key))
+                throw new KeyNotFoundException();
+            LogAdminAudit("Deleted", "GlobalSetting", detail: $"Key: {LoggingSanitizer.S(key)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("globalsetting", "delete");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -244,25 +220,20 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("cache/stats")]
         [ProducesResponseType(typeof(GlobalSettingCacheStatsDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetCacheStats()
+        public async Task<IActionResult> GetCacheStats()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var stats = await _cacheService.GetCacheStatsAsync();
-                    return new GlobalSettingCacheStatsDto
-                    {
-                        CacheSize = (int)stats["CacheSize"],
-                        CacheHits = (long)stats["CacheHits"],
-                        CacheMisses = (long)stats["CacheMisses"],
-                        Invalidations = (long)stats["Invalidations"],
-                        HitRate = (double)stats["HitRate"],
-                        LastLoadTime = (DateTime)stats["LastLoadTime"],
-                        CachedKeys = (List<string>)stats["CachedKeys"]
-                    };
-                },
-                Ok,
-                "GetCacheStats");
+            var stats = await _cacheService.GetCacheStatsAsync();
+            var statsDto = new GlobalSettingCacheStatsDto
+            {
+                CacheSize = (int)stats["CacheSize"],
+                CacheHits = (long)stats["CacheHits"],
+                CacheMisses = (long)stats["CacheMisses"],
+                Invalidations = (long)stats["Invalidations"],
+                HitRate = (double)stats["HitRate"],
+                LastLoadTime = (DateTime)stats["LastLoadTime"],
+                CachedKeys = (List<string>)stats["CachedKeys"]
+            };
+            return Ok(statsDto);
         }
 
         /// <summary>
@@ -272,16 +243,12 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("cache/reload")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ReloadCache()
+        public async Task<IActionResult> ReloadCache()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    await _cacheService.ReloadAllSettingsAsync();
-                    LogAdminAudit("Reloaded", "GlobalSettingsCache");
-                },
-                NoContent(),
-                "ReloadCache");
+            await _cacheService.ReloadAllSettingsAsync();
+            LogAdminAudit("Reloaded", "GlobalSettingsCache");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -292,17 +259,12 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("cache/invalidate/{key}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> InvalidateCacheSetting(string key)
+        public async Task<IActionResult> InvalidateCacheSetting(string key)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    await _cacheService.InvalidateSettingAsync(key);
-                    LogAdminAudit("Invalidated", "GlobalSettingsCache", detail: $"Key: {LoggingSanitizer.S(key)}");
-                },
-                NoContent(),
-                "InvalidateCacheSetting",
-                new { Key = key });
+            await _cacheService.InvalidateSettingAsync(key);
+            LogAdminAudit("Invalidated", "GlobalSettingsCache", detail: $"Key: {LoggingSanitizer.S(key)}");
+
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/HealthMonitoringController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/HealthMonitoringController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration;
 
@@ -14,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers
     /// </summary>
     [ApiController]
     [Route("api/health")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class HealthMonitoringController : AdminControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -45,89 +47,83 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Service health information.</returns>
         [HttpGet("services")]
-        public Task<IActionResult> GetServiceHealth(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetServiceHealth(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var services = new List<object>();
+
+            // Gateway API Service
+            services.Add(new
+            {
+                Id = "core-api",
+                Name = "Gateway API",
+                Status = "healthy",
+                Uptime = GetProcessUptime(),
+                LastCheck = DateTime.UtcNow,
+                ResponseTime = 15,
+                Details = new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+                    Version = typeof(HealthMonitoringController).Assembly.GetName().Version?.ToString() ?? "unknown",
+                    Environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production",
+                    RequestsHandled = await dbContext.RequestLogs
+                        .CountAsync(r => r.Timestamp >= DateTime.UtcNow.AddHours(-1), cancellationToken)
+                }
+            });
 
-                    var services = new List<object>();
+            // Admin API Service
+            services.Add(new
+            {
+                Id = "admin-api",
+                Name = "Admin API",
+                Status = "healthy",
+                Uptime = GetProcessUptime(),
+                LastCheck = DateTime.UtcNow,
+                ResponseTime = 10,
+                Details = new
+                {
+                    ActiveSessions = 1, // Current session
+                    ConfiguredKeys = await dbContext.VirtualKeys.CountAsync(cancellationToken)
+                }
+            });
 
-                    // Gateway API Service
-                    services.Add(new
-                    {
-                        Id = "core-api",
-                        Name = "Gateway API",
-                        Status = "healthy",
-                        Uptime = GetProcessUptime(),
-                        LastCheck = DateTime.UtcNow,
-                        ResponseTime = 15,
-                        Details = new
-                        {
-                            Version = typeof(HealthMonitoringController).Assembly.GetName().Version?.ToString() ?? "unknown",
-                            Environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production",
-                            RequestsHandled = await dbContext.RequestLogs
-                                .CountAsync(r => r.Timestamp >= DateTime.UtcNow.AddHours(-1), cancellationToken)
-                        }
-                    });
-
-                    // Admin API Service
-                    services.Add(new
-                    {
-                        Id = "admin-api",
-                        Name = "Admin API",
-                        Status = "healthy",
-                        Uptime = GetProcessUptime(),
-                        LastCheck = DateTime.UtcNow,
-                        ResponseTime = 10,
-                        Details = new
-                        {
-                            ActiveSessions = 1, // Current session
-                            ConfiguredKeys = await dbContext.VirtualKeys.CountAsync(cancellationToken)
-                        }
-                    });
-
-                    // Database Service
-                    var dbHealthCheck = await CheckDatabaseHealth(dbContext, cancellationToken);
-                    services.Add(new
-                    {
-                        Id = "database",
-                        Name = "PostgreSQL Database",
-                        Status = dbHealthCheck.IsHealthy ? "healthy" : "unhealthy",
-                        Uptime = TimeSpan.FromDays(30), // Would need actual DB uptime
-                        LastCheck = DateTime.UtcNow,
-                        ResponseTime = dbHealthCheck.ResponseTime,
-                        Details = new
-                        {
-                            ConnectionPooling = true,
-                            ActiveConnections = 5, // Would need actual connection count
-                            DatabaseSize = await GetDatabaseSize(dbContext, cancellationToken)
-                        }
-                    });
+            // Database Service
+            var dbHealthCheck = await CheckDatabaseHealth(dbContext, cancellationToken);
+            services.Add(new
+            {
+                Id = "database",
+                Name = "PostgreSQL Database",
+                Status = dbHealthCheck.IsHealthy ? "healthy" : "unhealthy",
+                Uptime = TimeSpan.FromDays(30), // Would need actual DB uptime
+                LastCheck = DateTime.UtcNow,
+                ResponseTime = dbHealthCheck.ResponseTime,
+                Details = new
+                {
+                    ConnectionPooling = true,
+                    ActiveConnections = 5, // Would need actual connection count
+                    DatabaseSize = await GetDatabaseSize(dbContext, cancellationToken)
+                }
+            });
 
 
-                    // Calculate overall health
-                    var healthyCount = services.Count(s => ((dynamic)s).Status == "healthy");
-                    var degradedCount = services.Count(s => ((dynamic)s).Status == "degraded");
-                    var unhealthyCount = services.Count(s => ((dynamic)s).Status == "unhealthy");
+            // Calculate overall health
+            var healthyCount = services.Count(s => ((dynamic)s).Status == "healthy");
+            var degradedCount = services.Count(s => ((dynamic)s).Status == "degraded");
+            var unhealthyCount = services.Count(s => ((dynamic)s).Status == "unhealthy");
 
-                    return new
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        OverallStatus = unhealthyCount > 0 ? "unhealthy" : (degradedCount > 0 ? "degraded" : "healthy"),
-                        Summary = new
-                        {
-                            Healthy = healthyCount,
-                            Degraded = degradedCount,
-                            Unhealthy = unhealthyCount,
-                            Total = services.Count
-                        },
-                        Services = services
-                    };
+            return Ok(new
+            {
+                Timestamp = DateTime.UtcNow,
+                OverallStatus = unhealthyCount > 0 ? "unhealthy" : (degradedCount > 0 ? "degraded" : "healthy"),
+                Summary = new
+                {
+                    Healthy = healthyCount,
+                    Degraded = degradedCount,
+                    Unhealthy = unhealthyCount,
+                    Total = services.Count
                 },
-                result => Ok(result),
-                "GetServiceHealth");
+                Services = services
+            });
         }
 
         /// <summary>
@@ -137,85 +133,79 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Incident history data.</returns>
         [HttpGet("incidents")]
-        public Task<IActionResult> GetIncidents(
+        public async Task<IActionResult> GetIncidents(
             [FromQuery] int days = 7,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var startDate = DateTime.UtcNow.AddDays(-days);
+
+            // Analyze request logs for incidents
+            var errorSpikes = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= startDate && r.StatusCode >= 400)
+                .GroupBy(r => new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+                    Date = r.Timestamp.Date,
+                    Hour = r.Timestamp.Hour,
+                    Model = r.ModelName
+                })
+                .Select(g => new
+                {
+                    Date = g.Key.Date,
+                    Hour = g.Key.Hour,
+                    Service = g.Key.Model, // Using ModelName as service identifier
+                    ErrorCount = g.Count(),
+                    ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
+                })
+                .Where(g => g.ErrorCount >= 10) // Threshold for incident
+                .ToListAsync(cancellationToken);
 
-                    var startDate = DateTime.UtcNow.AddDays(-days);
+            // Convert to incidents
+            var incidents = errorSpikes.Select(spike => new
+            {
+                Id = Guid.NewGuid().ToString(),
+                Title = $"{spike.Service} Service Degradation",
+                Type = "service_degradation",
+                Severity = spike.ErrorCount >= 50 ? "critical" : (spike.ErrorCount >= 25 ? "major" : "minor"),
+                Status = spike.Date.Date == DateTime.UtcNow.Date ? "active" : "resolved",
+                StartTime = new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 0, 0),
+                EndTime = spike.Date.Date == DateTime.UtcNow.Date ? (DateTime?)null :
+                         new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 59, 59),
+                AffectedService = spike.Service,
+                Impact = $"{spike.ErrorCount} errors in 1 hour period",
+                Details = new
+                {
+                    ErrorCount = spike.ErrorCount,
+                    UniqueErrorTypes = spike.ErrorTypes
+                }
+            }).ToList();
 
-                    // Analyze request logs for incidents
-                    var errorSpikes = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= startDate && r.StatusCode >= 400)
-                        .GroupBy(r => new
-                        {
-                            Date = r.Timestamp.Date,
-                            Hour = r.Timestamp.Hour,
-                            Model = r.ModelName
-                        })
-                        .Select(g => new
-                        {
-                            Date = g.Key.Date,
-                            Hour = g.Key.Hour,
-                            Service = g.Key.Model, // Using ModelName as service identifier
-                            ErrorCount = g.Count(),
-                            ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
-                        })
-                        .Where(g => g.ErrorCount >= 10) // Threshold for incident
-                        .ToListAsync(cancellationToken);
+            // Health failures removed - no longer tracking provider health
 
-                    // Convert to incidents
-                    var incidents = errorSpikes.Select(spike => new
-                    {
-                        Id = Guid.NewGuid().ToString(),
-                        Title = $"{spike.Service} Service Degradation",
-                        Type = "service_degradation",
-                        Severity = spike.ErrorCount >= 50 ? "critical" : (spike.ErrorCount >= 25 ? "major" : "minor"),
-                        Status = spike.Date.Date == DateTime.UtcNow.Date ? "active" : "resolved",
-                        StartTime = new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 0, 0),
-                        EndTime = spike.Date.Date == DateTime.UtcNow.Date ? (DateTime?)null :
-                                 new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 59, 59),
-                        AffectedService = spike.Service,
-                        Impact = $"{spike.ErrorCount} errors in 1 hour period",
-                        Details = new
-                        {
-                            ErrorCount = spike.ErrorCount,
-                            UniqueErrorTypes = spike.ErrorTypes
-                        }
-                    }).ToList();
+            var allIncidents = incidents
+                .Cast<object>()
+                .OrderByDescending(i => ((dynamic)i).StartTime)
+                .ToList();
 
-                    // Health failures removed - no longer tracking provider health
-
-                    var allIncidents = incidents
-                        .Cast<object>()
-                        .OrderByDescending(i => ((dynamic)i).StartTime)
-                        .ToList();
-
-                    return new
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        TimeRange = new { Start = startDate, End = DateTime.UtcNow },
-                        TotalIncidents = allIncidents.Count,
-                        ActiveIncidents = allIncidents.Count(i => ((dynamic)i).Status == "active"),
-                        IncidentsByType = allIncidents.GroupBy(i => ((dynamic)i).Type).Select(g => new
-                        {
-                            Type = g.Key,
-                            Count = g.Count()
-                        }),
-                        IncidentsBySeverity = allIncidents.GroupBy(i => ((dynamic)i).Severity).Select(g => new
-                        {
-                            Severity = g.Key,
-                            Count = g.Count()
-                        }),
-                        Incidents = allIncidents
-                    };
-                },
-                result => Ok(result),
-                "GetIncidents");
+            return Ok(new
+            {
+                Timestamp = DateTime.UtcNow,
+                TimeRange = new { Start = startDate, End = DateTime.UtcNow },
+                TotalIncidents = allIncidents.Count,
+                ActiveIncidents = allIncidents.Count(i => ((dynamic)i).Status == "active"),
+                IncidentsByType = allIncidents.GroupBy(i => ((dynamic)i).Type).Select(g => new
+                {
+                    Type = g.Key,
+                    Count = g.Count()
+                }),
+                IncidentsBySeverity = allIncidents.GroupBy(i => ((dynamic)i).Severity).Select(g => new
+                {
+                    Severity = g.Key,
+                    Count = g.Count()
+                }),
+                Incidents = allIncidents
+            });
         }
 
         /// <summary>
@@ -225,66 +215,60 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Health history time series.</returns>
         [HttpGet("history")]
-        public Task<IActionResult> GetHealthHistory(
+        public async Task<IActionResult> GetHealthHistory(
             [FromQuery] int hours = 24,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var startTime = DateTime.UtcNow.AddHours(-hours);
+            var intervalMinutes = hours <= 24 ? 15 : 60; // 15 min intervals for 24h, 1h for longer
+
+            var healthHistory = new List<object>();
+            var currentTime = startTime;
+
+            while (currentTime < DateTime.UtcNow)
+            {
+                var intervalEnd = currentTime.AddMinutes(intervalMinutes);
+
+                // Provider health tracking has been removed
+
+                // Get error rates for this interval
+                var errorStats = await dbContext.RequestLogs
+                    .Where(r => r.Timestamp >= currentTime && r.Timestamp < intervalEnd)
+                    .GroupBy(r => 1)
+                    .Select(g => new
+                    {
+                        TotalRequests = g.Count(),
+                        ErrorCount = g.Count(r => r.StatusCode >= 400),
+                        AvgLatency = g.Average(r => (double?)r.ResponseTimeMs) ?? 0
+                    })
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                healthHistory.Add(new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+                    Timestamp = currentTime,
+                    SystemHealth = errorStats?.TotalRequests > 0
+                        ? 100 - (errorStats.ErrorCount * 100.0 / errorStats.TotalRequests)
+                        : 100,
+                    ProviderHealth = 100, // Provider health tracking removed
+                    ResponseTime = errorStats?.AvgLatency ?? 0,
+                    RequestVolume = errorStats?.TotalRequests ?? 0,
+                    ErrorRate = errorStats?.TotalRequests > 0
+                        ? errorStats.ErrorCount * 100.0 / errorStats.TotalRequests
+                        : 0
+                });
 
-                    var startTime = DateTime.UtcNow.AddHours(-hours);
-                    var intervalMinutes = hours <= 24 ? 15 : 60; // 15 min intervals for 24h, 1h for longer
+                currentTime = intervalEnd;
+            }
 
-                    var healthHistory = new List<object>();
-                    var currentTime = startTime;
-
-                    while (currentTime < DateTime.UtcNow)
-                    {
-                        var intervalEnd = currentTime.AddMinutes(intervalMinutes);
-
-                        // Provider health tracking has been removed
-
-                        // Get error rates for this interval
-                        var errorStats = await dbContext.RequestLogs
-                            .Where(r => r.Timestamp >= currentTime && r.Timestamp < intervalEnd)
-                            .GroupBy(r => 1)
-                            .Select(g => new
-                            {
-                                TotalRequests = g.Count(),
-                                ErrorCount = g.Count(r => r.StatusCode >= 400),
-                                AvgLatency = g.Average(r => (double?)r.ResponseTimeMs) ?? 0
-                            })
-                            .FirstOrDefaultAsync(cancellationToken);
-
-                        healthHistory.Add(new
-                        {
-                            Timestamp = currentTime,
-                            SystemHealth = errorStats?.TotalRequests > 0
-                                ? 100 - (errorStats.ErrorCount * 100.0 / errorStats.TotalRequests)
-                                : 100,
-                            ProviderHealth = 100, // Provider health tracking removed
-                            ResponseTime = errorStats?.AvgLatency ?? 0,
-                            RequestVolume = errorStats?.TotalRequests ?? 0,
-                            ErrorRate = errorStats?.TotalRequests > 0
-                                ? errorStats.ErrorCount * 100.0 / errorStats.TotalRequests
-                                : 0
-                        });
-
-                        currentTime = intervalEnd;
-                    }
-
-                    return new
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        TimeRange = new { Start = startTime, End = DateTime.UtcNow },
-                        IntervalMinutes = intervalMinutes,
-                        History = healthHistory
-                    };
-                },
-                result => Ok(result),
-                "GetHealthHistory");
+            return Ok(new
+            {
+                Timestamp = DateTime.UtcNow,
+                TimeRange = new { Start = startTime, End = DateTime.UtcNow },
+                IntervalMinutes = intervalMinutes,
+                History = healthHistory
+            });
         }
 
         private async Task<(bool IsHealthy, int ResponseTime)> CheckDatabaseHealth(

--- a/Services/ConduitLLM.Admin/Controllers/IpFilterController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/IpFilterController.cs
@@ -1,4 +1,6 @@
 using ConduitLLM.Core.Extensions;
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration.DTOs.IpFilter;
 
@@ -13,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class IpFilterController : AdminControllerBase
 {
     private readonly IAdminIpFilterService _ipFilterService;
@@ -37,12 +40,10 @@ public class IpFilterController : AdminControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<IpFilterDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAllFilters()
+    public async Task<IActionResult> GetAllFilters()
     {
-        return ExecuteAsync(
-            () => _ipFilterService.GetAllFiltersAsync(),
-            Ok,
-            "GetAllFilters");
+        var filters = await _ipFilterService.GetAllFiltersAsync();
+        return Ok(filters);
     }
 
     /// <summary>
@@ -52,12 +53,10 @@ public class IpFilterController : AdminControllerBase
     [HttpGet("enabled")]
     [ProducesResponseType(typeof(IEnumerable<IpFilterDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetEnabledFilters()
+    public async Task<IActionResult> GetEnabledFilters()
     {
-        return ExecuteAsync(
-            () => _ipFilterService.GetEnabledFiltersAsync(),
-            Ok,
-            "GetEnabledFilters");
+        var filters = await _ipFilterService.GetEnabledFiltersAsync();
+        return Ok(filters);
     }
 
     /// <summary>
@@ -69,14 +68,14 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(typeof(IpFilterDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetFilterById(int id)
+    public async Task<IActionResult> GetFilterById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _ipFilterService.GetFilterByIdAsync(id),
-            Ok,
-            "IP filter",
-            id,
-            "GetFilterById");
+        var filter = await _ipFilterService.GetFilterByIdAsync(id);
+        if (filter == null)
+        {
+            return this.NotFoundEntity("IP filter", id);
+        }
+        return Ok(filter);
     }
 
     /// <summary>
@@ -91,26 +90,17 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateFilter([FromBody] CreateIpFilterDto filter)
+    public async Task<IActionResult> CreateFilter([FromBody] CreateIpFilterDto filter)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var (success, errorMessage, createdFilter) = await _ipFilterService.CreateFilterAsync(filter);
+        var (success, errorMessage, createdFilter) = await _ipFilterService.CreateFilterAsync(filter);
 
-                if (!success)
-                {
-                    throw new InvalidOperationException(errorMessage);
-                }
+        if (!success)
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
 
-                return createdFilter!;
-            },
-            createdFilter =>
-            {
-                LogAdminAudit("Created", "IpFilter", createdFilter.Id, $"CIDR: {LoggingSanitizer.S(filter.IpAddressOrCidr)}, Type: {filter.FilterType}");
-                return CreatedAtAction(nameof(GetFilterById), new { id = createdFilter.Id }, createdFilter);
-            },
-            "CreateFilter");
+        LogAdminAudit("Created", "IpFilter", createdFilter!.Id, $"CIDR: {LoggingSanitizer.S(filter.IpAddressOrCidr)}, Type: {filter.FilterType}");
+        return CreatedAtAction(nameof(GetFilterById), new { id = createdFilter.Id }, createdFilter);
     }
 
     /// <summary>
@@ -127,34 +117,28 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateFilter(int id, [FromBody] UpdateIpFilterDto filter)
+    public async Task<IActionResult> UpdateFilter(int id, [FromBody] UpdateIpFilterDto filter)
     {
         // Ensure ID in route matches ID in body
         if (id != filter.Id)
         {
-            return Task.FromResult<IActionResult>(BadRequest("ID in route must match ID in body"));
+            return BadRequest("ID in route must match ID in body");
         }
 
-        return ExecuteAsync(
-            async () =>
+        var (success, errorMessage) = await _ipFilterService.UpdateFilterAsync(filter);
+
+        if (!success)
+        {
+            if (errorMessage?.Contains("not found") == true)
             {
-                var (success, errorMessage) = await _ipFilterService.UpdateFilterAsync(filter);
+                throw new KeyNotFoundException(errorMessage);
+            }
 
-                if (!success)
-                {
-                    if (errorMessage?.Contains("not found") == true)
-                    {
-                        throw new KeyNotFoundException(errorMessage);
-                    }
+            throw new InvalidOperationException(errorMessage);
+        }
 
-                    throw new InvalidOperationException(errorMessage);
-                }
-
-                LogAdminAudit("Updated", "IpFilter", id, $"CIDR: {LoggingSanitizer.S(filter.IpAddressOrCidr)}, Type: {filter.FilterType}");
-            },
-            NoContent(),
-            "UpdateFilter",
-            new { Id = id });
+        LogAdminAudit("Updated", "IpFilter", id, $"CIDR: {LoggingSanitizer.S(filter.IpAddressOrCidr)}, Type: {filter.FilterType}");
+        return NoContent();
     }
 
     /// <summary>
@@ -169,28 +153,22 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteFilter(int id)
+    public async Task<IActionResult> DeleteFilter(int id)
     {
-        return ExecuteAsync(
-            async () =>
+        var (success, errorMessage) = await _ipFilterService.DeleteFilterAsync(id);
+
+        if (!success)
+        {
+            if (errorMessage?.Contains("not found") == true)
             {
-                var (success, errorMessage) = await _ipFilterService.DeleteFilterAsync(id);
+                throw new KeyNotFoundException(errorMessage);
+            }
 
-                if (!success)
-                {
-                    if (errorMessage?.Contains("not found") == true)
-                    {
-                        throw new KeyNotFoundException(errorMessage);
-                    }
+            throw new InvalidOperationException(errorMessage);
+        }
 
-                    throw new InvalidOperationException(errorMessage);
-                }
-
-                LogAdminAudit("Deleted", "IpFilter", id, $"Id: {id}");
-            },
-            NoContent(),
-            "DeleteFilter",
-            new { Id = id });
+        LogAdminAudit("Deleted", "IpFilter", id, $"Id: {id}");
+        return NoContent();
     }
 
     /// <summary>
@@ -200,12 +178,10 @@ public class IpFilterController : AdminControllerBase
     [HttpGet("settings")]
     [ProducesResponseType(typeof(IpFilterSettingsDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetSettings()
+    public async Task<IActionResult> GetSettings()
     {
-        return ExecuteAsync(
-            () => _ipFilterService.GetIpFilterSettingsAsync(),
-            Ok,
-            "GetSettings");
+        var settings = await _ipFilterService.GetIpFilterSettingsAsync();
+        return Ok(settings);
     }
 
     /// <summary>
@@ -220,22 +196,17 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateSettings([FromBody] IpFilterSettingsDto settings)
+    public async Task<IActionResult> UpdateSettings([FromBody] IpFilterSettingsDto settings)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var (success, errorMessage) = await _ipFilterService.UpdateIpFilterSettingsAsync(settings);
+        var (success, errorMessage) = await _ipFilterService.UpdateIpFilterSettingsAsync(settings);
 
-                if (!success)
-                {
-                    throw new InvalidOperationException(errorMessage);
-                }
+        if (!success)
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
 
-                LogAdminAudit("Updated", "IpFilterSettings", detail: $"Enabled: {settings.IsEnabled}, DefaultAllow: {settings.DefaultAllow}");
-            },
-            NoContent(),
-            "UpdateSettings");
+        LogAdminAudit("Updated", "IpFilterSettings", detail: $"Enabled: {settings.IsEnabled}, DefaultAllow: {settings.DefaultAllow}");
+        return NoContent();
     }
 
     /// <summary>
@@ -248,17 +219,14 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(typeof(IpCheckResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CheckIpAddress(string ipAddress)
+    public async Task<IActionResult> CheckIpAddress(string ipAddress)
     {
         if (string.IsNullOrWhiteSpace(ipAddress))
         {
-            return Task.FromResult<IActionResult>(BadRequest("IP address must be provided"));
+            return BadRequest("IP address must be provided");
         }
 
-        return ExecuteAsync(
-            () => _ipFilterService.CheckIpAddressAsync(ipAddress),
-            Ok,
-            "CheckIpAddress",
-            new { IpAddress = LoggingSanitizer.S(ipAddress) });
+        var result = await _ipFilterService.CheckIpAddressAsync(ipAddress);
+        return Ok(result);
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/MediaController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/MediaController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using ConduitLLM.Configuration.DTOs;
@@ -13,6 +14,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/admin/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class MediaController : AdminControllerBase
     {
         private readonly IAdminMediaService _mediaService;
@@ -40,13 +42,10 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="virtualKeyGroupId">Optional filter by virtual key group ID</param>
         /// <returns>Overall storage statistics.</returns>
         [HttpGet("stats")]
-        public Task<IActionResult> GetOverallStats([FromQuery] int? virtualKeyGroupId = null)
+        public async Task<IActionResult> GetOverallStats([FromQuery] int? virtualKeyGroupId = null)
         {
-            return ExecuteAsync(
-                () => _mediaService.GetOverallStorageStatsAsync(virtualKeyGroupId),
-                Ok,
-                "GetOverallStats",
-                new { VirtualKeyGroupId = virtualKeyGroupId });
+            var stats = await _mediaService.GetOverallStorageStatsAsync(virtualKeyGroupId);
+            return Ok(stats);
         }
 
         /// <summary>
@@ -55,13 +54,10 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="virtualKeyId">The ID of the virtual key.</param>
         /// <returns>Storage statistics for the virtual key.</returns>
         [HttpGet("stats/virtual-key/{virtualKeyId}")]
-        public Task<IActionResult> GetStatsByVirtualKey(int virtualKeyId)
+        public async Task<IActionResult> GetStatsByVirtualKey(int virtualKeyId)
         {
-            return ExecuteAsync(
-                () => _mediaService.GetStorageStatsByVirtualKeyAsync(virtualKeyId),
-                Ok,
-                "GetStatsByVirtualKey",
-                new { VirtualKeyId = virtualKeyId });
+            var stats = await _mediaService.GetStorageStatsByVirtualKeyAsync(virtualKeyId);
+            return Ok(stats);
         }
 
         /// <summary>
@@ -69,12 +65,10 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>Dictionary of provider names to storage size.</returns>
         [HttpGet("stats/by-provider")]
-        public Task<IActionResult> GetStatsByProvider()
+        public async Task<IActionResult> GetStatsByProvider()
         {
-            return ExecuteAsync(
-                () => _mediaService.GetStorageStatsByProviderAsync(),
-                Ok,
-                "GetStatsByProvider");
+            var stats = await _mediaService.GetStorageStatsByProviderAsync();
+            return Ok(stats);
         }
 
         /// <summary>
@@ -82,12 +76,10 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>Dictionary of media types to storage size.</returns>
         [HttpGet("stats/by-type")]
-        public Task<IActionResult> GetStatsByMediaType()
+        public async Task<IActionResult> GetStatsByMediaType()
         {
-            return ExecuteAsync(
-                () => _mediaService.GetStorageStatsByMediaTypeAsync(),
-                Ok,
-                "GetStatsByMediaType");
+            var stats = await _mediaService.GetStorageStatsByMediaTypeAsync();
+            return Ok(stats);
         }
 
         /// <summary>
@@ -96,13 +88,10 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="virtualKeyId">The ID of the virtual key.</param>
         /// <returns>List of media records.</returns>
         [HttpGet("virtual-key/{virtualKeyId}")]
-        public Task<IActionResult> GetMediaByVirtualKey(int virtualKeyId)
+        public async Task<IActionResult> GetMediaByVirtualKey(int virtualKeyId)
         {
-            return ExecuteAsync(
-                () => _mediaService.GetMediaByVirtualKeyAsync(virtualKeyId),
-                Ok,
-                "GetMediaByVirtualKey",
-                new { VirtualKeyId = virtualKeyId });
+            var media = await _mediaService.GetMediaByVirtualKeyAsync(virtualKeyId);
+            return Ok(media);
         }
 
         /// <summary>
@@ -111,18 +100,15 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="pattern">The pattern to search for in storage keys.</param>
         /// <returns>List of matching media records.</returns>
         [HttpGet("search")]
-        public Task<IActionResult> SearchMedia([FromQuery] string pattern)
+        public async Task<IActionResult> SearchMedia([FromQuery] string pattern)
         {
             if (string.IsNullOrWhiteSpace(pattern))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Search pattern is required")));
+                return BadRequest(new ErrorResponseDto("Search pattern is required"));
             }
 
-            return ExecuteAsync(
-                () => _mediaService.SearchMediaByStorageKeyAsync(pattern),
-                Ok,
-                "SearchMedia",
-                new { Pattern = pattern });
+            var media = await _mediaService.SearchMediaByStorageKeyAsync(pattern);
+            return Ok(media);
         }
 
         /// <summary>
@@ -131,18 +117,12 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="mediaId">The ID of the media record to delete.</param>
         /// <returns>Success status.</returns>
         [HttpDelete("{mediaId}")]
-        public Task<IActionResult> DeleteMedia(Guid mediaId)
+        public async Task<IActionResult> DeleteMedia(Guid mediaId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _mediaService.DeleteMediaAsync(mediaId))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("Deleted", "Media", mediaId);
-                },
-                Ok(new { message = "Media deleted successfully" }),
-                "DeleteMedia",
-                new { MediaId = mediaId });
+            if (!await _mediaService.DeleteMediaAsync(mediaId))
+                throw new KeyNotFoundException();
+            LogAdminAudit("Deleted", "Media", mediaId);
+            return Ok(new { message = "Media deleted successfully" });
         }
 
         /// <summary>
@@ -150,21 +130,15 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>Number of files cleaned up.</returns>
         [HttpPost("cleanup/expired")]
-        public Task<IActionResult> CleanupExpiredMedia()
+        public async Task<IActionResult> CleanupExpiredMedia()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var count = await _mediaService.CleanupExpiredMediaAsync();
-                    LogAdminAudit("CleanedUpExpired", "Media", detail: $"DeletedCount: {count}");
-                    return (object)new
-                    {
-                        message = $"Cleaned up {count} expired media files",
-                        deletedCount = count
-                    };
-                },
-                Ok,
-                "CleanupExpiredMedia");
+            var count = await _mediaService.CleanupExpiredMediaAsync();
+            LogAdminAudit("CleanedUpExpired", "Media", detail: $"DeletedCount: {count}");
+            return Ok(new
+            {
+                message = $"Cleaned up {count} expired media files",
+                deletedCount = count
+            });
         }
 
         /// <summary>
@@ -172,21 +146,15 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>Number of files cleaned up.</returns>
         [HttpPost("cleanup/orphaned")]
-        public Task<IActionResult> CleanupOrphanedMedia()
+        public async Task<IActionResult> CleanupOrphanedMedia()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var count = await _mediaService.CleanupOrphanedMediaAsync();
-                    LogAdminAudit("CleanedUpOrphaned", "Media", detail: $"DeletedCount: {count}");
-                    return (object)new
-                    {
-                        message = $"Cleaned up {count} orphaned media files",
-                        deletedCount = count
-                    };
-                },
-                Ok,
-                "CleanupOrphanedMedia");
+            var count = await _mediaService.CleanupOrphanedMediaAsync();
+            LogAdminAudit("CleanedUpOrphaned", "Media", detail: $"DeletedCount: {count}");
+            return Ok(new
+            {
+                message = $"Cleaned up {count} orphaned media files",
+                deletedCount = count
+            });
         }
 
         /// <summary>
@@ -195,27 +163,20 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="request">The pruning request with days to keep.</param>
         /// <returns>Number of files pruned.</returns>
         [HttpPost("cleanup/prune")]
-        public Task<IActionResult> PruneOldMedia([FromBody] PruneMediaRequest request)
+        public async Task<IActionResult> PruneOldMedia([FromBody] PruneMediaRequest request)
         {
             if (request?.DaysToKeep == null || request.DaysToKeep <= 0)
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("DaysToKeep must be a positive number")));
+                return BadRequest(new ErrorResponseDto("DaysToKeep must be a positive number"));
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var count = await _mediaService.PruneOldMediaAsync(request.DaysToKeep.Value);
-                    LogAdminAudit("Pruned", "Media", detail: $"DaysToKeep: {request.DaysToKeep}, DeletedCount: {count}");
-                    return (object)new
-                    {
-                        message = $"Pruned {count} media files older than {request.DaysToKeep} days",
-                        deletedCount = count
-                    };
-                },
-                Ok,
-                "PruneOldMedia",
-                new { DaysToKeep = request?.DaysToKeep });
+            var count = await _mediaService.PruneOldMediaAsync(request.DaysToKeep.Value);
+            LogAdminAudit("Pruned", "Media", detail: $"DaysToKeep: {request.DaysToKeep}, DeletedCount: {count}");
+            return Ok(new
+            {
+                message = $"Pruned {count} media files older than {request.DaysToKeep} days",
+                deletedCount = count
+            });
         }
 
         // ─── Cleanup Service Configuration ──────────────────────────────
@@ -226,28 +187,20 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         [HttpGet("/api/admin/media-cleanup/status")]
         [ProducesResponseType(typeof(MediaCleanupStatusDto), StatusCodes.Status200OK)]
-        public Task<IActionResult> GetCleanupStatus()
+        public async Task<IActionResult> GetCleanupStatus()
         {
-            return ExecuteAsync(
-                () => _cleanupStatusService.GetStatusAsync(),
-                Ok,
-                "GetCleanupStatus");
+            var status = await _cleanupStatusService.GetStatusAsync();
+            return Ok(status);
         }
 
         /// <summary>
         /// Gets whether the media cleanup service is currently enabled.
         /// </summary>
         [HttpGet("/api/admin/media-cleanup/enabled")]
-        public Task<IActionResult> GetCleanupEnabled()
+        public async Task<IActionResult> GetCleanupEnabled()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var isEnabled = await _cleanupStatusService.IsEnabledAsync();
-                    return new { enabled = isEnabled };
-                },
-                Ok,
-                "GetCleanupEnabled");
+            var isEnabled = await _cleanupStatusService.IsEnabledAsync();
+            return Ok(new { enabled = isEnabled });
         }
 
         /// <summary>
@@ -255,23 +208,17 @@ namespace ConduitLLM.Admin.Controllers
         /// This setting persists across restarts via GlobalSettings.
         /// </summary>
         [HttpPost("/api/admin/media-cleanup/enabled")]
-        public Task<IActionResult> SetCleanupEnabled([FromBody] UpdateMediaCleanupEnabledRequest request)
+        public async Task<IActionResult> SetCleanupEnabled([FromBody] UpdateMediaCleanupEnabledRequest request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    await _cleanupStatusService.SetEnabledAsync(request.Enabled);
-                    LogAdminAudit("SetEnabled", "MediaCleanupService", detail: $"Enabled: {request.Enabled}");
-                    return new
-                    {
-                        enabled = request.Enabled,
-                        message = request.Enabled
-                            ? "Media cleanup service has been enabled"
-                            : "Media cleanup service has been disabled"
-                    };
-                },
-                Ok,
-                "SetCleanupEnabled");
+            await _cleanupStatusService.SetEnabledAsync(request.Enabled);
+            LogAdminAudit("SetEnabled", "MediaCleanupService", detail: $"Enabled: {request.Enabled}");
+            return Ok(new
+            {
+                enabled = request.Enabled,
+                message = request.Enabled
+                    ? "Media cleanup service has been enabled"
+                    : "Media cleanup service has been disabled"
+            });
         }
 
         /// <summary>
@@ -279,20 +226,14 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         [HttpGet("/api/admin/media-cleanup/simple-retention")]
         [ProducesResponseType(typeof(SimpleRetentionResponse), StatusCodes.Status200OK)]
-        public Task<IActionResult> GetSimpleRetention()
+        public async Task<IActionResult> GetSimpleRetention()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var days = await _cleanupStatusService.GetSimpleRetentionOverrideAsync();
-                    return new SimpleRetentionResponse
-                    {
-                        RetentionDays = days,
-                        IsOverrideActive = days.HasValue
-                    };
-                },
-                Ok,
-                "GetSimpleRetention");
+            var days = await _cleanupStatusService.GetSimpleRetentionOverrideAsync();
+            return Ok(new SimpleRetentionResponse
+            {
+                RetentionDays = days,
+                IsOverrideActive = days.HasValue
+            });
         }
 
         /// <summary>
@@ -301,26 +242,20 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         [HttpPost("/api/admin/media-cleanup/simple-retention")]
         [ProducesResponseType(typeof(SimpleRetentionResponse), StatusCodes.Status200OK)]
-        public Task<IActionResult> SetSimpleRetention([FromBody] UpdateSimpleRetentionRequest request)
+        public async Task<IActionResult> SetSimpleRetention([FromBody] UpdateSimpleRetentionRequest request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    await _cleanupStatusService.SetSimpleRetentionOverrideAsync(request.RetentionDays);
-                    var message = request.RetentionDays.HasValue
-                        ? $"Simple retention override set to {request.RetentionDays} days - all media will be deleted after this period"
-                        : "Simple retention override cleared - using policy-based retention";
-                    LogAdminAudit("SetSimpleRetention", "MediaCleanupService",
-                        detail: $"RetentionDays: {request.RetentionDays?.ToString() ?? "cleared"}");
-                    return new SimpleRetentionResponse
-                    {
-                        RetentionDays = request.RetentionDays,
-                        IsOverrideActive = request.RetentionDays.HasValue,
-                        Message = message
-                    };
-                },
-                Ok,
-                "SetSimpleRetention");
+            await _cleanupStatusService.SetSimpleRetentionOverrideAsync(request.RetentionDays);
+            var message = request.RetentionDays.HasValue
+                ? $"Simple retention override set to {request.RetentionDays} days - all media will be deleted after this period"
+                : "Simple retention override cleared - using policy-based retention";
+            LogAdminAudit("SetSimpleRetention", "MediaCleanupService",
+                detail: $"RetentionDays: {request.RetentionDays?.ToString() ?? "cleared"}");
+            return Ok(new SimpleRetentionResponse
+            {
+                RetentionDays = request.RetentionDays,
+                IsOverrideActive = request.RetentionDays.HasValue,
+                Message = message
+            });
         }
     }
 

--- a/Services/ConduitLLM.Admin/Controllers/MediaRetentionController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/MediaRetentionController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Core.Extensions;
 
 using Microsoft.AspNetCore.Authorization;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/admin/media-retention")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class MediaRetentionController : AdminControllerBase
     {
         private readonly IConfigurationDbContext _context;
@@ -38,34 +40,33 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all retention policies</returns>
         [HttpGet("policies")]
         [ProducesResponseType(typeof(List<MediaRetentionPolicyDto>), 200)]
-        public Task<IActionResult> GetPolicies()
+        public async Task<IActionResult> GetPolicies()
         {
-            return ExecuteAsync(
-                async () => await _context.MediaRetentionPolicies
-                    .Include(p => p.VirtualKeyGroups)
-                    .OrderBy(p => p.Name)
-                    .Select(p => new MediaRetentionPolicyDto
-                    {
-                        Id = p.Id,
-                        Name = p.Name,
-                        Description = p.Description,
-                        PositiveBalanceRetentionDays = p.PositiveBalanceRetentionDays,
-                        ZeroBalanceRetentionDays = p.ZeroBalanceRetentionDays,
-                        NegativeBalanceRetentionDays = p.NegativeBalanceRetentionDays,
-                        SoftDeleteGracePeriodDays = p.SoftDeleteGracePeriodDays,
-                        RespectRecentAccess = p.RespectRecentAccess,
-                        RecentAccessWindowDays = p.RecentAccessWindowDays,
-                        IsDefault = p.IsDefault,
-                        MaxStorageSizeBytes = p.MaxStorageSizeBytes,
-                        MaxFileCount = p.MaxFileCount,
-                        IsActive = p.IsActive,
-                        CreatedAt = p.CreatedAt,
-                        UpdatedAt = p.UpdatedAt,
-                        VirtualKeyGroupCount = p.VirtualKeyGroups.Count
-                    })
-                    .ToListAsync(),
-                policies => Ok(policies),
-                nameof(GetPolicies));
+            var policies = await _context.MediaRetentionPolicies
+                .Include(p => p.VirtualKeyGroups)
+                .OrderBy(p => p.Name)
+                .Select(p => new MediaRetentionPolicyDto
+                {
+                    Id = p.Id,
+                    Name = p.Name,
+                    Description = p.Description,
+                    PositiveBalanceRetentionDays = p.PositiveBalanceRetentionDays,
+                    ZeroBalanceRetentionDays = p.ZeroBalanceRetentionDays,
+                    NegativeBalanceRetentionDays = p.NegativeBalanceRetentionDays,
+                    SoftDeleteGracePeriodDays = p.SoftDeleteGracePeriodDays,
+                    RespectRecentAccess = p.RespectRecentAccess,
+                    RecentAccessWindowDays = p.RecentAccessWindowDays,
+                    IsDefault = p.IsDefault,
+                    MaxStorageSizeBytes = p.MaxStorageSizeBytes,
+                    MaxFileCount = p.MaxFileCount,
+                    IsActive = p.IsActive,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    VirtualKeyGroupCount = p.VirtualKeyGroups.Count
+                })
+                .ToListAsync();
+
+            return Ok(policies);
         }
 
         /// <summary>
@@ -76,38 +77,42 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("policies/{id}")]
         [ProducesResponseType(typeof(MediaRetentionPolicyDetailDto), 200)]
         [ProducesResponseType(404)]
-        public Task<IActionResult> GetPolicy(int id)
+        public async Task<IActionResult> GetPolicy(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _context.MediaRetentionPolicies
-                    .Include(p => p.VirtualKeyGroups)
-                        .ThenInclude(vkg => vkg.VirtualKeys)
-                    .FirstOrDefaultAsync(p => p.Id == id),
-                policy => Ok(new MediaRetentionPolicyDetailDto
+            var policy = await _context.MediaRetentionPolicies
+                .Include(p => p.VirtualKeyGroups)
+                    .ThenInclude(vkg => vkg.VirtualKeys)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (policy == null)
+            {
+                return this.NotFoundEntity("Retention policy", id);
+            }
+
+            return Ok(new MediaRetentionPolicyDetailDto
+            {
+                Id = policy.Id,
+                Name = policy.Name,
+                Description = policy.Description,
+                PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
+                ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
+                NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
+                SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
+                RespectRecentAccess = policy.RespectRecentAccess,
+                RecentAccessWindowDays = policy.RecentAccessWindowDays,
+                IsDefault = policy.IsDefault,
+                MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
+                MaxFileCount = policy.MaxFileCount,
+                IsActive = policy.IsActive,
+                CreatedAt = policy.CreatedAt,
+                UpdatedAt = policy.UpdatedAt,
+                VirtualKeyGroups = policy.VirtualKeyGroups.Select(vkg => new VirtualKeyGroupSummaryDto
                 {
-                    Id = policy.Id,
-                    Name = policy.Name,
-                    Description = policy.Description,
-                    PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
-                    ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
-                    NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
-                    SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
-                    RespectRecentAccess = policy.RespectRecentAccess,
-                    RecentAccessWindowDays = policy.RecentAccessWindowDays,
-                    IsDefault = policy.IsDefault,
-                    MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
-                    MaxFileCount = policy.MaxFileCount,
-                    IsActive = policy.IsActive,
-                    CreatedAt = policy.CreatedAt,
-                    UpdatedAt = policy.UpdatedAt,
-                    VirtualKeyGroups = policy.VirtualKeyGroups.Select(vkg => new VirtualKeyGroupSummaryDto
-                    {
-                        Id = vkg.Id,
-                        Balance = vkg.Balance,
-                        VirtualKeyCount = vkg.VirtualKeys.Count
-                    }).ToList()
-                }),
-                "Retention policy", id, nameof(GetPolicy));
+                    Id = vkg.Id,
+                    Balance = vkg.Balance,
+                    VirtualKeyCount = vkg.VirtualKeys.Count
+                }).ToList()
+            });
         }
 
         /// <summary>
@@ -118,73 +123,68 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("policies")]
         [ProducesResponseType(typeof(MediaRetentionPolicyDto), 201)]
         [ProducesResponseType(400)]
-        public Task<IActionResult> CreatePolicy([FromBody] CreateMediaRetentionPolicyRequest request)
+        public async Task<IActionResult> CreatePolicy([FromBody] CreateMediaRetentionPolicyRequest request)
         {
             if (request.PositiveBalanceRetentionDays <= 0)
             {
-                return Task.FromResult<IActionResult>(
-                    this.BadRequestError("Positive balance retention days must be greater than 0"));
+                return this.BadRequestError("Positive balance retention days must be greater than 0");
             }
 
-            return ExecuteAsync<MediaRetentionPolicyDto>(
-                async () =>
+            if (request.IsDefault)
+            {
+                // Ensure only one default policy exists
+                var existingDefault = await _context.MediaRetentionPolicies
+                    .FirstOrDefaultAsync(p => p.IsDefault);
+                if (existingDefault != null)
                 {
-                    if (request.IsDefault)
-                    {
-                        // Ensure only one default policy exists
-                        var existingDefault = await _context.MediaRetentionPolicies
-                            .FirstOrDefaultAsync(p => p.IsDefault);
-                        if (existingDefault != null)
-                        {
-                            existingDefault.IsDefault = false;
-                        }
-                    }
+                    existingDefault.IsDefault = false;
+                }
+            }
 
-                    var policy = new MediaRetentionPolicy
-                    {
-                        Name = request.Name,
-                        Description = request.Description,
-                        PositiveBalanceRetentionDays = request.PositiveBalanceRetentionDays,
-                        ZeroBalanceRetentionDays = request.ZeroBalanceRetentionDays,
-                        NegativeBalanceRetentionDays = request.NegativeBalanceRetentionDays,
-                        SoftDeleteGracePeriodDays = request.SoftDeleteGracePeriodDays,
-                        RespectRecentAccess = request.RespectRecentAccess,
-                        RecentAccessWindowDays = request.RecentAccessWindowDays,
-                        IsDefault = request.IsDefault,
-                        MaxStorageSizeBytes = request.MaxStorageSizeBytes,
-                        MaxFileCount = request.MaxFileCount,
-                        IsActive = true,
-                        CreatedAt = DateTime.UtcNow,
-                        UpdatedAt = DateTime.UtcNow
-                    };
+            var policy = new MediaRetentionPolicy
+            {
+                Name = request.Name,
+                Description = request.Description,
+                PositiveBalanceRetentionDays = request.PositiveBalanceRetentionDays,
+                ZeroBalanceRetentionDays = request.ZeroBalanceRetentionDays,
+                NegativeBalanceRetentionDays = request.NegativeBalanceRetentionDays,
+                SoftDeleteGracePeriodDays = request.SoftDeleteGracePeriodDays,
+                RespectRecentAccess = request.RespectRecentAccess,
+                RecentAccessWindowDays = request.RecentAccessWindowDays,
+                IsDefault = request.IsDefault,
+                MaxStorageSizeBytes = request.MaxStorageSizeBytes,
+                MaxFileCount = request.MaxFileCount,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-                    _context.MediaRetentionPolicies.Add(policy);
-                    await _context.SaveChangesAsync();
+            _context.MediaRetentionPolicies.Add(policy);
+            await _context.SaveChangesAsync();
 
-                    LogAdminAudit("Created", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+            LogAdminAudit("Created", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
 
-                    return new MediaRetentionPolicyDto
-                    {
-                        Id = policy.Id,
-                        Name = policy.Name,
-                        Description = policy.Description,
-                        PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
-                        ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
-                        NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
-                        SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
-                        RespectRecentAccess = policy.RespectRecentAccess,
-                        RecentAccessWindowDays = policy.RecentAccessWindowDays,
-                        IsDefault = policy.IsDefault,
-                        MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
-                        MaxFileCount = policy.MaxFileCount,
-                        IsActive = policy.IsActive,
-                        CreatedAt = policy.CreatedAt,
-                        UpdatedAt = policy.UpdatedAt,
-                        VirtualKeyGroupCount = 0
-                    };
-                },
-                dto => CreatedAtAction(nameof(GetPolicy), new { id = dto.Id }, dto),
-                nameof(CreatePolicy));
+            var dto = new MediaRetentionPolicyDto
+            {
+                Id = policy.Id,
+                Name = policy.Name,
+                Description = policy.Description,
+                PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
+                ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
+                NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
+                SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
+                RespectRecentAccess = policy.RespectRecentAccess,
+                RecentAccessWindowDays = policy.RecentAccessWindowDays,
+                IsDefault = policy.IsDefault,
+                MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
+                MaxFileCount = policy.MaxFileCount,
+                IsActive = policy.IsActive,
+                CreatedAt = policy.CreatedAt,
+                UpdatedAt = policy.UpdatedAt,
+                VirtualKeyGroupCount = 0
+            };
+
+            return CreatedAtAction(nameof(GetPolicy), new { id = dto.Id }, dto);
         }
 
         /// <summary>
@@ -197,65 +197,66 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(MediaRetentionPolicyDto), 200)]
         [ProducesResponseType(404)]
         [ProducesResponseType(400)]
-        public Task<IActionResult> UpdatePolicy(int id, [FromBody] UpdateMediaRetentionPolicyRequest request)
+        public async Task<IActionResult> UpdatePolicy(int id, [FromBody] UpdateMediaRetentionPolicyRequest request)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _context.MediaRetentionPolicies
-                    .Include(p => p.VirtualKeyGroups)
-                    .FirstOrDefaultAsync(p => p.Id == id),
-                async policy =>
+            var policy = await _context.MediaRetentionPolicies
+                .Include(p => p.VirtualKeyGroups)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (policy == null)
+            {
+                return this.NotFoundEntity("Retention policy", id);
+            }
+
+            if (request.IsDefault == true && !policy.IsDefault)
+            {
+                // Ensure only one default policy exists
+                var existingDefault = await _context.MediaRetentionPolicies
+                    .FirstOrDefaultAsync(p => p.IsDefault && p.Id != id);
+                if (existingDefault != null)
                 {
-                    if (request.IsDefault == true && !policy.IsDefault)
-                    {
-                        // Ensure only one default policy exists
-                        var existingDefault = await _context.MediaRetentionPolicies
-                            .FirstOrDefaultAsync(p => p.IsDefault && p.Id != id);
-                        if (existingDefault != null)
-                        {
-                            existingDefault.IsDefault = false;
-                        }
-                    }
+                    existingDefault.IsDefault = false;
+                }
+            }
 
-                    // Update fields
-                    policy.Name = request.Name ?? policy.Name;
-                    policy.Description = request.Description ?? policy.Description;
-                    policy.PositiveBalanceRetentionDays = request.PositiveBalanceRetentionDays ?? policy.PositiveBalanceRetentionDays;
-                    policy.ZeroBalanceRetentionDays = request.ZeroBalanceRetentionDays ?? policy.ZeroBalanceRetentionDays;
-                    policy.NegativeBalanceRetentionDays = request.NegativeBalanceRetentionDays ?? policy.NegativeBalanceRetentionDays;
-                    policy.SoftDeleteGracePeriodDays = request.SoftDeleteGracePeriodDays ?? policy.SoftDeleteGracePeriodDays;
-                    policy.RespectRecentAccess = request.RespectRecentAccess ?? policy.RespectRecentAccess;
-                    policy.RecentAccessWindowDays = request.RecentAccessWindowDays ?? policy.RecentAccessWindowDays;
-                    policy.IsDefault = request.IsDefault ?? policy.IsDefault;
-                    policy.MaxStorageSizeBytes = request.MaxStorageSizeBytes ?? policy.MaxStorageSizeBytes;
-                    policy.MaxFileCount = request.MaxFileCount ?? policy.MaxFileCount;
-                    policy.IsActive = request.IsActive ?? policy.IsActive;
-                    policy.UpdatedAt = DateTime.UtcNow;
+            // Update fields
+            policy.Name = request.Name ?? policy.Name;
+            policy.Description = request.Description ?? policy.Description;
+            policy.PositiveBalanceRetentionDays = request.PositiveBalanceRetentionDays ?? policy.PositiveBalanceRetentionDays;
+            policy.ZeroBalanceRetentionDays = request.ZeroBalanceRetentionDays ?? policy.ZeroBalanceRetentionDays;
+            policy.NegativeBalanceRetentionDays = request.NegativeBalanceRetentionDays ?? policy.NegativeBalanceRetentionDays;
+            policy.SoftDeleteGracePeriodDays = request.SoftDeleteGracePeriodDays ?? policy.SoftDeleteGracePeriodDays;
+            policy.RespectRecentAccess = request.RespectRecentAccess ?? policy.RespectRecentAccess;
+            policy.RecentAccessWindowDays = request.RecentAccessWindowDays ?? policy.RecentAccessWindowDays;
+            policy.IsDefault = request.IsDefault ?? policy.IsDefault;
+            policy.MaxStorageSizeBytes = request.MaxStorageSizeBytes ?? policy.MaxStorageSizeBytes;
+            policy.MaxFileCount = request.MaxFileCount ?? policy.MaxFileCount;
+            policy.IsActive = request.IsActive ?? policy.IsActive;
+            policy.UpdatedAt = DateTime.UtcNow;
 
-                    await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
 
-                    LogAdminAudit("Updated", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+            LogAdminAudit("Updated", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
 
-                    return Ok(new MediaRetentionPolicyDto
-                    {
-                        Id = policy.Id,
-                        Name = policy.Name,
-                        Description = policy.Description,
-                        PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
-                        ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
-                        NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
-                        SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
-                        RespectRecentAccess = policy.RespectRecentAccess,
-                        RecentAccessWindowDays = policy.RecentAccessWindowDays,
-                        IsDefault = policy.IsDefault,
-                        MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
-                        MaxFileCount = policy.MaxFileCount,
-                        IsActive = policy.IsActive,
-                        CreatedAt = policy.CreatedAt,
-                        UpdatedAt = policy.UpdatedAt,
-                        VirtualKeyGroupCount = policy.VirtualKeyGroups.Count
-                    });
-                },
-                "Retention policy", id, nameof(UpdatePolicy));
+            return Ok(new MediaRetentionPolicyDto
+            {
+                Id = policy.Id,
+                Name = policy.Name,
+                Description = policy.Description,
+                PositiveBalanceRetentionDays = policy.PositiveBalanceRetentionDays,
+                ZeroBalanceRetentionDays = policy.ZeroBalanceRetentionDays,
+                NegativeBalanceRetentionDays = policy.NegativeBalanceRetentionDays,
+                SoftDeleteGracePeriodDays = policy.SoftDeleteGracePeriodDays,
+                RespectRecentAccess = policy.RespectRecentAccess,
+                RecentAccessWindowDays = policy.RecentAccessWindowDays,
+                IsDefault = policy.IsDefault,
+                MaxStorageSizeBytes = policy.MaxStorageSizeBytes,
+                MaxFileCount = policy.MaxFileCount,
+                IsActive = policy.IsActive,
+                CreatedAt = policy.CreatedAt,
+                UpdatedAt = policy.UpdatedAt,
+                VirtualKeyGroupCount = policy.VirtualKeyGroups.Count
+            });
         }
 
         /// <summary>
@@ -267,33 +268,34 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(204)]
         [ProducesResponseType(404)]
         [ProducesResponseType(400)]
-        public Task<IActionResult> DeletePolicy(int id)
+        public async Task<IActionResult> DeletePolicy(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _context.MediaRetentionPolicies
-                    .Include(p => p.VirtualKeyGroups)
-                    .FirstOrDefaultAsync(p => p.Id == id),
-                async policy =>
-                {
-                    if (policy.IsDefault)
-                    {
-                        return this.BadRequestError("Cannot delete the default retention policy");
-                    }
+            var policy = await _context.MediaRetentionPolicies
+                .Include(p => p.VirtualKeyGroups)
+                .FirstOrDefaultAsync(p => p.Id == id);
 
-                    if (policy.VirtualKeyGroups.Any())
-                    {
-                        return this.BadRequestError(
-                            $"Cannot delete policy - it is assigned to {policy.VirtualKeyGroups.Count} virtual key group(s)");
-                    }
+            if (policy == null)
+            {
+                return this.NotFoundEntity("Retention policy", id);
+            }
 
-                    _context.MediaRetentionPolicies.Remove(policy);
-                    await _context.SaveChangesAsync();
+            if (policy.IsDefault)
+            {
+                return this.BadRequestError("Cannot delete the default retention policy");
+            }
 
-                    LogAdminAudit("Deleted", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+            if (policy.VirtualKeyGroups.Any())
+            {
+                return this.BadRequestError(
+                    $"Cannot delete policy - it is assigned to {policy.VirtualKeyGroups.Count} virtual key group(s)");
+            }
 
-                    return NoContent();
-                },
-                "Retention policy", id, nameof(DeletePolicy));
+            _context.MediaRetentionPolicies.Remove(policy);
+            await _context.SaveChangesAsync();
+
+            LogAdminAudit("Deleted", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -305,29 +307,26 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("assign/{groupId}/{policyId}")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
-        public Task<IActionResult> AssignPolicyToGroup(int groupId, int policyId)
+        public async Task<IActionResult> AssignPolicyToGroup(int groupId, int policyId)
         {
-            return ExecuteAsync(async () =>
+            var group = await _context.VirtualKeyGroups.FindAsync(groupId);
+            if (group == null)
             {
-                var group = await _context.VirtualKeyGroups.FindAsync(groupId);
-                if (group == null)
-                {
-                    return this.NotFoundEntity("Virtual key group", groupId);
-                }
+                return this.NotFoundEntity("Virtual key group", groupId);
+            }
 
-                var policy = await _context.MediaRetentionPolicies.FindAsync(policyId);
-                if (policy == null)
-                {
-                    return this.NotFoundEntity("Retention policy", policyId);
-                }
+            var policy = await _context.MediaRetentionPolicies.FindAsync(policyId);
+            if (policy == null)
+            {
+                return this.NotFoundEntity("Retention policy", policyId);
+            }
 
-                group.MediaRetentionPolicyId = policyId;
-                await _context.SaveChangesAsync();
+            group.MediaRetentionPolicyId = policyId;
+            await _context.SaveChangesAsync();
 
-                LogAdminAudit("AssignedPolicy", "MediaRetentionPolicy", policyId, $"GroupId: {groupId}");
+            LogAdminAudit("AssignedPolicy", "MediaRetentionPolicy", policyId, $"GroupId: {groupId}");
 
-                return Ok(new { message = $"Successfully assigned policy '{policy.Name}' to group {groupId}" });
-            }, nameof(AssignPolicyToGroup), new { groupId, policyId });
+            return Ok(new { message = $"Successfully assigned policy '{policy.Name}' to group {groupId}" });
         }
 
         /// <summary>
@@ -339,35 +338,36 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("policies/{id}/set-default")]
         [ProducesResponseType(200)]
         [ProducesResponseType(404)]
-        public Task<IActionResult> SetDefaultPolicy(int id)
+        public async Task<IActionResult> SetDefaultPolicy(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _context.MediaRetentionPolicies.FindAsync(id).AsTask(),
-                async policy =>
-                {
-                    if (!policy.IsActive)
-                    {
-                        return this.BadRequestError("Cannot set an inactive policy as default");
-                    }
+            var policy = await _context.MediaRetentionPolicies.FindAsync(id);
 
-                    // Clear existing default
-                    var currentDefault = await _context.MediaRetentionPolicies
-                        .FirstOrDefaultAsync(p => p.IsDefault && p.Id != id);
-                    if (currentDefault != null)
-                    {
-                        currentDefault.IsDefault = false;
-                    }
+            if (policy == null)
+            {
+                return this.NotFoundEntity("Retention policy", id);
+            }
 
-                    // Set new default
-                    policy.IsDefault = true;
-                    policy.UpdatedAt = DateTime.UtcNow;
-                    await _context.SaveChangesAsync();
+            if (!policy.IsActive)
+            {
+                return this.BadRequestError("Cannot set an inactive policy as default");
+            }
 
-                    LogAdminAudit("SetDefault", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+            // Clear existing default
+            var currentDefault = await _context.MediaRetentionPolicies
+                .FirstOrDefaultAsync(p => p.IsDefault && p.Id != id);
+            if (currentDefault != null)
+            {
+                currentDefault.IsDefault = false;
+            }
 
-                    return Ok(new { message = $"'{policy.Name}' is now the default retention policy" });
-                },
-                "Retention policy", id, nameof(SetDefaultPolicy));
+            // Set new default
+            policy.IsDefault = true;
+            policy.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+
+            LogAdminAudit("SetDefault", "MediaRetentionPolicy", policy.Id, $"Name: {LoggingSanitizer.S(policy.Name)}");
+
+            return Ok(new { message = $"'{policy.Name}' is now the default retention policy" });
         }
 
         /// <summary>
@@ -379,10 +379,11 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("cleanup/{groupId}")]
         [ProducesResponseType(typeof(CleanupResultDto), 200)]
         [ProducesResponseType(404)]
-        public Task<IActionResult> TriggerCleanup(int groupId, [FromQuery] bool dryRun = true)
+        public async Task<IActionResult> TriggerCleanup(int groupId, [FromQuery] bool dryRun = true)
         {
             // Placeholder — manual cleanup not yet implemented
-            return Task.FromResult<IActionResult>(Ok(new CleanupResultDto
+            await Task.CompletedTask;
+            return Ok(new CleanupResultDto
             {
                 VirtualKeyGroupId = groupId,
                 DryRun = dryRun,
@@ -391,7 +392,7 @@ namespace ConduitLLM.Admin.Controllers
                 MediaRecordsDeleted = 0,
                 StorageBytesFreed = 0,
                 Message = "Manual cleanup trigger not yet implemented. Use the scheduled cleanup system."
-            }));
+            });
         }
     }
 

--- a/Services/ConduitLLM.Admin/Controllers/MetricsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/MetricsController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration;
 
 using Microsoft.AspNetCore.Authorization;
@@ -16,6 +17,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("metrics")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class MetricsController : AdminControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -39,68 +41,62 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Connection pool metrics.</returns>
         [HttpGet("database/pool")]
-        public Task<IActionResult> GetDatabasePoolMetrics(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetDatabasePoolMetrics(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+            var connection = dbContext.Database.GetDbConnection() as NpgsqlConnection;
+
+            if (connection == null)
+            {
+                return Ok(new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
-                    var connection = dbContext.Database.GetDbConnection() as NpgsqlConnection;
+                    provider = "non-postgresql",
+                    message = "Connection pool metrics only available for PostgreSQL"
+                });
+            }
 
-                    if (connection == null)
-                    {
-                        return (object)new
-                        {
-                            provider = "non-postgresql",
-                            message = "Connection pool metrics only available for PostgreSQL"
-                        };
-                    }
+            // Get connection string to extract pool settings
+            var connectionString = connection.ConnectionString;
+            var builder = new NpgsqlConnectionStringBuilder(connectionString);
 
-                    // Get connection string to extract pool settings
-                    var connectionString = connection.ConnectionString;
-                    var builder = new NpgsqlConnectionStringBuilder(connectionString);
+            // Measure connection acquisition time
+            var stopwatch = Stopwatch.StartNew();
+            await connection.OpenAsync(cancellationToken);
+            stopwatch.Stop();
+            await connection.CloseAsync();
 
-                    // Measure connection acquisition time
-                    var stopwatch = Stopwatch.StartNew();
-                    await connection.OpenAsync(cancellationToken);
-                    stopwatch.Stop();
-                    await connection.CloseAsync();
+            // Note: Npgsql doesn't expose pool statistics directly in current versions
+            // We can only infer pool health from connection acquisition time
+            // For detailed monitoring, use PostgreSQL's pg_stat_activity or external monitoring tools
 
-                    // Note: Npgsql doesn't expose pool statistics directly in current versions
-                    // We can only infer pool health from connection acquisition time
-                    // For detailed monitoring, use PostgreSQL's pg_stat_activity or external monitoring tools
-
-                    return (object)new
-                    {
-                        timestamp = DateTime.UtcNow,
-                        provider = "postgresql",
-                        connectionString = new
-                        {
-                            host = builder.Host,
-                            port = builder.Port,
-                            database = builder.Database,
-                            applicationName = builder.ApplicationName ?? "Conduit Gateway API"
-                        },
-                        poolConfiguration = new
-                        {
-                            minPoolSize = builder.MinPoolSize,
-                            maxPoolSize = builder.MaxPoolSize,
-                            connectionLifetime = builder.ConnectionLifetime,
-                            connectionIdleLifetime = builder.ConnectionIdleLifetime,
-                            pooling = builder.Pooling
-                        },
-                        currentMetrics = new
-                        {
-                            connectionAcquisitionTimeMs = stopwatch.ElapsedMilliseconds,
-                            healthStatus = GetHealthStatus(stopwatch.ElapsedMilliseconds),
-                            // Additional metrics can be obtained from pg_stat_activity if needed
-                            // but we avoid that here to prevent performance impact
-                            note = "For detailed pool statistics, query pg_stat_activity directly or use monitoring tools"
-                        }
-                    };
+            return Ok(new
+            {
+                timestamp = DateTime.UtcNow,
+                provider = "postgresql",
+                connectionString = new
+                {
+                    host = builder.Host,
+                    port = builder.Port,
+                    database = builder.Database,
+                    applicationName = builder.ApplicationName ?? "Conduit Gateway API"
                 },
-                Ok,
-                "GetDatabasePoolMetrics");
+                poolConfiguration = new
+                {
+                    minPoolSize = builder.MinPoolSize,
+                    maxPoolSize = builder.MaxPoolSize,
+                    connectionLifetime = builder.ConnectionLifetime,
+                    connectionIdleLifetime = builder.ConnectionIdleLifetime,
+                    pooling = builder.Pooling
+                },
+                currentMetrics = new
+                {
+                    connectionAcquisitionTimeMs = stopwatch.ElapsedMilliseconds,
+                    healthStatus = GetHealthStatus(stopwatch.ElapsedMilliseconds),
+                    // Additional metrics can be obtained from pg_stat_activity if needed
+                    // but we avoid that here to prevent performance impact
+                    note = "For detailed pool statistics, query pg_stat_activity directly or use monitoring tools"
+                }
+            });
         }
 
         /// <summary>
@@ -109,37 +105,31 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Comprehensive application metrics.</returns>
         [HttpGet]
-        public Task<IActionResult> GetAllMetrics(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetAllMetrics(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Get database pool metrics
-                    var poolMetricsResult = await GetDatabasePoolMetrics(cancellationToken);
-                    var poolMetrics = (poolMetricsResult as OkObjectResult)?.Value;
+            // Get database pool metrics
+            var poolMetricsResult = await GetDatabasePoolMetrics(cancellationToken);
+            var poolMetrics = (poolMetricsResult as OkObjectResult)?.Value;
 
-                    return new
-                    {
-                        timestamp = DateTime.UtcNow,
-                        application = new
-                        {
-                            name = "Conduit Gateway API",
-                            version = typeof(MetricsController).Assembly.GetName().Version?.ToString() ?? "unknown",
-                            environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"
-                        },
-                        database = poolMetrics,
-                        system = new
-                        {
-                            cpuCount = Environment.ProcessorCount,
-                            workingSetMb = Environment.WorkingSet / 1024 / 1024,
-                            gcMemoryMb = GC.GetTotalMemory(false) / 1024 / 1024,
-                            threadCount = Process.GetCurrentProcess().Threads.Count,
-                            uptime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime()
-                        }
-                    };
+            return Ok(new
+            {
+                timestamp = DateTime.UtcNow,
+                application = new
+                {
+                    name = "Conduit Gateway API",
+                    version = typeof(MetricsController).Assembly.GetName().Version?.ToString() ?? "unknown",
+                    environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"
                 },
-                Ok,
-                "GetAllMetrics");
+                database = poolMetrics,
+                system = new
+                {
+                    cpuCount = Environment.ProcessorCount,
+                    workingSetMb = Environment.WorkingSet / 1024 / 1024,
+                    gcMemoryMb = GC.GetTotalMemory(false) / 1024 / 1024,
+                    threadCount = Process.GetCurrentProcess().Threads.Count,
+                    uptime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime()
+                }
+            });
         }
 
         private static string GetHealthStatus(long acquisitionTimeMs)

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.Identifiers.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.Identifiers.cs
@@ -19,29 +19,29 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelIdentifiers(int id)
+        public async Task<IActionResult> GetModelIdentifiers(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelRepository.GetByIdWithDetailsAsync(id),
-                model =>
-                {
-                    var identifiers = model.Identifiers.Select(i => new
-                    {
-                        id = i.Id,
-                        identifier = i.Identifier,
-                        provider = (int?)i.Provider,
-                        isPrimary = i.IsPrimary,
-                        maxInputTokens = i.MaxInputTokens,
-                        maxOutputTokens = i.MaxOutputTokens,
-                        speedScore = i.SpeedScore,
-                        qualityScore = i.QualityScore,
-                        providerVariation = i.ProviderVariation,
-                        modelCostId = i.ModelCostId
-                    });
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return this.NotFoundEntity("Model", id);
+            }
 
-                    return Ok(identifiers);
-                },
-                "Model", id, "GetModelIdentifiers");
+            var identifiers = model.Identifiers.Select(i => new
+            {
+                id = i.Id,
+                identifier = i.Identifier,
+                provider = (int?)i.Provider,
+                isPrimary = i.IsPrimary,
+                maxInputTokens = i.MaxInputTokens,
+                maxOutputTokens = i.MaxOutputTokens,
+                speedScore = i.SpeedScore,
+                qualityScore = i.QualityScore,
+                providerVariation = i.ProviderVariation,
+                modelCostId = i.ModelCostId
+            });
+
+            return Ok(identifiers);
         }
 
         /// <summary>
@@ -54,60 +54,60 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAvailableProviders(int id)
+        public async Task<IActionResult> GetAvailableProviders(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelRepository.GetByIdWithDetailsAsync(id),
-                async model =>
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return this.NotFoundEntity("Model", id);
+            }
+
+            var providers = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                _providerRepository.GetPaginatedAsync);
+            var enabledProviders = providers.Where(p => p.IsEnabled).ToList();
+
+            var result = new List<object>();
+
+            foreach (var association in model.Identifiers)
+            {
+                // Skip associations without a provider type - they're not properly configured
+                if (association.Provider == null)
                 {
-                    var providers = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
-                        _providerRepository.GetPaginatedAsync);
-                    var enabledProviders = providers.Where(p => p.IsEnabled).ToList();
+                    Logger.LogWarning(
+                        "ModelIdentifier {AssociationId} for model {ModelId} has null Provider field - skipping",
+                        association.Id, id);
+                    continue;
+                }
 
-                    var result = new List<object>();
+                // Find matching providers for this association
+                var matchingProviders = enabledProviders.Where(p =>
+                    p.ProviderType == association.Provider
+                ).ToList();
 
-                    foreach (var association in model.Identifiers)
+                if (matchingProviders.Any())
+                {
+                    result.Add(new
                     {
-                        // Skip associations without a provider type - they're not properly configured
-                        if (association.Provider == null)
+                        associationId = association.Id,
+                        identifier = association.Identifier,
+                        provider = (int?)association.Provider,
+                        providerVariation = association.ProviderVariation,
+                        maxInputTokens = association.MaxInputTokens,
+                        maxOutputTokens = association.MaxOutputTokens,
+                        speedScore = association.SpeedScore,
+                        qualityScore = association.QualityScore,
+                        isPrimary = association.IsPrimary,
+                        availableProviders = matchingProviders.Select(p => new
                         {
-                            Logger.LogWarning(
-                                "ModelIdentifier {AssociationId} for model {ModelId} has null Provider field - skipping",
-                                association.Id, id);
-                            continue;
-                        }
+                            providerId = p.Id,
+                            providerName = p.ProviderName,
+                            providerType = p.ProviderType.ToString()
+                        })
+                    });
+                }
+            }
 
-                        // Find matching providers for this association
-                        var matchingProviders = enabledProviders.Where(p =>
-                            p.ProviderType == association.Provider
-                        ).ToList();
-
-                        if (matchingProviders.Any())
-                        {
-                            result.Add(new
-                            {
-                                associationId = association.Id,
-                                identifier = association.Identifier,
-                                provider = (int?)association.Provider,
-                                providerVariation = association.ProviderVariation,
-                                maxInputTokens = association.MaxInputTokens,
-                                maxOutputTokens = association.MaxOutputTokens,
-                                speedScore = association.SpeedScore,
-                                qualityScore = association.QualityScore,
-                                isPrimary = association.IsPrimary,
-                                availableProviders = matchingProviders.Select(p => new
-                                {
-                                    providerId = p.Id,
-                                    providerName = p.ProviderName,
-                                    providerType = p.ProviderType.ToString()
-                                })
-                            });
-                        }
-                    }
-
-                    return (IActionResult)Ok(result);
-                },
-                "Model", id, "GetAvailableProviders");
+            return Ok(result);
         }
 
         /// <summary>
@@ -121,66 +121,59 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        public Task<IActionResult> CreateModelIdentifier(int id, [FromBody] CreateModelIdentifierDto dto)
+        public async Task<IActionResult> CreateModelIdentifier(int id, [FromBody] CreateModelIdentifierDto dto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var model = await _modelRepository.GetByIdWithDetailsAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
 
-                    // Parse provider if provided as integer
-                    ProviderType? providerType = dto.Provider.HasValue ? (ProviderType)dto.Provider.Value : null;
+            // Parse provider if provided as integer
+            ProviderType? providerType = dto.Provider.HasValue ? (ProviderType)dto.Provider.Value : null;
 
-                    // Check if identifier already exists for this provider
-                    var existing = model.Identifiers.FirstOrDefault(i =>
-                        i.Identifier == dto.Identifier &&
-                        i.Provider == providerType);
+            // Check if identifier already exists for this provider
+            var existing = model.Identifiers.FirstOrDefault(i =>
+                i.Identifier == dto.Identifier &&
+                i.Provider == providerType);
 
-                    if (existing != null)
-                    {
-                        return Conflict($"Identifier '{dto.Identifier}' already exists for provider '{dto.Provider}'");
-                    }
+            if (existing != null)
+            {
+                return Conflict($"Identifier '{dto.Identifier}' already exists for provider '{dto.Provider}'");
+            }
 
-                    var identifier = new ModelProviderTypeAssociation
-                    {
-                        ModelId = id,
-                        Identifier = dto.Identifier,
-                        Provider = providerType,
-                        IsPrimary = dto.IsPrimary ?? false,
-                        Metadata = dto.Metadata,
-                        MaxInputTokens = dto.MaxInputTokens,
-                        MaxOutputTokens = dto.MaxOutputTokens,
-                        SpeedScore = dto.SpeedScore,
-                        QualityScore = dto.QualityScore,
-                        ProviderVariation = dto.ProviderVariation
-                    };
+            var identifier = new ModelProviderTypeAssociation
+            {
+                ModelId = id,
+                Identifier = dto.Identifier,
+                Provider = providerType,
+                IsPrimary = dto.IsPrimary ?? false,
+                Metadata = dto.Metadata,
+                MaxInputTokens = dto.MaxInputTokens,
+                MaxOutputTokens = dto.MaxOutputTokens,
+                SpeedScore = dto.SpeedScore,
+                QualityScore = dto.QualityScore,
+                ProviderVariation = dto.ProviderVariation
+            };
 
-                    model.Identifiers.Add(identifier);
-                    await _modelRepository.UpdateModelAsync(model);
+            model.Identifiers.Add(identifier);
+            await _modelRepository.UpdateModelAsync(model);
 
-                    LogAdminAudit("Created", "ModelIdentifier", identifier.Id,
-                        $"ModelId: {id}, Identifier: {LoggingSanitizer.S(dto.Identifier)}");
+            LogAdminAudit("Created", "ModelIdentifier", identifier.Id,
+                $"ModelId: {id}, Identifier: {LoggingSanitizer.S(dto.Identifier)}");
 
-                    return CreatedAtAction(nameof(GetModelIdentifiers), new { id }, new
-                    {
-                        id = identifier.Id,
-                        identifier = identifier.Identifier,
-                        provider = (int?)identifier.Provider,
-                        isPrimary = identifier.IsPrimary,
-                        maxInputTokens = identifier.MaxInputTokens,
-                        maxOutputTokens = identifier.MaxOutputTokens,
-                        speedScore = identifier.SpeedScore,
-                        qualityScore = identifier.QualityScore,
-                        providerVariation = identifier.ProviderVariation
-                    });
-                },
-                result => result,
-                "CreateModelIdentifier",
-                new { Id = id });
+            return CreatedAtAction(nameof(GetModelIdentifiers), new { id }, new
+            {
+                id = identifier.Id,
+                identifier = identifier.Identifier,
+                provider = (int?)identifier.Provider,
+                isPrimary = identifier.IsPrimary,
+                maxInputTokens = identifier.MaxInputTokens,
+                maxOutputTokens = identifier.MaxOutputTokens,
+                speedScore = identifier.SpeedScore,
+                qualityScore = identifier.QualityScore,
+                providerVariation = identifier.ProviderVariation
+            });
         }
 
         /// <summary>
@@ -195,60 +188,53 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        public Task<IActionResult> UpdateModelIdentifier(int id, int identifierId, [FromBody] UpdateModelIdentifierDto dto)
+        public async Task<IActionResult> UpdateModelIdentifier(int id, int identifierId, [FromBody] UpdateModelIdentifierDto dto)
         {
-            return ExecuteAsync(
-                async () =>
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
+
+            var identifier = model.Identifiers.FirstOrDefault(i => i.Id == identifierId);
+            if (identifier == null)
+            {
+                return NotFound($"Identifier with ID {identifierId} not found for model {id}");
+            }
+
+            // Parse provider if provided as integer
+            ProviderType? providerType = dto.Provider.HasValue ? (ProviderType)dto.Provider.Value : null;
+
+            // Check if the new identifier/provider combo already exists (if changed)
+            if (identifier.Identifier != dto.Identifier || identifier.Provider != providerType)
+            {
+                var existing = model.Identifiers.FirstOrDefault(i =>
+                    i.Id != identifierId &&
+                    i.Identifier == dto.Identifier &&
+                    i.Provider == providerType);
+
+                if (existing != null)
                 {
-                    var model = await _modelRepository.GetByIdWithDetailsAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+                    return Conflict($"Identifier '{dto.Identifier}' already exists for provider '{dto.Provider}'");
+                }
+            }
 
-                    var identifier = model.Identifiers.FirstOrDefault(i => i.Id == identifierId);
-                    if (identifier == null)
-                    {
-                        return NotFound($"Identifier with ID {identifierId} not found for model {id}");
-                    }
+            identifier.Identifier = dto.Identifier;
+            identifier.Provider = providerType;
+            identifier.IsPrimary = dto.IsPrimary ?? identifier.IsPrimary;
+            identifier.Metadata = dto.Metadata;
+            identifier.MaxInputTokens = dto.MaxInputTokens;
+            identifier.MaxOutputTokens = dto.MaxOutputTokens;
+            identifier.SpeedScore = dto.SpeedScore;
+            identifier.QualityScore = dto.QualityScore;
+            identifier.ProviderVariation = dto.ProviderVariation;
 
-                    // Parse provider if provided as integer
-                    ProviderType? providerType = dto.Provider.HasValue ? (ProviderType)dto.Provider.Value : null;
+            await _modelRepository.UpdateModelAsync(model);
 
-                    // Check if the new identifier/provider combo already exists (if changed)
-                    if (identifier.Identifier != dto.Identifier || identifier.Provider != providerType)
-                    {
-                        var existing = model.Identifiers.FirstOrDefault(i =>
-                            i.Id != identifierId &&
-                            i.Identifier == dto.Identifier &&
-                            i.Provider == providerType);
+            LogAdminAudit("Updated", "ModelIdentifier", identifierId,
+                $"ModelId: {id}, Identifier: {LoggingSanitizer.S(dto.Identifier)}");
 
-                        if (existing != null)
-                        {
-                            return Conflict($"Identifier '{dto.Identifier}' already exists for provider '{dto.Provider}'");
-                        }
-                    }
-
-                    identifier.Identifier = dto.Identifier;
-                    identifier.Provider = providerType;
-                    identifier.IsPrimary = dto.IsPrimary ?? identifier.IsPrimary;
-                    identifier.Metadata = dto.Metadata;
-                    identifier.MaxInputTokens = dto.MaxInputTokens;
-                    identifier.MaxOutputTokens = dto.MaxOutputTokens;
-                    identifier.SpeedScore = dto.SpeedScore;
-                    identifier.QualityScore = dto.QualityScore;
-                    identifier.ProviderVariation = dto.ProviderVariation;
-
-                    await _modelRepository.UpdateModelAsync(model);
-
-                    LogAdminAudit("Updated", "ModelIdentifier", identifierId,
-                        $"ModelId: {id}, Identifier: {LoggingSanitizer.S(dto.Identifier)}");
-
-                    return (IActionResult)NoContent();
-                },
-                result => result,
-                "UpdateModelIdentifier",
-                new { Id = id, IdentifierId = identifierId });
+            return NoContent();
         }
 
         /// <summary>
@@ -260,24 +246,19 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}/identifiers/{identifierId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public Task<IActionResult> DeleteModelIdentifier(int id, int identifierId)
+        public async Task<IActionResult> DeleteModelIdentifier(int id, int identifierId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Directly delete the identifier from the repository
-                    var deleted = await _modelRepository.DeleteIdentifierAsync(id, identifierId);
+            // Directly delete the identifier from the repository
+            var deleted = await _modelRepository.DeleteIdentifierAsync(id, identifierId);
 
-                    if (!deleted)
-                    {
-                        throw new KeyNotFoundException($"Identifier with ID {identifierId} not found for model {id}");
-                    }
+            if (!deleted)
+            {
+                throw new KeyNotFoundException($"Identifier with ID {identifierId} not found for model {id}");
+            }
 
-                    LogAdminAudit("Deleted", "ModelIdentifier", identifierId, $"ModelId: {id}");
-                },
-                NoContent(),
-                "DeleteModelIdentifier",
-                new { Id = id, IdentifierId = identifierId });
+            LogAdminAudit("Deleted", "ModelIdentifier", identifierId, $"ModelId: {id}");
+
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.ProviderMappings.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.ProviderMappings.cs
@@ -16,19 +16,19 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<ModelProviderMappingDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelProviderMappings(int id)
+        public async Task<IActionResult> GetModelProviderMappings(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelRepository.GetByIdAsync(id),
-                async model =>
-                {
-                    // Get all mappings for this model
-                    var mappings = await _mappingService.GetMappingsByModelIdAsync(id);
-                    var dtos = mappings.Select(m => m.ToDto());
+            var model = await _modelRepository.GetByIdAsync(id);
+            if (model == null)
+            {
+                return this.NotFoundEntity("Model", id);
+            }
 
-                    return (IActionResult)Ok(dtos);
-                },
-                "Model", id, "GetModelProviderMappings");
+            // Get all mappings for this model
+            var mappings = await _mappingService.GetMappingsByModelIdAsync(id);
+            var dtos = mappings.Select(m => m.ToDto());
+
+            return Ok(dtos);
         }
 
         /// <summary>
@@ -43,53 +43,46 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateModelProviderMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
+        public async Task<IActionResult> CreateModelProviderMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Skip ModelId validation since it's no longer on the DTO
-                    // The ModelProviderTypeAssociationId provides the model relationship
+            // Skip ModelId validation since it's no longer on the DTO
+            // The ModelProviderTypeAssociationId provides the model relationship
 
-                    // Check if model exists
-                    var model = await _modelRepository.GetByIdAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+            // Check if model exists
+            var model = await _modelRepository.GetByIdAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
 
-                    // Check for duplicate mapping
-                    var existingMappings = await _mappingService.GetMappingsByModelIdAsync(id);
-                    if (existingMappings.Any(m => m.ProviderId == mappingDto.ProviderId))
-                    {
-                        return Conflict($"A mapping for model ID {id} with provider ID {mappingDto.ProviderId} already exists");
-                    }
+            // Check for duplicate mapping
+            var existingMappings = await _mappingService.GetMappingsByModelIdAsync(id);
+            if (existingMappings.Any(m => m.ProviderId == mappingDto.ProviderId))
+            {
+                return Conflict($"A mapping for model ID {id} with provider ID {mappingDto.ProviderId} already exists");
+            }
 
-                    // Create the mapping
-                    var mapping = mappingDto.ToEntity();
-                    var success = await _mappingService.AddMappingAsync(mapping);
+            // Create the mapping
+            var mapping = mappingDto.ToEntity();
+            var success = await _mappingService.AddMappingAsync(mapping);
 
-                    if (!success)
-                    {
-                        return BadRequest("Failed to create provider mapping");
-                    }
+            if (!success)
+            {
+                return BadRequest("Failed to create provider mapping");
+            }
 
-                    // Get the created mapping
-                    var createdMappings = await _mappingService.GetMappingsByModelIdAsync(id);
-                    var createdMapping = createdMappings.FirstOrDefault(m => m.ProviderId == mappingDto.ProviderId);
+            // Get the created mapping
+            var createdMappings = await _mappingService.GetMappingsByModelIdAsync(id);
+            var createdMapping = createdMappings.FirstOrDefault(m => m.ProviderId == mappingDto.ProviderId);
 
-                    LogAdminAudit("Created", "ModelProviderMapping", createdMapping?.Id,
-                        $"ModelId: {id}, ProviderId: {mappingDto.ProviderId}");
+            LogAdminAudit("Created", "ModelProviderMapping", createdMapping?.Id,
+                $"ModelId: {id}, ProviderId: {mappingDto.ProviderId}");
 
-                    return CreatedAtAction(
-                        nameof(GetModelProviderMappings),
-                        new { id = id },
-                        createdMapping?.ToDto()
-                    );
-                },
-                result => result,
-                "CreateModelProviderMapping",
-                new { Id = id });
+            return CreatedAtAction(
+                nameof(GetModelProviderMappings),
+                new { id = id },
+                createdMapping?.ToDto()
+            );
         }
 
         /// <summary>
@@ -104,53 +97,46 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateModelProviderMapping(int id, int mappingId, [FromBody] ModelProviderMappingDto mappingDto)
+        public async Task<IActionResult> UpdateModelProviderMapping(int id, int mappingId, [FromBody] ModelProviderMappingDto mappingDto)
         {
             if (mappingDto.Id != mappingId)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Mapping ID in URL does not match Mapping ID in request body"));
+                return BadRequest("Mapping ID in URL does not match Mapping ID in request body");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Skip ModelId validation since it's no longer on the DTO
-                    // The ModelProviderTypeAssociationId provides the model relationship
+            // Skip ModelId validation since it's no longer on the DTO
+            // The ModelProviderTypeAssociationId provides the model relationship
 
-                    // Check if model exists
-                    var model = await _modelRepository.GetByIdAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+            // Check if model exists
+            var model = await _modelRepository.GetByIdAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
 
-                    // Get and update the mapping
-                    var existingMapping = await _mappingService.GetMappingByIdAsync(mappingId);
-                    if (existingMapping == null)
-                    {
-                        return NotFound($"Provider mapping with ID {mappingId} not found");
-                    }
+            // Get and update the mapping
+            var existingMapping = await _mappingService.GetMappingByIdAsync(mappingId);
+            if (existingMapping == null)
+            {
+                return NotFound($"Provider mapping with ID {mappingId} not found");
+            }
 
-                    if (existingMapping.ModelProviderTypeAssociation?.ModelId != id)
-                    {
-                        return BadRequest($"Mapping with ID {mappingId} does not belong to model with ID {id}");
-                    }
+            if (existingMapping.ModelProviderTypeAssociation?.ModelId != id)
+            {
+                return BadRequest($"Mapping with ID {mappingId} does not belong to model with ID {id}");
+            }
 
-                    existingMapping.UpdateFromDto(mappingDto);
-                    var success = await _mappingService.UpdateMappingAsync(existingMapping);
+            existingMapping.UpdateFromDto(mappingDto);
+            var success = await _mappingService.UpdateMappingAsync(existingMapping);
 
-                    if (!success)
-                    {
-                        return BadRequest("Failed to update provider mapping");
-                    }
+            if (!success)
+            {
+                return BadRequest("Failed to update provider mapping");
+            }
 
-                    LogAdminAudit("Updated", "ModelProviderMapping", mappingId, $"ModelId: {id}");
+            LogAdminAudit("Updated", "ModelProviderMapping", mappingId, $"ModelId: {id}");
 
-                    return (IActionResult)NoContent();
-                },
-                result => result,
-                "UpdateModelProviderMapping",
-                new { Id = id, MappingId = mappingId });
+            return NoContent();
         }
 
         /// <summary>
@@ -163,44 +149,37 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteModelProviderMapping(int id, int mappingId)
+        public async Task<IActionResult> DeleteModelProviderMapping(int id, int mappingId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Check if model exists
-                    var model = await _modelRepository.GetByIdAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+            // Check if model exists
+            var model = await _modelRepository.GetByIdAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
 
-                    // Check if mapping exists and belongs to this model
-                    var existingMapping = await _mappingService.GetMappingByIdAsync(mappingId);
-                    if (existingMapping == null)
-                    {
-                        return NotFound($"Provider mapping with ID {mappingId} not found");
-                    }
+            // Check if mapping exists and belongs to this model
+            var existingMapping = await _mappingService.GetMappingByIdAsync(mappingId);
+            if (existingMapping == null)
+            {
+                return NotFound($"Provider mapping with ID {mappingId} not found");
+            }
 
-                    if (existingMapping.ModelProviderTypeAssociation?.ModelId != id)
-                    {
-                        return BadRequest($"Mapping with ID {mappingId} does not belong to model with ID {id}");
-                    }
+            if (existingMapping.ModelProviderTypeAssociation?.ModelId != id)
+            {
+                return BadRequest($"Mapping with ID {mappingId} does not belong to model with ID {id}");
+            }
 
-                    var success = await _mappingService.DeleteMappingAsync(mappingId);
+            var success = await _mappingService.DeleteMappingAsync(mappingId);
 
-                    if (!success)
-                    {
-                        return BadRequest("Failed to delete provider mapping");
-                    }
+            if (!success)
+            {
+                return BadRequest("Failed to delete provider mapping");
+            }
 
-                    LogAdminAudit("Deleted", "ModelProviderMapping", mappingId, $"ModelId: {id}");
+            LogAdminAudit("Deleted", "ModelProviderMapping", mappingId, $"ModelId: {id}");
 
-                    return (IActionResult)NoContent();
-                },
-                result => result,
-                "DeleteModelProviderMapping",
-                new { Id = id, MappingId = mappingId });
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Models.Models;
 using ConduitLLM.Admin.Models.ModelSeries;
 using ConduitLLM.Admin.Models.ModelCapabilities;
@@ -26,6 +27,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public partial class ModelController : AdminControllerBase
     {
         private readonly IModelRepository _modelRepository;
@@ -64,7 +66,7 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllModels(
+        public async Task<IActionResult> GetAllModels(
             [FromQuery] int? page = null,
             [FromQuery] int? pageSize = null,
             [FromQuery] string? search = null,
@@ -79,32 +81,26 @@ namespace ConduitLLM.Admin.Controllers
                 if (pageSize.Value > 100) pageSize = 100;
             }
 
-            return ExecuteAsync(
-                async () =>
+            var (models, totalCount) = await _modelRepository.GetPaginatedWithFilterAsync(
+                page, pageSize, search, capability, hasProviders);
+
+            var dtos = models.Select(m => m.ToDto()).ToList();
+
+            // Return paginated result when pagination params are provided
+            if (page.HasValue && pageSize.HasValue)
+            {
+                return Ok(new Configuration.DTOs.PagedResult<ModelDto>
                 {
-                    var (models, totalCount) = await _modelRepository.GetPaginatedWithFilterAsync(
-                        page, pageSize, search, capability, hasProviders);
+                    Items = dtos,
+                    TotalCount = totalCount,
+                    CurrentPage = page.Value,
+                    PageSize = pageSize.Value,
+                    TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize.Value)
+                });
+            }
 
-                    var dtos = models.Select(m => m.ToDto()).ToList();
-
-                    // Return paginated result when pagination params are provided
-                    if (page.HasValue && pageSize.HasValue)
-                    {
-                        return (object)new Configuration.DTOs.PagedResult<ModelDto>
-                        {
-                            Items = dtos,
-                            TotalCount = totalCount,
-                            CurrentPage = page.Value,
-                            PageSize = pageSize.Value,
-                            TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize.Value)
-                        };
-                    }
-
-                    // Backward compatible: return flat array
-                    return dtos;
-                },
-                result => Ok(result),
-                "GetAllModels");
+            // Backward compatible: return flat array
+            return Ok(dtos);
         }
 
         /// <summary>
@@ -116,12 +112,15 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelById(int id)
+        public async Task<IActionResult> GetModelById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelRepository.GetByIdWithDetailsAsync(id),
-                model => Ok(model.ToDto()),
-                "Model", id, "GetModelById");
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return this.NotFoundEntity("Model", id);
+            }
+
+            return Ok(model.ToDto());
         }
 
 
@@ -133,21 +132,15 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("search")]
         [ProducesResponseType(typeof(IEnumerable<ModelDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> SearchModels([FromQuery] string query)
+        public async Task<IActionResult> SearchModels([FromQuery] string query)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (string.IsNullOrWhiteSpace(query))
-                    {
-                        return (object)new List<ModelDto>();
-                    }
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return Ok(new List<ModelDto>());
+            }
 
-                    var models = await _modelRepository.SearchByNameAsync(query);
-                    return models.Select(m => m.ToDto());
-                },
-                result => Ok(result),
-                "SearchModels");
+            var models = await _modelRepository.SearchByNameAsync(query);
+            return Ok(models.Select(m => m.ToDto()));
         }
 
         /// <summary>
@@ -159,11 +152,11 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<ModelWithProviderIdDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelsByProvider(string provider)
+        public async Task<IActionResult> GetModelsByProvider(string provider)
         {
             if (string.IsNullOrWhiteSpace(provider))
             {
-                return Task.FromResult<IActionResult>(BadRequest("Provider name is required"));
+                return BadRequest("Provider name is required");
             }
 
             // Parse provider string to enum
@@ -171,50 +164,43 @@ namespace ConduitLLM.Admin.Controllers
             {
                 var validProviders = Enum.GetNames<ProviderType>()
                     .Select(p => p.ToLowerInvariant());
-                return Task.FromResult<IActionResult>(BadRequest($"Invalid provider '{provider}'. Valid providers: {string.Join(", ", validProviders)}"));
+                return BadRequest($"Invalid provider '{provider}'. Valid providers: {string.Join(", ", validProviders)}");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var models = await _modelRepository.GetByProviderAsync(providerType);
-                    return models.Select(m =>
-                    {
-                        // Repository already handles the provider string to enum conversion
-                        // Just get the first identifier for this model (they're already filtered by provider)
-                        var providerIdentifier = m.Identifiers?.FirstOrDefault()?.Identifier
-                            ?? m.Name; // Fallback to model name if no specific identifier
+            var models = await _modelRepository.GetByProviderAsync(providerType);
+            return Ok(models.Select(m =>
+            {
+                // Repository already handles the provider string to enum conversion
+                // Just get the first identifier for this model (they're already filtered by provider)
+                var providerIdentifier = m.Identifiers?.FirstOrDefault()?.Identifier
+                    ?? m.Name; // Fallback to model name if no specific identifier
 
-                        // Use MapToDto to get base DTO, then create extended DTO
-                        var baseDto = m.ToDto();
-                        return new ModelWithProviderIdDto
-                        {
-                            Id = baseDto.Id,
-                            Name = baseDto.Name,
-                            ProviderModelId = providerIdentifier,
-                            ModelSeriesId = baseDto.ModelSeriesId,
-                            IsActive = baseDto.IsActive,
-                            CreatedAt = baseDto.CreatedAt,
-                            UpdatedAt = baseDto.UpdatedAt,
-                            Series = baseDto.Series,
-                            ModelParameters = baseDto.ModelParameters,
-                            // Copy capability fields
-                            SupportsChat = baseDto.SupportsChat,
-                            SupportsVision = baseDto.SupportsVision,
-                            SupportsFunctionCalling = baseDto.SupportsFunctionCalling,
-                            SupportsStreaming = baseDto.SupportsStreaming,
-                            SupportsImageGeneration = baseDto.SupportsImageGeneration,
-                            SupportsVideoGeneration = baseDto.SupportsVideoGeneration,
-                            SupportsEmbeddings = baseDto.SupportsEmbeddings,
-                            MaxInputTokens = baseDto.MaxInputTokens,
-                            MaxOutputTokens = baseDto.MaxOutputTokens,
-                            TokenizerType = baseDto.TokenizerType
-                        };
-                    });
-                },
-                result => Ok(result),
-                "GetModelsByProvider",
-                new { Provider = provider });
+                // Use MapToDto to get base DTO, then create extended DTO
+                var baseDto = m.ToDto();
+                return new ModelWithProviderIdDto
+                {
+                    Id = baseDto.Id,
+                    Name = baseDto.Name,
+                    ProviderModelId = providerIdentifier,
+                    ModelSeriesId = baseDto.ModelSeriesId,
+                    IsActive = baseDto.IsActive,
+                    CreatedAt = baseDto.CreatedAt,
+                    UpdatedAt = baseDto.UpdatedAt,
+                    Series = baseDto.Series,
+                    ModelParameters = baseDto.ModelParameters,
+                    // Copy capability fields
+                    SupportsChat = baseDto.SupportsChat,
+                    SupportsVision = baseDto.SupportsVision,
+                    SupportsFunctionCalling = baseDto.SupportsFunctionCalling,
+                    SupportsStreaming = baseDto.SupportsStreaming,
+                    SupportsImageGeneration = baseDto.SupportsImageGeneration,
+                    SupportsVideoGeneration = baseDto.SupportsVideoGeneration,
+                    SupportsEmbeddings = baseDto.SupportsEmbeddings,
+                    MaxInputTokens = baseDto.MaxInputTokens,
+                    MaxOutputTokens = baseDto.MaxOutputTokens,
+                    TokenizerType = baseDto.TokenizerType
+                };
+            }));
         }
 
         /// <summary>
@@ -227,68 +213,62 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateModel([FromBody] CreateModelDto dto)
+        public async Task<IActionResult> CreateModel([FromBody] CreateModelDto dto)
         {
             if (dto == null)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Model data is required"));
+                return BadRequest("Model data is required");
             }
 
             if (string.IsNullOrWhiteSpace(dto.Name))
             {
-                return Task.FromResult<IActionResult>(BadRequest("Model name is required"));
+                return BadRequest("Model name is required");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Check if a model with the same name already exists
-                    var existing = await _modelRepository.GetByNameAsync(dto.Name);
-                    if (existing != null)
-                    {
-                        return (IActionResult)Conflict($"A model with name '{dto.Name}' already exists");
-                    }
+            // Check if a model with the same name already exists
+            var existing = await _modelRepository.GetByNameAsync(dto.Name);
+            if (existing != null)
+            {
+                return Conflict($"A model with name '{dto.Name}' already exists");
+            }
 
-                    var model = new Model
-                    {
-                        Name = dto.Name,
-                        ModelSeriesId = dto.ModelSeriesId,
-                        ModelParameters = dto.ModelParameters,
-                        IsActive = dto.IsActive ?? true,
-                        // Set capability fields directly
-                        SupportsChat = dto.SupportsChat,
-                        SupportsVision = dto.SupportsVision,
-                        SupportsFunctionCalling = dto.SupportsFunctionCalling,
-                        SupportsStreaming = dto.SupportsStreaming,
-                        SupportsImageGeneration = dto.SupportsImageGeneration,
-                        SupportsVideoGeneration = dto.SupportsVideoGeneration,
-                        SupportsEmbeddings = dto.SupportsEmbeddings,
-                        MaxInputTokens = dto.MaxInputTokens,
-                        MaxOutputTokens = dto.MaxOutputTokens,
-                        TokenizerType = dto.TokenizerType,
-                        CreatedAt = DateTime.UtcNow,
-                        UpdatedAt = DateTime.UtcNow
-                    };
+            var model = new Model
+            {
+                Name = dto.Name,
+                ModelSeriesId = dto.ModelSeriesId,
+                ModelParameters = dto.ModelParameters,
+                IsActive = dto.IsActive ?? true,
+                // Set capability fields directly
+                SupportsChat = dto.SupportsChat,
+                SupportsVision = dto.SupportsVision,
+                SupportsFunctionCalling = dto.SupportsFunctionCalling,
+                SupportsStreaming = dto.SupportsStreaming,
+                SupportsImageGeneration = dto.SupportsImageGeneration,
+                SupportsVideoGeneration = dto.SupportsVideoGeneration,
+                SupportsEmbeddings = dto.SupportsEmbeddings,
+                MaxInputTokens = dto.MaxInputTokens,
+                MaxOutputTokens = dto.MaxOutputTokens,
+                TokenizerType = dto.TokenizerType,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-                    await _modelRepository.CreateModelAsync(model);
+            await _modelRepository.CreateModelAsync(model);
 
-                    // Reload with capabilities
-                    model = await _modelRepository.GetByIdWithDetailsAsync(model.Id);
-                    if (model == null)
-                    {
-                        return StatusCode(StatusCodes.Status500InternalServerError, "Failed to reload created model");
-                    }
+            // Reload with capabilities
+            model = await _modelRepository.GetByIdWithDetailsAsync(model.Id);
+            if (model == null)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, "Failed to reload created model");
+            }
 
-                    LogAdminAudit("Created", "Model", model.Id, $"Name: {LoggingSanitizer.S(model.Name)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("model", "create");
+            LogAdminAudit("Created", "Model", model.Id, $"Name: {LoggingSanitizer.S(model.Name)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("model", "create");
 
-                    return CreatedAtAction(
-                        nameof(GetModelById),
-                        new { id = model.Id },
-                        model.ToDto());
-                },
-                result => result,
-                "CreateModel");
+            return CreatedAtAction(
+                nameof(GetModelById),
+                new { id = model.Id },
+                model.ToDto());
         }
 
         /// <summary>
@@ -303,157 +283,150 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateModel(int id, [FromBody] UpdateModelDto dto)
+        public async Task<IActionResult> UpdateModel(int id, [FromBody] UpdateModelDto dto)
         {
             if (dto == null)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Update data is required"));
+                return BadRequest("Update data is required");
             }
 
-            return ExecuteAsync(
-                async () =>
+            var model = await _modelRepository.GetByIdWithDetailsAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
+
+            // Capture pre-state for change tracking
+            var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+
+            // Check for name conflicts if name is being changed
+            if (!string.IsNullOrEmpty(dto.Name) && dto.Name != model.Name)
+            {
+                var existing = await _modelRepository.GetByNameAsync(dto.Name);
+                if (existing != null && existing.Id != id)
                 {
-                    var model = await _modelRepository.GetByIdWithDetailsAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+                    return Conflict($"A model with name '{dto.Name}' already exists");
+                }
+                changes.Add(("Name", model.Name, dto.Name));
+                model.Name = dto.Name;
+            }
 
-                    // Capture pre-state for change tracking
-                    var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+            if (dto.ModelSeriesId.HasValue && model.ModelSeriesId != dto.ModelSeriesId.Value)
+            {
+                changes.Add(("ModelSeriesId", model.ModelSeriesId.ToString(), dto.ModelSeriesId.Value.ToString()));
+                model.ModelSeriesId = dto.ModelSeriesId.Value;
+            }
+            else if (dto.ModelSeriesId.HasValue)
+            {
+                model.ModelSeriesId = dto.ModelSeriesId.Value;
+            }
 
-                    // Check for name conflicts if name is being changed
-                    if (!string.IsNullOrEmpty(dto.Name) && dto.Name != model.Name)
-                    {
-                        var existing = await _modelRepository.GetByNameAsync(dto.Name);
-                        if (existing != null && existing.Id != id)
-                        {
-                            return Conflict($"A model with name '{dto.Name}' already exists");
-                        }
-                        changes.Add(("Name", model.Name, dto.Name));
-                        model.Name = dto.Name;
-                    }
+            if (dto.IsActive.HasValue && model.IsActive != dto.IsActive.Value)
+            {
+                changes.Add(("IsActive", model.IsActive.ToString(), dto.IsActive.Value.ToString()));
+                model.IsActive = dto.IsActive.Value;
+            }
+            else if (dto.IsActive.HasValue)
+            {
+                model.IsActive = dto.IsActive.Value;
+            }
 
-                    if (dto.ModelSeriesId.HasValue && model.ModelSeriesId != dto.ModelSeriesId.Value)
-                    {
-                        changes.Add(("ModelSeriesId", model.ModelSeriesId.ToString(), dto.ModelSeriesId.Value.ToString()));
-                        model.ModelSeriesId = dto.ModelSeriesId.Value;
-                    }
-                    else if (dto.ModelSeriesId.HasValue)
-                    {
-                        model.ModelSeriesId = dto.ModelSeriesId.Value;
-                    }
+            if (dto.ModelParameters != null)
+            {
+                var newParams = string.IsNullOrWhiteSpace(dto.ModelParameters) ? null : dto.ModelParameters;
+                if (model.ModelParameters != newParams)
+                    changes.Add(("ModelParameters", model.ModelParameters ?? "null", newParams ?? "null"));
+                model.ModelParameters = newParams;
+            }
 
-                    if (dto.IsActive.HasValue && model.IsActive != dto.IsActive.Value)
-                    {
-                        changes.Add(("IsActive", model.IsActive.ToString(), dto.IsActive.Value.ToString()));
-                        model.IsActive = dto.IsActive.Value;
-                    }
-                    else if (dto.IsActive.HasValue)
-                    {
-                        model.IsActive = dto.IsActive.Value;
-                    }
+            // Update capability fields with change tracking
+            if (dto.SupportsChat.HasValue)
+            {
+                if (model.SupportsChat != dto.SupportsChat.Value)
+                    changes.Add(("SupportsChat", model.SupportsChat.ToString(), dto.SupportsChat.Value.ToString()));
+                model.SupportsChat = dto.SupportsChat.Value;
+            }
+            if (dto.SupportsVision.HasValue)
+            {
+                if (model.SupportsVision != dto.SupportsVision.Value)
+                    changes.Add(("SupportsVision", model.SupportsVision.ToString(), dto.SupportsVision.Value.ToString()));
+                model.SupportsVision = dto.SupportsVision.Value;
+            }
+            if (dto.SupportsFunctionCalling.HasValue)
+            {
+                if (model.SupportsFunctionCalling != dto.SupportsFunctionCalling.Value)
+                    changes.Add(("SupportsFunctionCalling", model.SupportsFunctionCalling.ToString(), dto.SupportsFunctionCalling.Value.ToString()));
+                model.SupportsFunctionCalling = dto.SupportsFunctionCalling.Value;
+            }
+            if (dto.SupportsStreaming.HasValue)
+            {
+                if (model.SupportsStreaming != dto.SupportsStreaming.Value)
+                    changes.Add(("SupportsStreaming", model.SupportsStreaming.ToString(), dto.SupportsStreaming.Value.ToString()));
+                model.SupportsStreaming = dto.SupportsStreaming.Value;
+            }
+            if (dto.SupportsImageGeneration.HasValue)
+            {
+                if (model.SupportsImageGeneration != dto.SupportsImageGeneration.Value)
+                    changes.Add(("SupportsImageGeneration", model.SupportsImageGeneration.ToString(), dto.SupportsImageGeneration.Value.ToString()));
+                model.SupportsImageGeneration = dto.SupportsImageGeneration.Value;
+            }
+            if (dto.SupportsVideoGeneration.HasValue)
+            {
+                if (model.SupportsVideoGeneration != dto.SupportsVideoGeneration.Value)
+                    changes.Add(("SupportsVideoGeneration", model.SupportsVideoGeneration.ToString(), dto.SupportsVideoGeneration.Value.ToString()));
+                model.SupportsVideoGeneration = dto.SupportsVideoGeneration.Value;
+            }
+            if (dto.SupportsEmbeddings.HasValue)
+            {
+                if (model.SupportsEmbeddings != dto.SupportsEmbeddings.Value)
+                    changes.Add(("SupportsEmbeddings", model.SupportsEmbeddings.ToString(), dto.SupportsEmbeddings.Value.ToString()));
+                model.SupportsEmbeddings = dto.SupportsEmbeddings.Value;
+            }
 
-                    if (dto.ModelParameters != null)
-                    {
-                        var newParams = string.IsNullOrWhiteSpace(dto.ModelParameters) ? null : dto.ModelParameters;
-                        if (model.ModelParameters != newParams)
-                            changes.Add(("ModelParameters", model.ModelParameters ?? "null", newParams ?? "null"));
-                        model.ModelParameters = newParams;
-                    }
+            // For nullable int fields, always update since frontend always sends them
+            if (model.MaxInputTokens != dto.MaxInputTokens)
+                changes.Add(("MaxInputTokens", model.MaxInputTokens?.ToString() ?? "null", dto.MaxInputTokens?.ToString() ?? "null"));
+            model.MaxInputTokens = dto.MaxInputTokens;
 
-                    // Update capability fields with change tracking
-                    if (dto.SupportsChat.HasValue)
-                    {
-                        if (model.SupportsChat != dto.SupportsChat.Value)
-                            changes.Add(("SupportsChat", model.SupportsChat.ToString(), dto.SupportsChat.Value.ToString()));
-                        model.SupportsChat = dto.SupportsChat.Value;
-                    }
-                    if (dto.SupportsVision.HasValue)
-                    {
-                        if (model.SupportsVision != dto.SupportsVision.Value)
-                            changes.Add(("SupportsVision", model.SupportsVision.ToString(), dto.SupportsVision.Value.ToString()));
-                        model.SupportsVision = dto.SupportsVision.Value;
-                    }
-                    if (dto.SupportsFunctionCalling.HasValue)
-                    {
-                        if (model.SupportsFunctionCalling != dto.SupportsFunctionCalling.Value)
-                            changes.Add(("SupportsFunctionCalling", model.SupportsFunctionCalling.ToString(), dto.SupportsFunctionCalling.Value.ToString()));
-                        model.SupportsFunctionCalling = dto.SupportsFunctionCalling.Value;
-                    }
-                    if (dto.SupportsStreaming.HasValue)
-                    {
-                        if (model.SupportsStreaming != dto.SupportsStreaming.Value)
-                            changes.Add(("SupportsStreaming", model.SupportsStreaming.ToString(), dto.SupportsStreaming.Value.ToString()));
-                        model.SupportsStreaming = dto.SupportsStreaming.Value;
-                    }
-                    if (dto.SupportsImageGeneration.HasValue)
-                    {
-                        if (model.SupportsImageGeneration != dto.SupportsImageGeneration.Value)
-                            changes.Add(("SupportsImageGeneration", model.SupportsImageGeneration.ToString(), dto.SupportsImageGeneration.Value.ToString()));
-                        model.SupportsImageGeneration = dto.SupportsImageGeneration.Value;
-                    }
-                    if (dto.SupportsVideoGeneration.HasValue)
-                    {
-                        if (model.SupportsVideoGeneration != dto.SupportsVideoGeneration.Value)
-                            changes.Add(("SupportsVideoGeneration", model.SupportsVideoGeneration.ToString(), dto.SupportsVideoGeneration.Value.ToString()));
-                        model.SupportsVideoGeneration = dto.SupportsVideoGeneration.Value;
-                    }
-                    if (dto.SupportsEmbeddings.HasValue)
-                    {
-                        if (model.SupportsEmbeddings != dto.SupportsEmbeddings.Value)
-                            changes.Add(("SupportsEmbeddings", model.SupportsEmbeddings.ToString(), dto.SupportsEmbeddings.Value.ToString()));
-                        model.SupportsEmbeddings = dto.SupportsEmbeddings.Value;
-                    }
+            if (model.MaxOutputTokens != dto.MaxOutputTokens)
+                changes.Add(("MaxOutputTokens", model.MaxOutputTokens?.ToString() ?? "null", dto.MaxOutputTokens?.ToString() ?? "null"));
+            model.MaxOutputTokens = dto.MaxOutputTokens;
 
-                    // For nullable int fields, always update since frontend always sends them
-                    if (model.MaxInputTokens != dto.MaxInputTokens)
-                        changes.Add(("MaxInputTokens", model.MaxInputTokens?.ToString() ?? "null", dto.MaxInputTokens?.ToString() ?? "null"));
-                    model.MaxInputTokens = dto.MaxInputTokens;
+            model.UpdatedAt = DateTime.UtcNow;
 
-                    if (model.MaxOutputTokens != dto.MaxOutputTokens)
-                        changes.Add(("MaxOutputTokens", model.MaxOutputTokens?.ToString() ?? "null", dto.MaxOutputTokens?.ToString() ?? "null"));
-                    model.MaxOutputTokens = dto.MaxOutputTokens;
+            // Track if parameters were changed
+            bool parametersChanged = dto.ModelParameters != null;
 
-                    model.UpdatedAt = DateTime.UtcNow;
+            var updatedModel = await _modelRepository.UpdateModelAsync(model);
 
-                    // Track if parameters were changed
-                    bool parametersChanged = dto.ModelParameters != null;
+            // Publish ModelUpdated event for cache invalidation
+            var changedPropertyNames = changes.Count > 0
+                ? changes.Select(c => c.Property).ToArray()
+                : GetChangedProperties(dto);
 
-                    var updatedModel = await _modelRepository.UpdateModelAsync(model);
+            await _publishEndpoint.Publish(new ModelUpdated
+            {
+                ModelId = updatedModel.Id,
+                ModelName = updatedModel.Name,
+                ModelSeriesId = updatedModel.ModelSeriesId,
+                ChangeType = "Updated",
+                ParametersChanged = parametersChanged,
+                ChangedProperties = changedPropertyNames
+            });
 
-                    // Publish ModelUpdated event for cache invalidation
-                    var changedPropertyNames = changes.Count > 0
-                        ? changes.Select(c => c.Property).ToArray()
-                        : GetChangedProperties(dto);
+            if (changes.Count > 0)
+            {
+                LogAdminAuditWithChanges("Model", updatedModel.Id, changes,
+                    $"Name: {LoggingSanitizer.S(updatedModel.Name)}");
+            }
+            else
+            {
+                LogAdminAudit("Updated", "Model", updatedModel.Id,
+                    $"Name: {LoggingSanitizer.S(updatedModel.Name)}, no value changes detected");
+            }
+            AdminOperationsMetricsService.RecordConfigurationChange("model", "update");
 
-                    await _publishEndpoint.Publish(new ModelUpdated
-                    {
-                        ModelId = updatedModel.Id,
-                        ModelName = updatedModel.Name,
-                        ModelSeriesId = updatedModel.ModelSeriesId,
-                        ChangeType = "Updated",
-                        ParametersChanged = parametersChanged,
-                        ChangedProperties = changedPropertyNames
-                    });
-
-                    if (changes.Count > 0)
-                    {
-                        LogAdminAuditWithChanges("Model", updatedModel.Id, changes,
-                            $"Name: {LoggingSanitizer.S(updatedModel.Name)}");
-                    }
-                    else
-                    {
-                        LogAdminAudit("Updated", "Model", updatedModel.Id,
-                            $"Name: {LoggingSanitizer.S(updatedModel.Name)}, no value changes detected");
-                    }
-                    AdminOperationsMetricsService.RecordConfigurationChange("model", "update");
-
-                    return (IActionResult)Ok(updatedModel.ToDto());
-                },
-                result => result,
-                "UpdateModel",
-                new { Id = id });
+            return Ok(updatedModel.ToDto());
         }
 
         /// <summary>
@@ -466,34 +439,27 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteModel(int id)
+        public async Task<IActionResult> DeleteModel(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var model = await _modelRepository.GetByIdAsync(id);
-                    if (model == null)
-                    {
-                        return (IActionResult)NotFound($"Model with ID {id} not found");
-                    }
+            var model = await _modelRepository.GetByIdAsync(id);
+            if (model == null)
+            {
+                return NotFound($"Model with ID {id} not found");
+            }
 
-                    // Check if model is referenced by any mappings
-                    var hasReferences = await _modelRepository.HasMappingReferencesAsync(id);
-                    if (hasReferences)
-                    {
-                        return Conflict("Cannot delete model that is referenced by model provider mappings");
-                    }
+            // Check if model is referenced by any mappings
+            var hasReferences = await _modelRepository.HasMappingReferencesAsync(id);
+            if (hasReferences)
+            {
+                return Conflict("Cannot delete model that is referenced by model provider mappings");
+            }
 
-                    await _modelRepository.DeleteAsync(id);
+            await _modelRepository.DeleteAsync(id);
 
-                    LogAdminAudit("Deleted", "Model", id);
-                    AdminOperationsMetricsService.RecordConfigurationChange("model", "delete");
+            LogAdminAudit("Deleted", "Model", id);
+            AdminOperationsMetricsService.RecordConfigurationChange("model", "delete");
 
-                    return (IActionResult)NoContent();
-                },
-                result => result,
-                "DeleteModel",
-                new { Id = id });
+            return NoContent();
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/ModelCostsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelCostsController.cs
@@ -1,6 +1,8 @@
 using ConduitLLM.Core.Extensions;
 using System.Text;
 
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Core.Models.Pricing;
@@ -17,6 +19,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ModelCostsController : AdminControllerBase
     {
         private readonly IAdminModelCostService _modelCostService;
@@ -48,47 +51,41 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelCostDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllModelCosts(
+        public async Task<IActionResult> GetAllModelCosts(
             [FromQuery] int? page = null,
             [FromQuery] int? pageSize = null,
             [FromQuery] string? modelType = null)
         {
-            return ExecuteAsync(
-                async () =>
+            var modelCosts = await _modelCostService.GetAllModelCostsAsync();
+
+            // Apply modelType filter if provided
+            if (!string.IsNullOrWhiteSpace(modelType))
+            {
+                modelCosts = modelCosts.Where(c =>
+                    string.Equals(c.ModelType, modelType, StringComparison.OrdinalIgnoreCase));
+            }
+
+            // If pagination parameters are provided, return paginated response
+            if (page.HasValue && pageSize.HasValue)
+            {
+                var totalCount = modelCosts.Count();
+                var items = modelCosts
+                    .Skip((page.Value - 1) * pageSize.Value)
+                    .Take(pageSize.Value)
+                    .ToList();
+
+                return Ok(new
                 {
-                    var modelCosts = await _modelCostService.GetAllModelCostsAsync();
+                    items = items,
+                    totalCount = totalCount,
+                    page = page.Value,
+                    pageSize = pageSize.Value,
+                    totalPages = (int)Math.Ceiling(totalCount / (double)pageSize.Value)
+                });
+            }
 
-                    // Apply modelType filter if provided
-                    if (!string.IsNullOrWhiteSpace(modelType))
-                    {
-                        modelCosts = modelCosts.Where(c =>
-                            string.Equals(c.ModelType, modelType, StringComparison.OrdinalIgnoreCase));
-                    }
-
-                    // If pagination parameters are provided, return paginated response
-                    if (page.HasValue && pageSize.HasValue)
-                    {
-                        var totalCount = modelCosts.Count();
-                        var items = modelCosts
-                            .Skip((page.Value - 1) * pageSize.Value)
-                            .Take(pageSize.Value)
-                            .ToList();
-
-                        return (object)new
-                        {
-                            items = items,
-                            totalCount = totalCount,
-                            page = page.Value,
-                            pageSize = pageSize.Value,
-                            totalPages = (int)Math.Ceiling(totalCount / (double)pageSize.Value)
-                        };
-                    }
-
-                    // Otherwise return all items (backward compatibility)
-                    return (object)modelCosts;
-                },
-                result => Ok(result),
-                "GetAllModelCosts");
+            // Otherwise return all items (backward compatibility)
+            return Ok(modelCosts);
         }
 
         /// <summary>
@@ -100,12 +97,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelCostById(int id)
+        public async Task<IActionResult> GetModelCostById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelCostService.GetModelCostByIdAsync(id),
-                Ok,
-                "Model cost", id, "GetModelCostById");
+            var modelCost = await _modelCostService.GetModelCostByIdAsync(id);
+            if (modelCost == null)
+            {
+                return this.NotFoundEntity("Model cost", id);
+            }
+            return Ok(modelCost);
         }
 
         /// <summary>
@@ -116,13 +115,10 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("provider/{providerId}")]
         [ProducesResponseType(typeof(IEnumerable<ModelCostDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelCostsByProvider(int providerId)
+        public async Task<IActionResult> GetModelCostsByProvider(int providerId)
         {
-            return ExecuteAsync(
-                () => _modelCostService.GetModelCostsByProviderAsync(providerId),
-                result => Ok(result),
-                "GetModelCostsByProvider",
-                new { ProviderId = providerId });
+            var result = await _modelCostService.GetModelCostsByProviderAsync(providerId);
+            return Ok(result);
         }
 
         /// <summary>
@@ -134,12 +130,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelCostByCostName(string costName)
+        public async Task<IActionResult> GetModelCostByCostName(string costName)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _modelCostService.GetModelCostByCostNameAsync(costName),
-                Ok,
-                "Model cost", costName, "GetModelCostByCostName");
+            var modelCost = await _modelCostService.GetModelCostByCostNameAsync(costName);
+            if (modelCost == null)
+            {
+                return this.NotFoundEntity("Model cost", costName);
+            }
+            return Ok(modelCost);
         }
 
         /// <summary>
@@ -151,17 +149,11 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateModelCost([FromBody] CreateModelCostDto modelCost)
+        public async Task<IActionResult> CreateModelCost([FromBody] CreateModelCostDto modelCost)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var result = await _modelCostService.CreateModelCostAsync(modelCost);
-                    LogAdminAudit("Created", "ModelCost", result.Id, $"CostName: {LoggingSanitizer.S(result.CostName)}");
-                    return result;
-                },
-                result => CreatedAtAction(nameof(GetModelCostById), new { id = result.Id }, result),
-                "CreateModelCost");
+            var result = await _modelCostService.CreateModelCostAsync(modelCost);
+            LogAdminAudit("Created", "ModelCost", result.Id, $"CostName: {LoggingSanitizer.S(result.CostName)}");
+            return CreatedAtAction(nameof(GetModelCostById), new { id = result.Id }, result);
         }
 
         /// <summary>
@@ -175,29 +167,24 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateModelCost(int id, [FromBody] UpdateModelCostDto modelCost)
+        public async Task<IActionResult> UpdateModelCost(int id, [FromBody] UpdateModelCostDto modelCost)
         {
             // Ensure ID in route matches ID in body
             if (id != modelCost.Id)
             {
-                return Task.FromResult<IActionResult>(BadRequest("ID in route must match ID in body"));
+                return BadRequest("ID in route must match ID in body");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var success = await _modelCostService.UpdateModelCostAsync(modelCost);
+            var success = await _modelCostService.UpdateModelCostAsync(modelCost);
 
-                    if (!success)
-                    {
-                        throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
-                    }
+            if (!success)
+            {
+                throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
+            }
 
-                    LogAdminAudit("Updated", "ModelCost", id, $"CostName: {LoggingSanitizer.S(modelCost.CostName)}");
-                },
-                NoContent(),
-                "UpdateModelCost",
-                new { Id = id });
+            LogAdminAudit("Updated", "ModelCost", id, $"CostName: {LoggingSanitizer.S(modelCost.CostName)}");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -209,24 +196,19 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteModelCost(int id)
+        public async Task<IActionResult> DeleteModelCost(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var existing = await _modelCostService.GetModelCostByIdAsync(id);
-                    var success = await _modelCostService.DeleteModelCostAsync(id);
+            var existing = await _modelCostService.GetModelCostByIdAsync(id);
+            var success = await _modelCostService.DeleteModelCostAsync(id);
 
-                    if (!success)
-                    {
-                        throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
-                    }
+            if (!success)
+            {
+                throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
+            }
 
-                    LogAdminAudit("Deleted", "ModelCost", id, existing != null ? $"CostName: {LoggingSanitizer.S(existing.CostName)}" : null);
-                },
-                NoContent(),
-                "DeleteModelCost",
-                new { Id = id });
+            LogAdminAudit("Deleted", "ModelCost", id, existing != null ? $"CostName: {LoggingSanitizer.S(existing.CostName)}" : null);
+
+            return NoContent();
         }
 
         /// <summary>
@@ -239,20 +221,17 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<ModelCostOverviewDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelCostOverview(
+        public async Task<IActionResult> GetModelCostOverview(
             [FromQuery] DateTime startDate,
             [FromQuery] DateTime endDate)
         {
             if (startDate > endDate)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Start date cannot be after end date"));
+                return BadRequest("Start date cannot be after end date");
             }
 
-            return ExecuteAsync(
-                () => _modelCostService.GetModelCostOverviewAsync(startDate, endDate),
-                result => Ok(result),
-                "GetModelCostOverview",
-                new { StartDate = startDate, EndDate = endDate });
+            var result = await _modelCostService.GetModelCostOverviewAsync(startDate, endDate);
+            return Ok(result);
         }
 
         /// <summary>
@@ -264,22 +243,16 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ImportModelCosts([FromBody] IEnumerable<CreateModelCostDto> modelCosts)
+        public async Task<IActionResult> ImportModelCosts([FromBody] IEnumerable<CreateModelCostDto> modelCosts)
         {
             if (modelCosts == null || !modelCosts.Any())
             {
-                return Task.FromResult<IActionResult>(BadRequest("No model costs provided for import"));
+                return BadRequest("No model costs provided for import");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var result = await _modelCostService.ImportModelCostsAsync(modelCosts);
-                    LogAdminAudit("Imported", "ModelCost", detail: $"Count: {result}");
-                    return result;
-                },
-                result => Ok(result),
-                "ImportModelCosts");
+            var result = await _modelCostService.ImportModelCostsAsync(modelCosts);
+            LogAdminAudit("Imported", "ModelCost", detail: $"Count: {result}");
+            return Ok(result);
         }
 
         /// <summary>
@@ -290,17 +263,12 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("export/csv")]
         [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ExportCsv([FromQuery] int? providerId = null)
+        public async Task<IActionResult> ExportCsv([FromQuery] int? providerId = null)
         {
-            return ExecuteAsync(
-                () => _modelCostService.ExportModelCostsAsync("csv", providerId),
-                result =>
-                {
-                    var bytes = Encoding.UTF8.GetBytes(result);
-                    var fileName = $"model-costs-{DateTime.UtcNow:yyyy-MM-dd-HHmmss}.csv";
-                    return File(bytes, "text/csv", fileName);
-                },
-                "ExportCsv");
+            var result = await _modelCostService.ExportModelCostsAsync("csv", providerId);
+            var bytes = Encoding.UTF8.GetBytes(result);
+            var fileName = $"model-costs-{DateTime.UtcNow:yyyy-MM-dd-HHmmss}.csv";
+            return File(bytes, "text/csv", fileName);
         }
 
         /// <summary>
@@ -311,17 +279,12 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("export/json")]
         [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ExportJson([FromQuery] int? providerId = null)
+        public async Task<IActionResult> ExportJson([FromQuery] int? providerId = null)
         {
-            return ExecuteAsync(
-                () => _modelCostService.ExportModelCostsAsync("json", providerId),
-                result =>
-                {
-                    var bytes = Encoding.UTF8.GetBytes(result);
-                    var fileName = $"model-costs-{DateTime.UtcNow:yyyy-MM-dd-HHmmss}.json";
-                    return File(bytes, "application/json", fileName);
-                },
-                "ExportJson");
+            var result = await _modelCostService.ExportModelCostsAsync("json", providerId);
+            var bytes = Encoding.UTF8.GetBytes(result);
+            var fileName = $"model-costs-{DateTime.UtcNow:yyyy-MM-dd-HHmmss}.json";
+            return File(bytes, "application/json", fileName);
         }
 
         /// <summary>
@@ -333,42 +296,36 @@ namespace ConduitLLM.Admin.Controllers
         // [ProducesResponseType(typeof(BulkImportResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ImportCsv(IFormFile file)
+        public async Task<IActionResult> ImportCsv(IFormFile file)
         {
             if (file == null || file.Length == 0)
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("No file provided for import")));
+                return BadRequest(new ErrorResponseDto("No file provided for import"));
             }
 
             if (!file.FileName.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("File must be a CSV file")));
+                return BadRequest(new ErrorResponseDto("File must be a CSV file"));
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var reader = new StreamReader(file.OpenReadStream());
-                    var csvData = await reader.ReadToEndAsync();
+            using var reader = new StreamReader(file.OpenReadStream());
+            var csvData = await reader.ReadToEndAsync();
 
-                    var result = await _modelCostService.ImportModelCostsAsync(csvData, "csv");
+            var result = await _modelCostService.ImportModelCostsAsync(csvData, "csv");
 
-                    if (result.SuccessCount == 0 && result.FailureCount > 0)
-                    {
-                        throw new InvalidOperationException(
-                            System.Text.Json.JsonSerializer.Serialize(new {
-                                message = "Import failed",
-                                errors = result.Errors,
-                                successCount = result.SuccessCount,
-                                failureCount = result.FailureCount
-                            }));
-                    }
+            if (result.SuccessCount == 0 && result.FailureCount > 0)
+            {
+                throw new InvalidOperationException(
+                    System.Text.Json.JsonSerializer.Serialize(new {
+                        message = "Import failed",
+                        errors = result.Errors,
+                        successCount = result.SuccessCount,
+                        failureCount = result.FailureCount
+                    }));
+            }
 
-                    LogAdminAuditBulk("ImportedCsv", "ModelCost", result.SuccessCount, result.FailureCount);
-                    return result;
-                },
-                result => Ok(result),
-                "ImportCsv");
+            LogAdminAuditBulk("ImportedCsv", "ModelCost", result.SuccessCount, result.FailureCount);
+            return Ok(result);
         }
 
         /// <summary>
@@ -380,42 +337,36 @@ namespace ConduitLLM.Admin.Controllers
         // [ProducesResponseType(typeof(BulkImportResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ImportJson(IFormFile file)
+        public async Task<IActionResult> ImportJson(IFormFile file)
         {
             if (file == null || file.Length == 0)
             {
-                return Task.FromResult<IActionResult>(BadRequest("No file provided for import"));
+                return BadRequest("No file provided for import");
             }
 
             if (!file.FileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.FromResult<IActionResult>(BadRequest("File must be a JSON file"));
+                return BadRequest("File must be a JSON file");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var reader = new StreamReader(file.OpenReadStream());
-                    var jsonData = await reader.ReadToEndAsync();
+            using var reader = new StreamReader(file.OpenReadStream());
+            var jsonData = await reader.ReadToEndAsync();
 
-                    var result = await _modelCostService.ImportModelCostsAsync(jsonData, "json");
+            var result = await _modelCostService.ImportModelCostsAsync(jsonData, "json");
 
-                    if (result.SuccessCount == 0 && result.FailureCount > 0)
-                    {
-                        throw new InvalidOperationException(
-                            System.Text.Json.JsonSerializer.Serialize(new {
-                                message = "Import failed",
-                                errors = result.Errors,
-                                successCount = result.SuccessCount,
-                                failureCount = result.FailureCount
-                            }));
-                    }
+            if (result.SuccessCount == 0 && result.FailureCount > 0)
+            {
+                throw new InvalidOperationException(
+                    System.Text.Json.JsonSerializer.Serialize(new {
+                        message = "Import failed",
+                        errors = result.Errors,
+                        successCount = result.SuccessCount,
+                        failureCount = result.FailureCount
+                    }));
+            }
 
-                    LogAdminAuditBulk("ImportedJson", "ModelCost", result.SuccessCount, result.FailureCount);
-                    return result;
-                },
-                result => Ok(result),
-                "ImportJson");
+            LogAdminAuditBulk("ImportedJson", "ModelCost", result.SuccessCount, result.FailureCount);
+            return Ok(result);
         }
 
         /// <summary>
@@ -429,40 +380,34 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ValidatePricingRules(
+        public async Task<IActionResult> ValidatePricingRules(
             int id,
             [FromBody] ValidatePricingRulesRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.PricingConfiguration))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Pricing configuration is required")));
+                return BadRequest(new ErrorResponseDto("Pricing configuration is required"));
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Verify the model cost exists
-                    var modelCost = await _modelCostService.GetModelCostByIdAsync(id);
-                    if (modelCost == null)
-                    {
-                        throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
-                    }
+            // Verify the model cost exists
+            var modelCost = await _modelCostService.GetModelCostByIdAsync(id);
+            if (modelCost == null)
+            {
+                throw new KeyNotFoundException($"Model cost with ID '{id}' not found");
+            }
 
-                    // Get parameter schema from associated model if available
-                    string? parameterSchema = null;
-                    if (!string.IsNullOrEmpty(request.ParameterSchema))
-                    {
-                        // Use provided schema (for testing or when model schema is known)
-                        parameterSchema = request.ParameterSchema;
-                    }
-                    // TODO: In the future, we could look up the model's parameter schema from ModelSeries
+            // Get parameter schema from associated model if available
+            string? parameterSchema = null;
+            if (!string.IsNullOrEmpty(request.ParameterSchema))
+            {
+                // Use provided schema (for testing or when model schema is known)
+                parameterSchema = request.ParameterSchema;
+            }
+            // TODO: In the future, we could look up the model's parameter schema from ModelSeries
 
-                    // Validate the configuration
-                    return _pricingRulesValidator.ValidateJson(request.PricingConfiguration, parameterSchema);
-                },
-                result => Ok(result),
-                "ValidatePricingRules",
-                new { Id = id });
+            // Validate the configuration
+            var result = _pricingRulesValidator.ValidateJson(request.PricingConfiguration, parameterSchema);
+            return Ok(result);
         }
 
         /// <summary>
@@ -474,23 +419,19 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ValidationResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ValidatePricingRulesStandalone([FromBody] ValidatePricingRulesRequest request)
+        public async Task<IActionResult> ValidatePricingRulesStandalone([FromBody] ValidatePricingRulesRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.PricingConfiguration))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("Pricing configuration is required")));
+                return BadRequest(new ErrorResponseDto("Pricing configuration is required"));
             }
 
-            return ExecuteAsync(
-                () =>
-                {
-                    var result = _pricingRulesValidator.ValidateJson(
-                        request.PricingConfiguration,
-                        request.ParameterSchema);
-                    return Task.FromResult(result);
-                },
-                result => Ok(result),
-                "ValidatePricingRulesStandalone");
+            await Task.CompletedTask;
+
+            var result = _pricingRulesValidator.ValidateJson(
+                request.PricingConfiguration,
+                request.ParameterSchema);
+            return Ok(result);
         }
     }
 

--- a/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
@@ -1,5 +1,7 @@
 using ConduitLLM.Configuration.Interfaces;
 
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
@@ -18,6 +20,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class ModelProviderMappingController : AdminControllerBase
 {
     private readonly IAdminModelProviderMappingService _mappingService;
@@ -46,16 +49,11 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<ModelProviderMappingDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetAllMappings()
+    public async Task<IActionResult> GetAllMappings()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var mappings = await _mappingService.GetAllMappingsAsync();
-                return mappings.Select(m => m.ToDto());
-            },
-            result => Ok(result),
-            "GetAllMappings");
+        var mappings = await _mappingService.GetAllMappingsAsync();
+        var result = mappings.Select(m => m.ToDto());
+        return Ok(result);
     }
 
     /// <summary>
@@ -67,12 +65,11 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(typeof(ModelProviderMappingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetMappingById(int id)
+    public async Task<IActionResult> GetMappingById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _mappingService.GetMappingByIdAsync(id),
-            mapping => Ok(mapping.ToDto()),
-            "Model provider mapping", id, "GetMappingById");
+        var mapping = await _mappingService.GetMappingByIdAsync(id);
+        if (mapping == null) { return this.NotFoundEntity("Model provider mapping", id); }
+        return Ok(mapping.ToDto());
     }
 
     /// <summary>
@@ -85,38 +82,32 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateMapping([FromBody] ModelProviderMappingDto mappingDto)
+    public async Task<IActionResult> CreateMapping([FromBody] ModelProviderMappingDto mappingDto)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // Check if a mapping with the same model alias already exists
-                var existingMappings = await _mappingService.GetAllMappingsAsync();
-                var existingMapping = existingMappings.FirstOrDefault(m => m.ModelAlias.Equals(mappingDto.ModelAlias, StringComparison.OrdinalIgnoreCase));
-                if (existingMapping != null)
-                {
-                    return (IActionResult)Conflict(new ErrorResponseDto($"A mapping for model alias '{mappingDto.ModelAlias}' already exists"));
-                }
+        // Check if a mapping with the same model alias already exists
+        var existingMappings = await _mappingService.GetAllMappingsAsync();
+        var existingMapping = existingMappings.FirstOrDefault(m => m.ModelAlias.Equals(mappingDto.ModelAlias, StringComparison.OrdinalIgnoreCase));
+        if (existingMapping != null)
+        {
+            return Conflict(new ErrorResponseDto($"A mapping for model alias '{mappingDto.ModelAlias}' already exists"));
+        }
 
-                var mapping = mappingDto.ToEntity();
-                var success = await _mappingService.AddMappingAsync(mapping);
+        var mapping = mappingDto.ToEntity();
+        var success = await _mappingService.AddMappingAsync(mapping);
 
-                if (!success)
-                {
-                    return BadRequest(new ErrorResponseDto("Failed to create model provider mapping. Please check the provider ID."));
-                }
+        if (!success)
+        {
+            return BadRequest(new ErrorResponseDto("Failed to create model provider mapping. Please check the provider ID."));
+        }
 
-                var createdMapping = await _mappingService.GetMappingByIdAsync(mapping.Id);
+        var createdMapping = await _mappingService.GetMappingByIdAsync(mapping.Id);
 
-                LogAdminAudit("Created", "ModelProviderMapping", createdMapping?.Id,
-                    $"ModelAlias: {LoggingSanitizer.S(mappingDto.ModelAlias)}, ProviderId: {mappingDto.ProviderId}");
-                AdminOperationsMetricsService.RecordModelMappingOperation("create", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "create");
+        LogAdminAudit("Created", "ModelProviderMapping", createdMapping?.Id,
+            $"ModelAlias: {LoggingSanitizer.S(mappingDto.ModelAlias)}, ProviderId: {mappingDto.ProviderId}");
+        AdminOperationsMetricsService.RecordModelMappingOperation("create", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "create");
 
-                return CreatedAtAction(nameof(GetMappingById), new { id = createdMapping?.Id }, createdMapping?.ToDto());
-            },
-            result => result,
-            "CreateMapping");
+        return CreatedAtAction(nameof(GetMappingById), new { id = createdMapping?.Id }, createdMapping?.ToDto());
     }
 
     /// <summary>
@@ -130,37 +121,32 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
+    public async Task<IActionResult> UpdateMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
     {
         if (id != mappingDto.Id)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("ID mismatch")));
+            return BadRequest(new ErrorResponseDto("ID mismatch"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                var existingMapping = await _mappingService.GetMappingByIdAsync(id);
-                if (existingMapping == null)
-                {
-                    throw new KeyNotFoundException($"Model provider mapping with ID '{id}' not found");
-                }
+        var existingMapping = await _mappingService.GetMappingByIdAsync(id);
+        if (existingMapping == null)
+        {
+            throw new KeyNotFoundException($"Model provider mapping with ID '{id}' not found");
+        }
 
-                existingMapping.UpdateFromDto(mappingDto);
-                var success = await _mappingService.UpdateMappingAsync(existingMapping);
+        existingMapping.UpdateFromDto(mappingDto);
+        var success = await _mappingService.UpdateMappingAsync(existingMapping);
 
-                if (!success)
-                {
-                    throw new InvalidOperationException("Failed to update model provider mapping");
-                }
+        if (!success)
+        {
+            throw new InvalidOperationException("Failed to update model provider mapping");
+        }
 
-                LogAdminAudit("Updated", "ModelProviderMapping", id);
-                AdminOperationsMetricsService.RecordModelMappingOperation("update", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "update");
-            },
-            NoContent(),
-            "UpdateMapping",
-            new { Id = id });
+        LogAdminAudit("Updated", "ModelProviderMapping", id);
+        AdminOperationsMetricsService.RecordModelMappingOperation("update", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "update");
+
+        return NoContent();
     }
 
     /// <summary>
@@ -172,31 +158,26 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteMapping(int id)
+    public async Task<IActionResult> DeleteMapping(int id)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var existingMapping = await _mappingService.GetMappingByIdAsync(id);
-                if (existingMapping == null)
-                {
-                    throw new KeyNotFoundException($"Model provider mapping with ID '{id}' not found");
-                }
+        var existingMapping = await _mappingService.GetMappingByIdAsync(id);
+        if (existingMapping == null)
+        {
+            throw new KeyNotFoundException($"Model provider mapping with ID '{id}' not found");
+        }
 
-                var success = await _mappingService.DeleteMappingAsync(id);
+        var success = await _mappingService.DeleteMappingAsync(id);
 
-                if (!success)
-                {
-                    throw new InvalidOperationException("Failed to delete model provider mapping");
-                }
+        if (!success)
+        {
+            throw new InvalidOperationException("Failed to delete model provider mapping");
+        }
 
-                LogAdminAudit("Deleted", "ModelProviderMapping", id);
-                AdminOperationsMetricsService.RecordModelMappingOperation("delete", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "delete");
-            },
-            NoContent(),
-            "DeleteMapping",
-            new { Id = id });
+        LogAdminAudit("Deleted", "ModelProviderMapping", id);
+        AdminOperationsMetricsService.RecordModelMappingOperation("delete", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "delete");
+
+        return NoContent();
     }
 
     /// <summary>
@@ -206,12 +187,10 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpGet("providers")]
     [ProducesResponseType(typeof(IEnumerable<Provider>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetProviders()
+    public async Task<IActionResult> GetProviders()
     {
-        return ExecuteAsync(
-            () => _mappingService.GetProvidersAsync(),
-            result => Ok(result),
-            "GetProviders");
+        var result = await _mappingService.GetProvidersAsync();
+        return Ok(result);
     }
 
     /// <summary>
@@ -223,35 +202,29 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(typeof(BulkMappingResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> CreateBulkMappings([FromBody] List<ModelProviderMappingDto> mappingDtos)
+    public async Task<IActionResult> CreateBulkMappings([FromBody] List<ModelProviderMappingDto> mappingDtos)
     {
         if (mappingDtos == null || !mappingDtos.Any())
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("No mappings provided")));
+            return BadRequest(new ErrorResponseDto("No mappings provided"));
         }
 
-        return ExecuteAsync(
-            async () =>
-            {
-                var mappings = mappingDtos.Select(dto => dto.ToEntity()).ToList();
-                var (created, errors) = await _mappingService.CreateBulkMappingsAsync(mappings);
+        var mappings = mappingDtos.Select(dto => dto.ToEntity()).ToList();
+        var (created, errors) = await _mappingService.CreateBulkMappingsAsync(mappings);
 
-                var result = new BulkMappingResult
-                {
-                    Created = created.Select(m => m.ToDto()).ToList(),
-                    Errors = errors.ToList(),
-                    TotalProcessed = mappingDtos.Count(),
-                    SuccessCount = created.Count(),
-                    FailureCount = errors.Count()
-                };
+        var result = new BulkMappingResult
+        {
+            Created = created.Select(m => m.ToDto()).ToList(),
+            Errors = errors.ToList(),
+            TotalProcessed = mappingDtos.Count(),
+            SuccessCount = created.Count(),
+            FailureCount = errors.Count()
+        };
 
-                LogAdminAuditBulk("BulkCreated", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
-                AdminOperationsMetricsService.RecordModelMappingOperation("bulk_create", "success");
+        LogAdminAuditBulk("BulkCreated", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
+        AdminOperationsMetricsService.RecordModelMappingOperation("bulk_create", "success");
 
-                return result;
-            },
-            result => Ok(result),
-            "CreateBulkMappings");
+        return Ok(result);
     }
 
     /// <summary>
@@ -263,63 +236,57 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(typeof(BulkDeleteResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteBulkMappings([FromBody] List<int> ids)
+    public async Task<IActionResult> DeleteBulkMappings([FromBody] List<int> ids)
     {
         if (ids == null || ids.Count == 0)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("No mapping IDs provided")));
+            return BadRequest(new ErrorResponseDto("No mapping IDs provided"));
         }
 
-        return ExecuteAsync(
-            async () =>
+        var deleted = new List<int>();
+        var errors = new List<string>();
+
+        foreach (var id in ids)
+        {
+            try
             {
-                var deleted = new List<int>();
-                var errors = new List<string>();
-
-                foreach (var id in ids)
+                var existingMapping = await _mappingService.GetMappingByIdAsync(id);
+                if (existingMapping == null)
                 {
-                    try
-                    {
-                        var existingMapping = await _mappingService.GetMappingByIdAsync(id);
-                        if (existingMapping == null)
-                        {
-                            errors.Add($"Mapping with ID {id} not found");
-                            continue;
-                        }
-
-                        var success = await _mappingService.DeleteMappingAsync(id);
-                        if (success)
-                        {
-                            deleted.Add(id);
-                        }
-                        else
-                        {
-                            errors.Add($"Failed to delete mapping with ID {id}");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError(ex, "Error deleting mapping with ID {Id}", id);
-                        errors.Add($"Error deleting mapping with ID {id}: {ex.Message}");
-                    }
+                    errors.Add($"Mapping with ID {id} not found");
+                    continue;
                 }
 
-                var result = new BulkDeleteResult
+                var success = await _mappingService.DeleteMappingAsync(id);
+                if (success)
                 {
-                    DeletedIds = deleted,
-                    Errors = errors,
-                    TotalProcessed = ids.Count,
-                    SuccessCount = deleted.Count,
-                    FailureCount = errors.Count
-                };
+                    deleted.Add(id);
+                }
+                else
+                {
+                    errors.Add($"Failed to delete mapping with ID {id}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error deleting mapping with ID {Id}", id);
+                errors.Add($"Error deleting mapping with ID {id}: {ex.Message}");
+            }
+        }
 
-                LogAdminAuditBulk("BulkDeleted", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
-                AdminOperationsMetricsService.RecordModelMappingOperation("bulk_delete", "success");
+        var result = new BulkDeleteResult
+        {
+            DeletedIds = deleted,
+            Errors = errors,
+            TotalProcessed = ids.Count,
+            SuccessCount = deleted.Count,
+            FailureCount = errors.Count
+        };
 
-                return result;
-            },
-            result => Ok(result),
-            "DeleteBulkMappings");
+        LogAdminAuditBulk("BulkDeleted", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
+        AdminOperationsMetricsService.RecordModelMappingOperation("bulk_delete", "success");
+
+        return Ok(result);
     }
 
     /// <summary>
@@ -350,65 +317,59 @@ public class ModelProviderMappingController : AdminControllerBase
         return await UpdateBulkMappingsStatus(ids, false);
     }
 
-    private Task<IActionResult> UpdateBulkMappingsStatus(List<int> ids, bool isEnabled)
+    private async Task<IActionResult> UpdateBulkMappingsStatus(List<int> ids, bool isEnabled)
     {
         if (ids == null || ids.Count == 0)
         {
-            return Task.FromResult<IActionResult>(BadRequest(new ErrorResponseDto("No mapping IDs provided")));
+            return BadRequest(new ErrorResponseDto("No mapping IDs provided"));
         }
 
-        return ExecuteAsync(
-            async () =>
+        var updated = new List<ModelProviderMappingDto>();
+        var errors = new List<string>();
+
+        foreach (var id in ids)
+        {
+            try
             {
-                var updated = new List<ModelProviderMappingDto>();
-                var errors = new List<string>();
-
-                foreach (var id in ids)
+                var existingMapping = await _mappingService.GetMappingByIdAsync(id);
+                if (existingMapping == null)
                 {
-                    try
-                    {
-                        var existingMapping = await _mappingService.GetMappingByIdAsync(id);
-                        if (existingMapping == null)
-                        {
-                            errors.Add($"Mapping with ID {id} not found");
-                            continue;
-                        }
-
-                        existingMapping.IsEnabled = isEnabled;
-                        var success = await _mappingService.UpdateMappingAsync(existingMapping);
-
-                        if (success)
-                        {
-                            updated.Add(existingMapping.ToDto());
-                        }
-                        else
-                        {
-                            errors.Add($"Failed to update mapping with ID {id}");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError(ex, "Error updating mapping with ID {Id}", id);
-                        errors.Add($"Error updating mapping with ID {id}: {ex.Message}");
-                    }
+                    errors.Add($"Mapping with ID {id} not found");
+                    continue;
                 }
 
-                var result = new BulkUpdateResult
+                existingMapping.IsEnabled = isEnabled;
+                var success = await _mappingService.UpdateMappingAsync(existingMapping);
+
+                if (success)
                 {
-                    Updated = updated,
-                    Errors = errors,
-                    TotalProcessed = ids.Count,
-                    SuccessCount = updated.Count,
-                    FailureCount = errors.Count
-                };
+                    updated.Add(existingMapping.ToDto());
+                }
+                else
+                {
+                    errors.Add($"Failed to update mapping with ID {id}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating mapping with ID {Id}", id);
+                errors.Add($"Error updating mapping with ID {id}: {ex.Message}");
+            }
+        }
 
-                LogAdminAuditBulk(isEnabled ? "BulkEnabled" : "BulkDisabled", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
-                AdminOperationsMetricsService.RecordModelMappingOperation(isEnabled ? "bulk_enable" : "bulk_disable", "success");
+        var result = new BulkUpdateResult
+        {
+            Updated = updated,
+            Errors = errors,
+            TotalProcessed = ids.Count,
+            SuccessCount = updated.Count,
+            FailureCount = errors.Count
+        };
 
-                return result;
-            },
-            result => Ok(result),
-            "UpdateBulkMappingsStatus");
+        LogAdminAuditBulk(isEnabled ? "BulkEnabled" : "BulkDisabled", "ModelProviderMapping", result.SuccessCount, result.FailureCount);
+        AdminOperationsMetricsService.RecordModelMappingOperation(isEnabled ? "bulk_enable" : "bulk_disable", "success");
+
+        return Ok(result);
     }
 
 }

--- a/Services/ConduitLLM.Admin/Controllers/ModelSeriesController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelSeriesController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Models.ModelSeries;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Repositories;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ModelSeriesController : AdminControllerBase
     {
         private readonly IModelSeriesRepository _repository;
@@ -37,16 +39,10 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelSeriesDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var series = await _repository.GetAllWithAuthorAsync();
-                    return series.Select(s => s.ToDto());
-                },
-                Ok,
-                "GetAll");
+            var series = await _repository.GetAllWithAuthorAsync();
+            return Ok(series.Select(s => s.ToDto()));
         }
 
         /// <summary>
@@ -58,14 +54,15 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelSeriesDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetById(int id)
+        public async Task<IActionResult> GetById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _repository.GetByIdWithAuthorAsync(id),
-                series => Ok(series.ToDto()),
-                "Model series",
-                id,
-                "GetById");
+            var series = await _repository.GetByIdWithAuthorAsync(id);
+            if (series == null)
+            {
+                return this.NotFoundEntity("Model series", id);
+            }
+
+            return Ok(series.ToDto());
         }
 
         /// <summary>
@@ -77,25 +74,23 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<SeriesSimpleModelDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetModelsInSeries(int id)
+        public async Task<IActionResult> GetModelsInSeries(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _repository.GetModelsInSeriesAsync(id),
-                models =>
-                {
-                    var dtos = models.Select(m => new SeriesSimpleModelDto
-                    {
-                        Id = m.Id,
-                        Name = m.Name,
-                        Version = m.Version,
-                        IsActive = m.IsActive
-                    });
+            var models = await _repository.GetModelsInSeriesAsync(id);
+            if (models == null)
+            {
+                return this.NotFoundEntity("Model series", id);
+            }
 
-                    return Ok(dtos);
-                },
-                "Model series",
-                id,
-                "GetModelsInSeries");
+            var dtos = models.Select(m => new SeriesSimpleModelDto
+            {
+                Id = m.Id,
+                Name = m.Name,
+                Version = m.Version,
+                IsActive = m.IsActive
+            });
+
+            return Ok(dtos);
         }
 
         /// <summary>
@@ -108,44 +103,39 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Create([FromBody] CreateModelSeriesDto dto)
+        public async Task<IActionResult> Create([FromBody] CreateModelSeriesDto dto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Check if series with same name and author already exists
-                    var existing = await _repository.GetByNameAndAuthorAsync(dto.Name, dto.AuthorId);
-                    if (existing != null)
-                    {
-                        throw new InvalidOperationException($"A model series with name '{dto.Name}' already exists for this author");
-                    }
+            // Check if series with same name and author already exists
+            var existing = await _repository.GetByNameAndAuthorAsync(dto.Name, dto.AuthorId);
+            if (existing != null)
+            {
+                throw new InvalidOperationException($"A model series with name '{dto.Name}' already exists for this author");
+            }
 
-                    var series = new ModelSeries
-                    {
-                        AuthorId = dto.AuthorId,
-                        Name = dto.Name,
-                        Description = dto.Description,
-                        TokenizerType = dto.TokenizerType,
-                        Parameters = dto.Parameters ?? "{}"
-                    };
+            var series = new ModelSeries
+            {
+                AuthorId = dto.AuthorId,
+                Name = dto.Name,
+                Description = dto.Description,
+                TokenizerType = dto.TokenizerType,
+                Parameters = dto.Parameters ?? "{}"
+            };
 
-                    await _repository.CreateAsync(series);
+            await _repository.CreateAsync(series);
 
-                    // Reload with author
-                    var reloaded = await _repository.GetByIdWithAuthorAsync(series.Id);
-                    if (reloaded == null)
-                    {
-                        throw new InvalidOperationException("Failed to reload created series");
-                    }
+            // Reload with author
+            var reloaded = await _repository.GetByIdWithAuthorAsync(series.Id);
+            if (reloaded == null)
+            {
+                throw new InvalidOperationException("Failed to reload created series");
+            }
 
-                    LogAdminAudit("Created", "ModelSeries", reloaded.Id, $"Name: {LoggingSanitizer.S(reloaded.Name)}");
-                    return reloaded;
-                },
-                series => CreatedAtAction(
-                    nameof(GetById),
-                    new { id = series.Id },
-                    series.ToDto()),
-                "Create");
+            LogAdminAudit("Created", "ModelSeries", reloaded.Id, $"Name: {LoggingSanitizer.S(reloaded.Name)}");
+
+            return CreatedAtAction(
+                nameof(GetById),
+                new { id = reloaded.Id },
+                reloaded.ToDto());
         }
 
         /// <summary>
@@ -160,46 +150,41 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Update(int id, [FromBody] UpdateModelSeriesDto dto)
+        public async Task<IActionResult> Update(int id, [FromBody] UpdateModelSeriesDto dto)
         {
             if (id != dto.Id)
             {
-                return Task.FromResult<IActionResult>(BadRequest("ID mismatch"));
+                return BadRequest("ID mismatch");
             }
 
-            return ExecuteAsync(
-                async () =>
+            var series = await _repository.GetByIdAsync(id);
+            if (series == null)
+            {
+                throw new KeyNotFoundException($"Model series with ID {id} not found");
+            }
+
+            // Check for name conflicts if name is being changed
+            if (!string.IsNullOrEmpty(dto.Name) && dto.Name != series.Name)
+            {
+                var existing = await _repository.GetByNameAndAuthorAsync(dto.Name, series.AuthorId);
+                if (existing != null && existing.Id != id)
                 {
-                    var series = await _repository.GetByIdAsync(id);
-                    if (series == null)
-                    {
-                        throw new KeyNotFoundException($"Model series with ID {id} not found");
-                    }
+                    throw new InvalidOperationException($"A model series with name '{dto.Name}' already exists for this author");
+                }
+                series.Name = dto.Name;
+            }
 
-                    // Check for name conflicts if name is being changed
-                    if (!string.IsNullOrEmpty(dto.Name) && dto.Name != series.Name)
-                    {
-                        var existing = await _repository.GetByNameAndAuthorAsync(dto.Name, series.AuthorId);
-                        if (existing != null && existing.Id != id)
-                        {
-                            throw new InvalidOperationException($"A model series with name '{dto.Name}' already exists for this author");
-                        }
-                        series.Name = dto.Name;
-                    }
+            if (dto.Description != null)
+                series.Description = dto.Description;
+            if (dto.TokenizerType.HasValue)
+                series.TokenizerType = dto.TokenizerType.Value;
+            if (dto.Parameters != null)
+                series.Parameters = dto.Parameters;
 
-                    if (dto.Description != null)
-                        series.Description = dto.Description;
-                    if (dto.TokenizerType.HasValue)
-                        series.TokenizerType = dto.TokenizerType.Value;
-                    if (dto.Parameters != null)
-                        series.Parameters = dto.Parameters;
+            await _repository.UpdateAsync(series);
+            LogAdminAudit("Updated", "ModelSeries", id, $"Name: {LoggingSanitizer.S(series.Name)}");
 
-                    await _repository.UpdateAsync(series);
-                    LogAdminAudit("Updated", "ModelSeries", id, $"Name: {LoggingSanitizer.S(series.Name)}");
-                },
-                NoContent(),
-                "Update",
-                new { Id = id });
+            return NoContent();
         }
 
         /// <summary>
@@ -212,30 +197,25 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> Delete(int id)
+        public async Task<IActionResult> Delete(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var series = await _repository.GetByIdAsync(id);
-                    if (series == null)
-                    {
-                        throw new KeyNotFoundException($"Model series with ID {id} not found");
-                    }
+            var series = await _repository.GetByIdAsync(id);
+            if (series == null)
+            {
+                throw new KeyNotFoundException($"Model series with ID {id} not found");
+            }
 
-                    // Check if series has models
-                    var models = await _repository.GetModelsInSeriesAsync(id);
-                    if (models != null && models.Any())
-                    {
-                        throw new InvalidOperationException($"Cannot delete model series with {models.Count()} associated models. Delete the models first.");
-                    }
+            // Check if series has models
+            var models = await _repository.GetModelsInSeriesAsync(id);
+            if (models != null && models.Any())
+            {
+                throw new InvalidOperationException($"Cannot delete model series with {models.Count()} associated models. Delete the models first.");
+            }
 
-                    await _repository.DeleteAsync(id);
-                    LogAdminAudit("Deleted", "ModelSeries", id, $"Name: {LoggingSanitizer.S(series.Name)}");
-                },
-                NoContent(),
-                "Delete",
-                new { Id = id });
+            await _repository.DeleteAsync(id);
+            LogAdminAudit("Deleted", "ModelSeries", id, $"Name: {LoggingSanitizer.S(series.Name)}");
+
+            return NoContent();
         }
 
     }

--- a/Services/ConduitLLM.Admin/Controllers/NotificationsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/NotificationsController.cs
@@ -1,3 +1,5 @@
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Core.Extensions;
@@ -13,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class NotificationsController : AdminControllerBase
     {
         private readonly IAdminNotificationService _notificationService;
@@ -37,12 +40,10 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<NotificationDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllNotifications()
+        public async Task<IActionResult> GetAllNotifications()
         {
-            return ExecuteAsync(
-                () => _notificationService.GetAllNotificationsAsync(),
-                Ok,
-                "GetAllNotifications");
+            var notifications = await _notificationService.GetAllNotificationsAsync();
+            return Ok(notifications);
         }
 
         /// <summary>
@@ -52,12 +53,10 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("unread")]
         [ProducesResponseType(typeof(IEnumerable<NotificationDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetUnreadNotifications()
+        public async Task<IActionResult> GetUnreadNotifications()
         {
-            return ExecuteAsync(
-                () => _notificationService.GetUnreadNotificationsAsync(),
-                Ok,
-                "GetUnreadNotifications");
+            var notifications = await _notificationService.GetUnreadNotificationsAsync();
+            return Ok(notifications);
         }
 
         /// <summary>
@@ -69,14 +68,14 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(NotificationDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetNotificationById(int id)
+        public async Task<IActionResult> GetNotificationById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _notificationService.GetNotificationByIdAsync(id),
-                Ok,
-                "Notification",
-                id,
-                "GetNotificationById");
+            var notification = await _notificationService.GetNotificationByIdAsync(id);
+            if (notification == null)
+            {
+                return this.NotFoundEntity("Notification", id);
+            }
+            return Ok(notification);
         }
 
         /// <summary>
@@ -88,17 +87,11 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(NotificationDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateNotification([FromBody] CreateNotificationDto notification)
+        public async Task<IActionResult> CreateNotification([FromBody] CreateNotificationDto notification)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var result = await _notificationService.CreateNotificationAsync(notification);
-                    LogAdminAudit("Created", "Notification", result.Id, $"Type: {result.Type}, Message: {LoggingSanitizer.S(result.Message)}");
-                    return result;
-                },
-                createdNotification => CreatedAtAction(nameof(GetNotificationById), new { id = createdNotification.Id }, createdNotification),
-                "CreateNotification");
+            var result = await _notificationService.CreateNotificationAsync(notification);
+            LogAdminAudit("Created", "Notification", result.Id, $"Type: {result.Type}, Message: {LoggingSanitizer.S(result.Message)}");
+            return CreatedAtAction(nameof(GetNotificationById), new { id = result.Id }, result);
         }
 
         /// <summary>
@@ -112,24 +105,18 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateNotification(int id, [FromBody] UpdateNotificationDto notification)
+        public async Task<IActionResult> UpdateNotification(int id, [FromBody] UpdateNotificationDto notification)
         {
             // Ensure ID in route matches ID in body
             if (id != notification.Id)
             {
-                return Task.FromResult<IActionResult>(BadRequest("ID in route must match ID in body"));
+                return BadRequest("ID in route must match ID in body");
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _notificationService.UpdateNotificationAsync(notification))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("Updated", "Notification", id, notification.Message != null ? $"Message: {LoggingSanitizer.S(notification.Message)}" : null);
-                },
-                NoContent(),
-                "UpdateNotification",
-                new { Id = id });
+            if (!await _notificationService.UpdateNotificationAsync(notification))
+                throw new KeyNotFoundException();
+            LogAdminAudit("Updated", "Notification", id, notification.Message != null ? $"Message: {LoggingSanitizer.S(notification.Message)}" : null);
+            return NoContent();
         }
 
         /// <summary>
@@ -141,18 +128,12 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> MarkAsRead(int id)
+        public async Task<IActionResult> MarkAsRead(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _notificationService.MarkNotificationAsReadAsync(id))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("MarkedAsRead", "Notification", id, "IsRead: true");
-                },
-                NoContent(),
-                "MarkAsRead",
-                new { Id = id });
+            if (!await _notificationService.MarkNotificationAsReadAsync(id))
+                throw new KeyNotFoundException();
+            LogAdminAudit("MarkedAsRead", "Notification", id, "IsRead: true");
+            return NoContent();
         }
 
         /// <summary>
@@ -162,17 +143,11 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("mark-all-read")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> MarkAllAsRead()
+        public async Task<IActionResult> MarkAllAsRead()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var count = await _notificationService.MarkAllNotificationsAsReadAsync();
-                    LogAdminAudit("MarkedAllAsRead", "Notification", detail: $"Count: {count}");
-                    return count;
-                },
-                result => Ok(result),
-                "MarkAllAsRead");
+            var count = await _notificationService.MarkAllNotificationsAsReadAsync();
+            LogAdminAudit("MarkedAllAsRead", "Notification", detail: $"Count: {count}");
+            return Ok(count);
         }
 
         /// <summary>
@@ -184,18 +159,12 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteNotification(int id)
+        public async Task<IActionResult> DeleteNotification(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (!await _notificationService.DeleteNotificationAsync(id))
-                        throw new KeyNotFoundException();
-                    LogAdminAudit("Deleted", "Notification", id, $"Id: {id}");
-                },
-                NoContent(),
-                "DeleteNotification",
-                new { Id = id });
+            if (!await _notificationService.DeleteNotificationAsync(id))
+                throw new KeyNotFoundException();
+            LogAdminAudit("Deleted", "Notification", id, $"Id: {id}");
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/PricingController.Audit.cs
+++ b/Services/ConduitLLM.Admin/Controllers/PricingController.Audit.cs
@@ -13,58 +13,52 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("audit/query")]
         [ProducesResponseType(typeof(PricingAuditQueryResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> QueryPricingAuditEvents([FromBody] PricingAuditQueryRequest request)
+        public async Task<IActionResult> QueryPricingAuditEvents([FromBody] PricingAuditQueryRequest request)
         {
             if (ControllerErrorExtensions.ValidateDateRange(request.From, request.To) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
             if (request.PageSize > 1000)
             {
-                return Task.FromResult<IActionResult>(BadRequest("Page size cannot exceed 1000"));
+                return BadRequest("Page size cannot exceed 1000");
             }
 
-            return ExecuteAsync(
-                async () =>
+            using var timer = PricingOperationDuration.WithLabels("audit_query").NewTimer();
+
+            var (events, totalCount) = await _pricingAuditService.GetAuditEventsAsync(
+                request.From,
+                request.To,
+                request.VirtualKeyId,
+                request.ModelId,
+                request.PricingType,
+                request.PageNumber,
+                request.PageSize);
+
+            LogAdminAudit("Queried", "PricingAudit", detail: $"From: {request.From:O}, To: {request.To:O}, Results: {totalCount}");
+            return Ok(new PricingAuditQueryResponse
+            {
+                Events = events.Select(e => new PricingAuditEventDto
                 {
-                    using var timer = PricingOperationDuration.WithLabels("audit_query").NewTimer();
-
-                    var (events, totalCount) = await _pricingAuditService.GetAuditEventsAsync(
-                        request.From,
-                        request.To,
-                        request.VirtualKeyId,
-                        request.ModelId,
-                        request.PricingType,
-                        request.PageNumber,
-                        request.PageSize);
-
-                    LogAdminAudit("Queried", "PricingAudit", detail: $"From: {request.From:O}, To: {request.To:O}, Results: {totalCount}");
-                    return new PricingAuditQueryResponse
-                    {
-                        Events = events.Select(e => new PricingAuditEventDto
-                        {
-                            Id = e.Id,
-                            Timestamp = e.Timestamp,
-                            VirtualKeyId = e.VirtualKeyId,
-                            ModelId = e.ModelId,
-                            ModelCostId = e.ModelCostId,
-                            PricingType = e.PricingType,
-                            InputParameters = e.InputParameters,
-                            MatchedRule = e.MatchedRule,
-                            UsedDefaultRate = e.UsedDefaultRate,
-                            AppliedRate = e.AppliedRate,
-                            Quantity = e.Quantity,
-                            CalculatedCost = e.CalculatedCost,
-                            RequestId = e.RequestId
-                        }).ToList(),
-                        TotalCount = totalCount,
-                        PageNumber = request.PageNumber,
-                        PageSize = request.PageSize
-                    };
-                },
-                Ok,
-                "QueryPricingAuditEvents");
+                    Id = e.Id,
+                    Timestamp = e.Timestamp,
+                    VirtualKeyId = e.VirtualKeyId,
+                    ModelId = e.ModelId,
+                    ModelCostId = e.ModelCostId,
+                    PricingType = e.PricingType,
+                    InputParameters = e.InputParameters,
+                    MatchedRule = e.MatchedRule,
+                    UsedDefaultRate = e.UsedDefaultRate,
+                    AppliedRate = e.AppliedRate,
+                    Quantity = e.Quantity,
+                    CalculatedCost = e.CalculatedCost,
+                    RequestId = e.RequestId
+                }).ToList(),
+                TotalCount = totalCount,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize
+            });
         }
 
         /// <summary>
@@ -73,25 +67,20 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("audit/summary")]
         [ProducesResponseType(typeof(PricingAuditSummary), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> GetPricingAuditSummary(
+        public async Task<IActionResult> GetPricingAuditSummary(
             [FromQuery] DateTime from,
             [FromQuery] DateTime to,
             [FromQuery] int? virtualKeyId = null)
         {
             if (ControllerErrorExtensions.ValidateDateRange(from, to) is { } dateError)
             {
-                return Task.FromResult(dateError);
+                return dateError;
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    using var timer = PricingOperationDuration.WithLabels("audit_summary").NewTimer();
+            using var timer = PricingOperationDuration.WithLabels("audit_summary").NewTimer();
 
-                    return await _pricingAuditService.GetSummaryAsync(from, to, virtualKeyId);
-                },
-                Ok,
-                "GetPricingAuditSummary");
+            var summary = await _pricingAuditService.GetSummaryAsync(from, to, virtualKeyId);
+            return Ok(summary);
         }
 
         /// <summary>
@@ -100,38 +89,31 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("audit/request/{requestId}")]
         [ProducesResponseType(typeof(IEnumerable<PricingAuditEventDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public Task<IActionResult> GetPricingAuditByRequestId(string requestId)
+        public async Task<IActionResult> GetPricingAuditByRequestId(string requestId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var events = await _pricingAuditService.GetByRequestIdAsync(requestId);
+            var events = await _pricingAuditService.GetByRequestIdAsync(requestId);
 
-                    if (!events.Any())
-                    {
-                        throw new KeyNotFoundException($"No pricing audit events found for request {requestId}");
-                    }
+            if (!events.Any())
+            {
+                throw new KeyNotFoundException($"No pricing audit events found for request {requestId}");
+            }
 
-                    return events.Select(e => new PricingAuditEventDto
-                    {
-                        Id = e.Id,
-                        Timestamp = e.Timestamp,
-                        VirtualKeyId = e.VirtualKeyId,
-                        ModelId = e.ModelId,
-                        ModelCostId = e.ModelCostId,
-                        PricingType = e.PricingType,
-                        InputParameters = e.InputParameters,
-                        MatchedRule = e.MatchedRule,
-                        UsedDefaultRate = e.UsedDefaultRate,
-                        AppliedRate = e.AppliedRate,
-                        Quantity = e.Quantity,
-                        CalculatedCost = e.CalculatedCost,
-                        RequestId = e.RequestId
-                    });
-                },
-                Ok,
-                "GetPricingAuditByRequestId",
-                new { RequestId = requestId });
+            return Ok(events.Select(e => new PricingAuditEventDto
+            {
+                Id = e.Id,
+                Timestamp = e.Timestamp,
+                VirtualKeyId = e.VirtualKeyId,
+                ModelId = e.ModelId,
+                ModelCostId = e.ModelCostId,
+                PricingType = e.PricingType,
+                InputParameters = e.InputParameters,
+                MatchedRule = e.MatchedRule,
+                UsedDefaultRate = e.UsedDefaultRate,
+                AppliedRate = e.AppliedRate,
+                Quantity = e.Quantity,
+                CalculatedCost = e.CalculatedCost,
+                RequestId = e.RequestId
+            }));
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/PricingController.Simulation.cs
+++ b/Services/ConduitLLM.Admin/Controllers/PricingController.Simulation.cs
@@ -14,36 +14,32 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("validate")]
         [ProducesResponseType(typeof(PricingValidationResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> ValidatePricingConfiguration([FromBody] PricingValidationRequest request)
+        public async Task<IActionResult> ValidatePricingConfiguration([FromBody] PricingValidationRequest request)
         {
-            return ExecuteAsync(
-                () =>
+            await Task.CompletedTask;
+
+            using var timer = PricingOperationDuration.WithLabels("validate").NewTimer();
+
+            if (!TryDeserializePricingConfig<PricingRulesConfig>(request.PricingConfiguration, out var config, out var errorMessage))
+            {
+                PricingValidations.WithLabels(errorMessage!.StartsWith("Invalid JSON") ? "invalid_json" : "null_config").Inc();
+                return Ok(new PricingValidationResponse
                 {
-                    using var timer = PricingOperationDuration.WithLabels("validate").NewTimer();
+                    IsValid = false,
+                    Errors = new[] { errorMessage! }
+                });
+            }
 
-                    if (!TryDeserializePricingConfig<PricingRulesConfig>(request.PricingConfiguration, out var config, out var errorMessage))
-                    {
-                        PricingValidations.WithLabels(errorMessage!.StartsWith("Invalid JSON") ? "invalid_json" : "null_config").Inc();
-                        return Task.FromResult<PricingValidationResponse>(new PricingValidationResponse
-                        {
-                            IsValid = false,
-                            Errors = new[] { errorMessage! }
-                        });
-                    }
+            var result = _pricingValidator.Validate(config!);
 
-                    var result = _pricingValidator.Validate(config!);
-
-                    PricingValidations.WithLabels(result.IsValid ? "valid" : "invalid").Inc();
-                    LogAdminAudit("Validated", "PricingConfiguration", detail: $"IsValid: {result.IsValid}, Errors: {result.Errors.Count}");
-                    return Task.FromResult(new PricingValidationResponse
-                    {
-                        IsValid = result.IsValid,
-                        Errors = result.Errors.Select(e => $"[{e.Field}] {e.Message}" + (e.RuleIndex.HasValue ? $" (rule {e.RuleIndex})" : "")).ToArray(),
-                        Warnings = result.Warnings.ToArray()
-                    });
-                },
-                Ok,
-                "ValidatePricingConfiguration");
+            PricingValidations.WithLabels(result.IsValid ? "valid" : "invalid").Inc();
+            LogAdminAudit("Validated", "PricingConfiguration", detail: $"IsValid: {result.IsValid}, Errors: {result.Errors.Count}");
+            return Ok(new PricingValidationResponse
+            {
+                IsValid = result.IsValid,
+                Errors = result.Errors.Select(e => $"[{e.Field}] {e.Message}" + (e.RuleIndex.HasValue ? $" (rule {e.RuleIndex})" : "")).ToArray(),
+                Warnings = result.Warnings.ToArray()
+            });
         }
 
         /// <summary>
@@ -54,62 +50,58 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("simulate")]
         [ProducesResponseType(typeof(PricingSimulationResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public Task<IActionResult> SimulatePricing([FromBody] PricingSimulationRequest request)
+        public async Task<IActionResult> SimulatePricing([FromBody] PricingSimulationRequest request)
         {
-            return ExecuteAsync(
-                () =>
+            await Task.CompletedTask;
+
+            using var timer = PricingOperationDuration.WithLabels("simulate").NewTimer();
+
+            // Parse pricing configuration
+            if (!TryDeserializePricingConfig<PricingRulesConfig>(request.PricingConfiguration, out var config, out var errorMessage))
+            {
+                PricingSimulations.WithLabels(errorMessage!.StartsWith("Invalid JSON") ? "invalid_json" : "null_config").Inc();
+                throw new ArgumentException($"Invalid pricing configuration JSON: {errorMessage}");
+            }
+
+            // Validate configuration first
+            var validationResult = _pricingValidator.Validate(config!);
+            if (!validationResult.IsValid)
+            {
+                PricingSimulations.WithLabels("invalid_config").Inc();
+                throw new ArgumentException("Pricing configuration is invalid");
+            }
+
+            // Build usage object for simulation
+            var usage = new ConduitLLM.Core.Models.Usage
+            {
+                VideoDurationSeconds = request.VideoDurationSeconds,
+                VideoResolution = request.VideoResolution,
+                ImageCount = request.ImageCount,
+                ImageResolution = request.ImageResolution,
+                ImageQuality = request.ImageQuality,
+                PricingParameters = request.Parameters ?? new Dictionary<string, object>()
+            };
+
+            // Evaluate the pricing rules
+            var result = _pricingEvaluator.Evaluate(config!, request.Parameters ?? new Dictionary<string, object>(), usage);
+
+            PricingSimulations.WithLabels("success").Inc();
+            LogAdminAudit("Simulated", "PricingCalculation", detail: $"Cost: {result.Cost}, UsedDefault: {result.UsedDefaultRate}");
+            return Ok(new PricingSimulationResponse
+            {
+                CalculatedCost = result.Cost,
+                AppliedRate = result.Rate,
+                Quantity = result.Quantity,
+                MatchedRule = result.MatchedRule != null ? new MatchedRuleInfo
                 {
-                    using var timer = PricingOperationDuration.WithLabels("simulate").NewTimer();
-
-                    // Parse pricing configuration
-                    if (!TryDeserializePricingConfig<PricingRulesConfig>(request.PricingConfiguration, out var config, out var errorMessage))
-                    {
-                        PricingSimulations.WithLabels(errorMessage!.StartsWith("Invalid JSON") ? "invalid_json" : "null_config").Inc();
-                        throw new ArgumentException($"Invalid pricing configuration JSON: {errorMessage}");
-                    }
-
-                    // Validate configuration first
-                    var validationResult = _pricingValidator.Validate(config!);
-                    if (!validationResult.IsValid)
-                    {
-                        PricingSimulations.WithLabels("invalid_config").Inc();
-                        throw new ArgumentException("Pricing configuration is invalid");
-                    }
-
-                    // Build usage object for simulation
-                    var usage = new ConduitLLM.Core.Models.Usage
-                    {
-                        VideoDurationSeconds = request.VideoDurationSeconds,
-                        VideoResolution = request.VideoResolution,
-                        ImageCount = request.ImageCount,
-                        ImageResolution = request.ImageResolution,
-                        ImageQuality = request.ImageQuality,
-                        PricingParameters = request.Parameters ?? new Dictionary<string, object>()
-                    };
-
-                    // Evaluate the pricing rules
-                    var result = _pricingEvaluator.Evaluate(config!, request.Parameters ?? new Dictionary<string, object>(), usage);
-
-                    PricingSimulations.WithLabels("success").Inc();
-                    LogAdminAudit("Simulated", "PricingCalculation", detail: $"Cost: {result.Cost}, UsedDefault: {result.UsedDefaultRate}");
-                    return Task.FromResult(new PricingSimulationResponse
-                    {
-                        CalculatedCost = result.Cost,
-                        AppliedRate = result.Rate,
-                        Quantity = result.Quantity,
-                        MatchedRule = result.MatchedRule != null ? new MatchedRuleInfo
-                        {
-                            Description = result.MatchedRule.Description,
-                            Priority = result.MatchedRule.Priority,
-                            Rate = result.MatchedRule.Rate,
-                            ConditionsSummary = result.MatchedRule.Conditions?.Select(c => $"{c.Key} = {c.Value}").ToArray()
-                        } : null,
-                        UsedDefaultRate = result.UsedDefaultRate,
-                        WarningMessage = result.UsedDefaultRate ? "No matching rule found, default rate was used" : null
-                    });
-                },
-                Ok,
-                "SimulatePricing");
+                    Description = result.MatchedRule.Description,
+                    Priority = result.MatchedRule.Priority,
+                    Rate = result.MatchedRule.Rate,
+                    ConditionsSummary = result.MatchedRule.Conditions?.Select(c => $"{c.Key} = {c.Value}").ToArray()
+                } : null,
+                UsedDefaultRate = result.UsedDefaultRate,
+                WarningMessage = result.UsedDefaultRate ? "No matching rule found, default rate was used" : null
+            });
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/PricingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/PricingController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Models.Pricing;
 using ConduitLLM.Core.Services;
@@ -14,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public partial class PricingController : AdminControllerBase
     {
         private readonly IPricingRulesValidator _pricingValidator;

--- a/Services/ConduitLLM.Admin/Controllers/PromptCachingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/PromptCachingController.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.DTOs.PromptCaching;
@@ -18,6 +19,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/prompt-caching")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class PromptCachingController : AdminControllerBase
 {
     private const string SettingKey = "PromptCaching.Config";
@@ -52,43 +54,37 @@ public class PromptCachingController : AdminControllerBase
     /// <returns>The current prompt caching configuration, or defaults if not set.</returns>
     [HttpGet("config")]
     [ProducesResponseType(typeof(PromptCachingConfigDto), StatusCodes.Status200OK)]
-    public Task<IActionResult> GetConfig()
+    public async Task<IActionResult> GetConfig()
     {
-        return ExecuteAsync(
-            async () =>
+        var json = await _cacheService.GetSettingValueAsync(SettingKey);
+        if (json == null)
+        {
+            return Ok(new PromptCachingConfigDto
             {
-                var json = await _cacheService.GetSettingValueAsync(SettingKey);
-                if (json == null)
-                {
-                    return new PromptCachingConfigDto
-                    {
-                        AutoInjectEnabled = false,
-                        InjectionPoints = new List<CacheInjectionPointDto>()
-                    };
-                }
+                AutoInjectEnabled = false,
+                InjectionPoints = new List<CacheInjectionPointDto>()
+            });
+        }
 
-                var config = JsonSerializer.Deserialize<PromptCachingConfig>(json, JsonOptions);
-                if (config == null)
-                {
-                    return new PromptCachingConfigDto
-                    {
-                        AutoInjectEnabled = false,
-                        InjectionPoints = new List<CacheInjectionPointDto>()
-                    };
-                }
+        var config = JsonSerializer.Deserialize<PromptCachingConfig>(json, JsonOptions);
+        if (config == null)
+        {
+            return Ok(new PromptCachingConfigDto
+            {
+                AutoInjectEnabled = false,
+                InjectionPoints = new List<CacheInjectionPointDto>()
+            });
+        }
 
-                return new PromptCachingConfigDto
-                {
-                    AutoInjectEnabled = config.AutoInjectEnabled,
-                    InjectionPoints = config.InjectionPoints.Select(p => new CacheInjectionPointDto
-                    {
-                        Role = p.Role,
-                        Index = p.Index
-                    }).ToList()
-                };
-            },
-            Ok,
-            "GetPromptCachingConfig");
+        return Ok(new PromptCachingConfigDto
+        {
+            AutoInjectEnabled = config.AutoInjectEnabled,
+            InjectionPoints = config.InjectionPoints.Select(p => new CacheInjectionPointDto
+            {
+                Role = p.Role,
+                Index = p.Index
+            }).ToList()
+        });
     }
 
     /// <summary>
@@ -99,57 +95,51 @@ public class PromptCachingController : AdminControllerBase
     [HttpPut("config")]
     [ProducesResponseType(typeof(PromptCachingConfigDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponseDto), StatusCodes.Status400BadRequest)]
-    public Task<IActionResult> UpdateConfig([FromBody] UpdatePromptCachingConfigDto dto)
+    public async Task<IActionResult> UpdateConfig([FromBody] UpdatePromptCachingConfigDto dto)
     {
-        return ExecuteAsync(
-            async () =>
+        // Map DTO to domain model
+        var config = new PromptCachingConfig
+        {
+            AutoInjectEnabled = dto.AutoInjectEnabled,
+            InjectionPoints = dto.InjectionPoints.Select(p => new CacheInjectionPoint
             {
-                // Map DTO to domain model
-                var config = new PromptCachingConfig
-                {
-                    AutoInjectEnabled = dto.AutoInjectEnabled,
-                    InjectionPoints = dto.InjectionPoints.Select(p => new CacheInjectionPoint
-                    {
-                        Role = p.Role,
-                        Index = p.Index
-                    }).ToList()
-                };
+                Role = p.Role,
+                Index = p.Index
+            }).ToList()
+        };
 
-                var json = JsonSerializer.Serialize(config, JsonOptions);
+        var json = JsonSerializer.Serialize(config, JsonOptions);
 
-                // Upsert: try update first, create if not found
-                var existing = await _globalSettingService.GetSettingByKeyAsync(SettingKey);
-                if (existing != null)
-                {
-                    await _globalSettingService.UpdateSettingByKeyAsync(new UpdateGlobalSettingByKeyDto
-                    {
-                        Key = SettingKey,
-                        Value = json,
-                        Description = "Prompt caching auto-injection configuration"
-                    });
-                }
-                else
-                {
-                    await _globalSettingService.CreateSettingAsync(new CreateGlobalSettingDto
-                    {
-                        Key = SettingKey,
-                        Value = json,
-                        Description = "Prompt caching auto-injection configuration"
-                    });
-                }
+        // Upsert: try update first, create if not found
+        var existing = await _globalSettingService.GetSettingByKeyAsync(SettingKey);
+        if (existing != null)
+        {
+            await _globalSettingService.UpdateSettingByKeyAsync(new UpdateGlobalSettingByKeyDto
+            {
+                Key = SettingKey,
+                Value = json,
+                Description = "Prompt caching auto-injection configuration"
+            });
+        }
+        else
+        {
+            await _globalSettingService.CreateSettingAsync(new CreateGlobalSettingDto
+            {
+                Key = SettingKey,
+                Value = json,
+                Description = "Prompt caching auto-injection configuration"
+            });
+        }
 
-                // Invalidate cache so changes take effect immediately
-                await _cacheService.InvalidateSettingAsync(SettingKey);
+        // Invalidate cache so changes take effect immediately
+        await _cacheService.InvalidateSettingAsync(SettingKey);
 
-                LogAdminAudit("Updated", "PromptCachingConfig", detail: $"AutoInject={dto.AutoInjectEnabled}, Points={dto.InjectionPoints.Count}");
+        LogAdminAudit("Updated", "PromptCachingConfig", detail: $"AutoInject={dto.AutoInjectEnabled}, Points={dto.InjectionPoints.Count}");
 
-                return new PromptCachingConfigDto
-                {
-                    AutoInjectEnabled = dto.AutoInjectEnabled,
-                    InjectionPoints = dto.InjectionPoints
-                };
-            },
-            Ok,
-            "UpdatePromptCachingConfig");
+        return Ok(new PromptCachingConfigDto
+        {
+            AutoInjectEnabled = dto.AutoInjectEnabled,
+            InjectionPoints = dto.InjectionPoints
+        });
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Keys.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Keys.cs
@@ -19,31 +19,26 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetProviderKeyCredentials(int providerId)
+        public async Task<IActionResult> GetProviderKeyCredentials(int providerId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var keys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
-                        _keyRepository.GetByProviderIdPaginatedAsync, providerId);
-                    return keys.Select(k => new
-                    {
-                        k.Id,
-                        k.ProviderId,
-                        k.KeyName,
-                        k.IsPrimary,
-                        k.IsEnabled,
-                        k.ProviderAccountGroup,
-                        ApiKey = k.ApiKey != null ? "***" + k.ApiKey.Substring(Math.Max(0, k.ApiKey.Length - 4)) : "***", // Mask API key
-                        k.Organization,
-                        k.BaseUrl,
-                        k.CreatedAt,
-                        k.UpdatedAt
-                    });
-                },
-                result => Ok(result),
-                "GetProviderKeyCredentials",
-                new { ProviderId = providerId });
+            var keys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                _keyRepository.GetByProviderIdPaginatedAsync, providerId);
+            var result = keys.Select(k => new
+            {
+                k.Id,
+                k.ProviderId,
+                k.KeyName,
+                k.IsPrimary,
+                k.IsEnabled,
+                k.ProviderAccountGroup,
+                ApiKey = k.ApiKey != null ? "***" + k.ApiKey.Substring(Math.Max(0, k.ApiKey.Length - 4)) : "***", // Mask API key
+                k.Organization,
+                k.BaseUrl,
+                k.CreatedAt,
+                k.UpdatedAt
+            });
+
+            return Ok(result);
         }
 
         /// <summary>
@@ -56,36 +51,30 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetProviderKeyCredential(int providerId, int keyId)
+        public async Task<IActionResult> GetProviderKeyCredential(int providerId, int keyId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var key = await _keyRepository.GetByIdAsync(keyId);
+            var key = await _keyRepository.GetByIdAsync(keyId);
 
-                    if (key == null || key.ProviderId != providerId)
-                    {
-                        Logger.LogWarning("Key credential not found {KeyId} for provider {ProviderId}", keyId, providerId);
-                        return this.NotFoundEntity("Key credential", keyId);
-                    }
+            if (key == null || key.ProviderId != providerId)
+            {
+                Logger.LogWarning("Key credential not found {KeyId} for provider {ProviderId}", keyId, providerId);
+                return this.NotFoundEntity("Key credential", keyId);
+            }
 
-                    return Ok(new
-                    {
-                        key.Id,
-                        key.ProviderId,
-                        key.KeyName,
-                        key.IsPrimary,
-                        key.IsEnabled,
-                        key.ProviderAccountGroup,
-                        ApiKey = key.ApiKey != null ? "***" + key.ApiKey.Substring(Math.Max(0, key.ApiKey.Length - 4)) : "***", // Mask API key
-                        key.Organization,
-                        key.BaseUrl,
-                        key.CreatedAt,
-                        key.UpdatedAt
-                    });
-                },
-                "GetProviderKeyCredential",
-                new { ProviderId = providerId, KeyId = keyId });
+            return Ok(new
+            {
+                key.Id,
+                key.ProviderId,
+                key.KeyName,
+                key.IsPrimary,
+                key.IsEnabled,
+                key.ProviderAccountGroup,
+                ApiKey = key.ApiKey != null ? "***" + key.ApiKey.Substring(Math.Max(0, key.ApiKey.Length - 4)) : "***", // Mask API key
+                key.Organization,
+                key.BaseUrl,
+                key.CreatedAt,
+                key.UpdatedAt
+            });
         }
 
         /// <summary>
@@ -99,68 +88,62 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateProviderKeyCredential(int providerId, [FromBody] CreateKeyRequest request)
+        public async Task<IActionResult> CreateProviderKeyCredential(int providerId, [FromBody] CreateKeyRequest request)
         {
-            return ExecuteAsync(
-                async () =>
+            // Verify provider exists
+            var provider = await _providerRepository.GetByIdAsync(providerId);
+            if (provider == null)
+            {
+                return this.NotFoundEntity("Provider", providerId);
+            }
+
+            var keyCredential = new ProviderKeyCredential
+            {
+                ProviderId = providerId,
+                ApiKey = request.ApiKey,
+                KeyName = request.KeyName,
+                Organization = request.Organization,
+                BaseUrl = request.BaseUrl,
+                IsPrimary = request.IsPrimary,
+                IsEnabled = request.IsEnabled,
+                ProviderAccountGroup = (short)(request.ProviderAccountGroup ?? 0),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            var createdKeyId = await _keyRepository.CreateAsync(keyCredential);
+
+            // After CreateAsync, keyCredential has its Id populated and IsPrimary potentially modified
+            // Publish key created event
+            PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialCreated
+            {
+                KeyId = createdKeyId,
+                ProviderId = providerId,
+                IsPrimary = keyCredential.IsPrimary,
+                IsEnabled = keyCredential.IsEnabled,
+                CorrelationId = Guid.NewGuid()
+            }, "create provider key", new { ProviderId = providerId, KeyId = createdKeyId });
+
+            LogAdminAudit("Created", "ProviderKeyCredential", createdKeyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(keyCredential.KeyName)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "create");
+
+            return CreatedAtAction(
+                nameof(GetProviderKeyCredential),
+                new { providerId = providerId, keyId = createdKeyId },
+                new
                 {
-                    // Verify provider exists
-                    var provider = await _providerRepository.GetByIdAsync(providerId);
-                    if (provider == null)
-                    {
-                        return this.NotFoundEntity("Provider", providerId);
-                    }
-
-                    var keyCredential = new ProviderKeyCredential
-                    {
-                        ProviderId = providerId,
-                        ApiKey = request.ApiKey,
-                        KeyName = request.KeyName,
-                        Organization = request.Organization,
-                        BaseUrl = request.BaseUrl,
-                        IsPrimary = request.IsPrimary,
-                        IsEnabled = request.IsEnabled,
-                        ProviderAccountGroup = (short)(request.ProviderAccountGroup ?? 0),
-                        CreatedAt = DateTime.UtcNow,
-                        UpdatedAt = DateTime.UtcNow
-                    };
-
-                    var createdKeyId = await _keyRepository.CreateAsync(keyCredential);
-
-                    // After CreateAsync, keyCredential has its Id populated and IsPrimary potentially modified
-                    // Publish key created event
-                    PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialCreated
-                    {
-                        KeyId = createdKeyId,
-                        ProviderId = providerId,
-                        IsPrimary = keyCredential.IsPrimary,
-                        IsEnabled = keyCredential.IsEnabled,
-                        CorrelationId = Guid.NewGuid()
-                    }, "create provider key", new { ProviderId = providerId, KeyId = createdKeyId });
-
-                    LogAdminAudit("Created", "ProviderKeyCredential", createdKeyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(keyCredential.KeyName)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "create");
-
-                    return CreatedAtAction(
-                        nameof(GetProviderKeyCredential),
-                        new { providerId = providerId, keyId = createdKeyId },
-                        new
-                        {
-                            Id = createdKeyId,
-                            keyCredential.ProviderId,
-                            keyCredential.KeyName,
-                            keyCredential.IsPrimary,
-                            keyCredential.IsEnabled,
-                            keyCredential.ProviderAccountGroup,
-                            ApiKey = keyCredential.ApiKey != null ? "***" + keyCredential.ApiKey.Substring(Math.Max(0, keyCredential.ApiKey.Length - 4)) : "***",
-                            keyCredential.Organization,
-                            keyCredential.BaseUrl,
-                            keyCredential.CreatedAt,
-                            keyCredential.UpdatedAt
-                        });
-                },
-                "CreateProviderKeyCredential",
-                new { ProviderId = providerId });
+                    Id = createdKeyId,
+                    keyCredential.ProviderId,
+                    keyCredential.KeyName,
+                    keyCredential.IsPrimary,
+                    keyCredential.IsEnabled,
+                    keyCredential.ProviderAccountGroup,
+                    ApiKey = keyCredential.ApiKey != null ? "***" + keyCredential.ApiKey.Substring(Math.Max(0, keyCredential.ApiKey.Length - 4)) : "***",
+                    keyCredential.Organization,
+                    keyCredential.BaseUrl,
+                    keyCredential.CreatedAt,
+                    keyCredential.UpdatedAt
+                });
         }
 
         /// <summary>
@@ -175,88 +158,82 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateProviderKeyCredential(int providerId, int keyId, [FromBody] UpdateKeyRequest request)
+        public async Task<IActionResult> UpdateProviderKeyCredential(int providerId, int keyId, [FromBody] UpdateKeyRequest request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var key = await _keyRepository.GetByIdAsync(keyId);
-                    if (key == null || key.ProviderId != providerId)
-                    {
-                        Logger.LogWarning("Key credential not found for update {KeyId}", keyId);
-                        return this.NotFoundEntity("Key credential", keyId);
-                    }
+            var key = await _keyRepository.GetByIdAsync(keyId);
+            if (key == null || key.ProviderId != providerId)
+            {
+                Logger.LogWarning("Key credential not found for update {KeyId}", keyId);
+                return this.NotFoundEntity("Key credential", keyId);
+            }
 
-                    // Track changes with before/after values
-                    var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+            // Track changes with before/after values
+            var changes = new List<(string Property, string? OldValue, string? NewValue)>();
 
-                    if (!string.IsNullOrEmpty(request.KeyName) && key.KeyName != request.KeyName)
-                    {
-                        changes.Add(("KeyName", key.KeyName, request.KeyName));
-                        key.KeyName = request.KeyName;
-                    }
-                    if (!string.IsNullOrEmpty(request.ApiKey))
-                    {
-                        changes.Add(("ApiKey", "***", "***")); // Never log API key values
-                        key.ApiKey = request.ApiKey;
-                    }
-                    if (request.Organization != null && key.Organization != request.Organization)
-                    {
-                        changes.Add(("Organization", key.Organization, request.Organization));
-                        key.Organization = request.Organization;
-                    }
-                    if (request.BaseUrl != null && key.BaseUrl != request.BaseUrl)
-                    {
-                        changes.Add(("BaseUrl", key.BaseUrl, request.BaseUrl));
-                        key.BaseUrl = request.BaseUrl;
-                    }
-                    if (request.IsPrimary.HasValue && key.IsPrimary != request.IsPrimary.Value)
-                    {
-                        changes.Add(("IsPrimary", key.IsPrimary.ToString(), request.IsPrimary.Value.ToString()));
-                        key.IsPrimary = request.IsPrimary.Value;
-                    }
-                    if (request.IsEnabled.HasValue && key.IsEnabled != request.IsEnabled.Value)
-                    {
-                        changes.Add(("IsEnabled", key.IsEnabled.ToString(), request.IsEnabled.Value.ToString()));
-                        key.IsEnabled = request.IsEnabled.Value;
-                    }
-                    if (request.ProviderAccountGroup.HasValue && key.ProviderAccountGroup != (short)request.ProviderAccountGroup.Value)
-                    {
-                        changes.Add(("ProviderAccountGroup", key.ProviderAccountGroup.ToString(), request.ProviderAccountGroup.Value.ToString()));
-                        key.ProviderAccountGroup = (short)request.ProviderAccountGroup.Value;
-                    }
+            if (!string.IsNullOrEmpty(request.KeyName) && key.KeyName != request.KeyName)
+            {
+                changes.Add(("KeyName", key.KeyName, request.KeyName));
+                key.KeyName = request.KeyName;
+            }
+            if (!string.IsNullOrEmpty(request.ApiKey))
+            {
+                changes.Add(("ApiKey", "***", "***")); // Never log API key values
+                key.ApiKey = request.ApiKey;
+            }
+            if (request.Organization != null && key.Organization != request.Organization)
+            {
+                changes.Add(("Organization", key.Organization, request.Organization));
+                key.Organization = request.Organization;
+            }
+            if (request.BaseUrl != null && key.BaseUrl != request.BaseUrl)
+            {
+                changes.Add(("BaseUrl", key.BaseUrl, request.BaseUrl));
+                key.BaseUrl = request.BaseUrl;
+            }
+            if (request.IsPrimary.HasValue && key.IsPrimary != request.IsPrimary.Value)
+            {
+                changes.Add(("IsPrimary", key.IsPrimary.ToString(), request.IsPrimary.Value.ToString()));
+                key.IsPrimary = request.IsPrimary.Value;
+            }
+            if (request.IsEnabled.HasValue && key.IsEnabled != request.IsEnabled.Value)
+            {
+                changes.Add(("IsEnabled", key.IsEnabled.ToString(), request.IsEnabled.Value.ToString()));
+                key.IsEnabled = request.IsEnabled.Value;
+            }
+            if (request.ProviderAccountGroup.HasValue && key.ProviderAccountGroup != (short)request.ProviderAccountGroup.Value)
+            {
+                changes.Add(("ProviderAccountGroup", key.ProviderAccountGroup.ToString(), request.ProviderAccountGroup.Value.ToString()));
+                key.ProviderAccountGroup = (short)request.ProviderAccountGroup.Value;
+            }
 
-                    key.UpdatedAt = DateTime.UtcNow;
+            key.UpdatedAt = DateTime.UtcNow;
 
-                    await _keyRepository.UpdateAsync(key);
+            await _keyRepository.UpdateAsync(key);
 
-                    var changedProperties = changes.Count > 0
-                        ? changes.Select(c => c.Property).ToArray()
-                        : Array.Empty<string>();
+            var changedProperties = changes.Count > 0
+                ? changes.Select(c => c.Property).ToArray()
+                : Array.Empty<string>();
 
-                    if (changes.Count > 0)
-                    {
-                        LogAdminAuditWithChanges("ProviderKeyCredential", keyId, changes, $"Provider: {providerId}");
-                    }
-                    else
-                    {
-                        LogAdminAudit("Updated", "ProviderKeyCredential", keyId, $"Provider: {providerId} (no changes detected)");
-                    }
-                    AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "update");
+            if (changes.Count > 0)
+            {
+                LogAdminAuditWithChanges("ProviderKeyCredential", keyId, changes, $"Provider: {providerId}");
+            }
+            else
+            {
+                LogAdminAudit("Updated", "ProviderKeyCredential", keyId, $"Provider: {providerId} (no changes detected)");
+            }
+            AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "update");
 
-                    // Publish key updated event
-                    PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialUpdated
-                    {
-                        KeyId = keyId,
-                        ProviderId = providerId,
-                        ChangedProperties = changedProperties,
-                        CorrelationId = Guid.NewGuid()
-                    }, "update provider key", new { ProviderId = providerId, KeyId = keyId });
+            // Publish key updated event
+            PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialUpdated
+            {
+                KeyId = keyId,
+                ProviderId = providerId,
+                ChangedProperties = changedProperties,
+                CorrelationId = Guid.NewGuid()
+            }, "update provider key", new { ProviderId = providerId, KeyId = keyId });
 
-                    return NoContent();
-                },
-                "UpdateProviderKeyCredential",
-                new { ProviderId = providerId, KeyId = keyId });
+            return NoContent();
         }
 
         /// <summary>
@@ -269,35 +246,29 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteProviderKeyCredential(int providerId, int keyId)
+        public async Task<IActionResult> DeleteProviderKeyCredential(int providerId, int keyId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var key = await _keyRepository.GetByIdAsync(keyId);
-                    if (key == null || key.ProviderId != providerId)
-                    {
-                        Logger.LogWarning("Key credential not found for deletion {KeyId}", keyId);
-                        return this.NotFoundEntity("Key credential", keyId);
-                    }
+            var key = await _keyRepository.GetByIdAsync(keyId);
+            if (key == null || key.ProviderId != providerId)
+            {
+                Logger.LogWarning("Key credential not found for deletion {KeyId}", keyId);
+                return this.NotFoundEntity("Key credential", keyId);
+            }
 
-                    await _keyRepository.DeleteAsync(keyId);
+            await _keyRepository.DeleteAsync(keyId);
 
-                    LogAdminAudit("Deleted", "ProviderKeyCredential", keyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(key.KeyName)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "delete");
+            LogAdminAudit("Deleted", "ProviderKeyCredential", keyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(key.KeyName)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "delete");
 
-                    // Publish key deleted event
-                    PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialDeleted
-                    {
-                        KeyId = keyId,
-                        ProviderId = providerId,
-                        CorrelationId = Guid.NewGuid()
-                    }, "delete provider key", new { ProviderId = providerId, KeyId = keyId });
+            // Publish key deleted event
+            PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialDeleted
+            {
+                KeyId = keyId,
+                ProviderId = providerId,
+                CorrelationId = Guid.NewGuid()
+            }, "delete provider key", new { ProviderId = providerId, KeyId = keyId });
 
-                    return NoContent();
-                },
-                "DeleteProviderKeyCredential",
-                new { ProviderId = providerId, KeyId = keyId });
+            return NoContent();
         }
 
         /// <summary>
@@ -311,49 +282,43 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> SetPrimaryKey(int providerId, int keyId)
+        public async Task<IActionResult> SetPrimaryKey(int providerId, int keyId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var key = await _keyRepository.GetByIdAsync(keyId);
-                    if (key == null || key.ProviderId != providerId)
-                    {
-                        Logger.LogWarning("Key credential not found {KeyId} for provider {ProviderId}", keyId, providerId);
-                        return this.NotFoundEntity("Key credential", keyId);
-                    }
+            var key = await _keyRepository.GetByIdAsync(keyId);
+            if (key == null || key.ProviderId != providerId)
+            {
+                Logger.LogWarning("Key credential not found {KeyId} for provider {ProviderId}", keyId, providerId);
+                return this.NotFoundEntity("Key credential", keyId);
+            }
 
-                    // Unset all other primary keys for this provider
-                    var allKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
-                        _keyRepository.GetByProviderIdPaginatedAsync, providerId);
-                    foreach (var otherKey in allKeys.Where(k => k.IsPrimary && k.Id != keyId))
-                    {
-                        otherKey.IsPrimary = false;
-                        otherKey.UpdatedAt = DateTime.UtcNow;
-                        await _keyRepository.UpdateAsync(otherKey);
-                    }
+            // Unset all other primary keys for this provider
+            var allKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                _keyRepository.GetByProviderIdPaginatedAsync, providerId);
+            foreach (var otherKey in allKeys.Where(k => k.IsPrimary && k.Id != keyId))
+            {
+                otherKey.IsPrimary = false;
+                otherKey.UpdatedAt = DateTime.UtcNow;
+                await _keyRepository.UpdateAsync(otherKey);
+            }
 
-                    // Set this key as primary
-                    key.IsPrimary = true;
-                    key.UpdatedAt = DateTime.UtcNow;
-                    await _keyRepository.UpdateAsync(key);
+            // Set this key as primary
+            key.IsPrimary = true;
+            key.UpdatedAt = DateTime.UtcNow;
+            await _keyRepository.UpdateAsync(key);
 
-                    LogAdminAudit("SetPrimary", "ProviderKeyCredential", keyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(key.KeyName)}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "set_primary");
+            LogAdminAudit("SetPrimary", "ProviderKeyCredential", keyId, $"Provider: {providerId}, KeyName: {LoggingSanitizer.S(key.KeyName)}");
+            AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "set_primary");
 
-                    // Publish primary key changed event
-                    PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialPrimaryChanged
-                    {
-                        ProviderId = providerId,
-                        OldPrimaryKeyId = 0, // Not tracking old primary in this method
-                        NewPrimaryKeyId = keyId,
-                        CorrelationId = Guid.NewGuid()
-                    }, "set primary key", new { ProviderId = providerId, KeyId = keyId });
+            // Publish primary key changed event
+            PublishEventFireAndForget(new ConduitLLM.Configuration.Events.ProviderKeyCredentialPrimaryChanged
+            {
+                ProviderId = providerId,
+                OldPrimaryKeyId = 0, // Not tracking old primary in this method
+                NewPrimaryKeyId = keyId,
+                CorrelationId = Guid.NewGuid()
+            }, "set primary key", new { ProviderId = providerId, KeyId = keyId });
 
-                    return NoContent();
-                },
-                "SetPrimaryKey",
-                new { ProviderId = providerId, KeyId = keyId });
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Extensions;
@@ -19,6 +20,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public partial class ProviderCredentialsController : AdminControllerBase
     {
         private readonly IProviderRepository _providerRepository;
@@ -51,7 +53,7 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(Configuration.DTOs.PagedResult<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllProviders(
+        public async Task<IActionResult> GetAllProviders(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50,
             CancellationToken cancellationToken = default)
@@ -61,33 +63,29 @@ namespace ConduitLLM.Admin.Controllers
             if (pageSize < 1) pageSize = 50;
             if (pageSize > 100) pageSize = 100;
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var (providers, totalCount) = await _providerRepository.GetPaginatedAsync(page, pageSize, cancellationToken);
-                    var items = providers.Select(p => new
-                    {
-                        p.Id,
-                        p.ProviderType,
-                        p.ProviderName,
-                        p.BaseUrl,
-                        p.IsEnabled,
-                        p.CreatedAt,
-                        p.UpdatedAt,
-                        KeyCount = p.ProviderKeyCredentials?.Count ?? 0
-                    }).ToList();
+            var (providers, totalCount) = await _providerRepository.GetPaginatedAsync(page, pageSize, cancellationToken);
+            var items = providers.Select(p => new
+            {
+                p.Id,
+                p.ProviderType,
+                p.ProviderName,
+                p.BaseUrl,
+                p.IsEnabled,
+                p.CreatedAt,
+                p.UpdatedAt,
+                KeyCount = p.ProviderKeyCredentials?.Count ?? 0
+            }).ToList();
 
-                    return new Configuration.DTOs.PagedResult<object>
-                    {
-                        Items = items.Cast<object>().ToList(),
-                        TotalCount = totalCount,
-                        CurrentPage = page,
-                        PageSize = pageSize,
-                        TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize)
-                    };
-                },
-                result => Ok(result),
-                "GetAllProviders");
+            var result = new Configuration.DTOs.PagedResult<object>
+            {
+                Items = items.Cast<object>().ToList(),
+                TotalCount = totalCount,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize)
+            };
+
+            return Ok(result);
         }
 
         /// <summary>
@@ -99,24 +97,25 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetProviderById(int id)
+        public async Task<IActionResult> GetProviderById(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _providerRepository.GetByIdAsync(id),
-                provider => Ok(new
-                {
-                    provider.Id,
-                    provider.ProviderType,
-                    provider.ProviderName,
-                    provider.BaseUrl,
-                    provider.IsEnabled,
-                    provider.CreatedAt,
-                    provider.UpdatedAt,
-                    KeyCount = provider.ProviderKeyCredentials?.Count ?? 0
-                }),
-                "Provider",
-                id,
-                "GetProviderById");
+            var provider = await _providerRepository.GetByIdAsync(id);
+            if (provider == null)
+            {
+                return this.NotFoundEntity("Provider", id);
+            }
+
+            return Ok(new
+            {
+                provider.Id,
+                provider.ProviderType,
+                provider.ProviderName,
+                provider.BaseUrl,
+                provider.IsEnabled,
+                provider.CreatedAt,
+                provider.UpdatedAt,
+                KeyCount = provider.ProviderKeyCredentials?.Count ?? 0
+            });
         }
 
         /// <summary>
@@ -127,54 +126,48 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> CreateProvider([FromBody] CreateProviderRequest request)
+        public async Task<IActionResult> CreateProvider([FromBody] CreateProviderRequest request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var provider = new Provider
-                    {
-                        ProviderType = request.ProviderType,
-                        ProviderName = request.ProviderName,
-                        BaseUrl = request.BaseUrl,
-                        IsEnabled = request.IsEnabled,
-                        CreatedAt = DateTime.UtcNow,
-                        UpdatedAt = DateTime.UtcNow
-                    };
+            var provider = new Provider
+            {
+                ProviderType = request.ProviderType,
+                ProviderName = request.ProviderName,
+                BaseUrl = request.BaseUrl,
+                IsEnabled = request.IsEnabled,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-                    var id = await _providerRepository.CreateAsync(provider);
-                    provider.Id = id;
+            var id = await _providerRepository.CreateAsync(provider);
+            provider.Id = id;
 
-                    // Publish provider created event
-                    PublishEventFireAndForget(new ProviderCreated
-                    {
-                        ProviderId = id,
-                        ProviderType = provider.ProviderType.ToString(),
-                        ProviderName = provider.ProviderName,
-                        BaseUrl = provider.BaseUrl,
-                        IsEnabled = provider.IsEnabled,
-                        CreatedAt = provider.CreatedAt,
-                        CorrelationId = Guid.NewGuid().ToString()
-                    }, "create provider");
+            // Publish provider created event
+            PublishEventFireAndForget(new ProviderCreated
+            {
+                ProviderId = id,
+                ProviderType = provider.ProviderType.ToString(),
+                ProviderName = provider.ProviderName,
+                BaseUrl = provider.BaseUrl,
+                IsEnabled = provider.IsEnabled,
+                CreatedAt = provider.CreatedAt,
+                CorrelationId = Guid.NewGuid().ToString()
+            }, "create provider");
 
-                    LogAdminAudit("Created", "Provider", id, $"Type: {provider.ProviderType}, Name: {LoggingSanitizer.S(provider.ProviderName)}");
-                    AdminOperationsMetricsService.RecordProviderOperation("create", provider.ProviderType.ToString(), "success");
-                    AdminOperationsMetricsService.RecordConfigurationChange("provider", "create");
+            LogAdminAudit("Created", "Provider", id, $"Type: {provider.ProviderType}, Name: {LoggingSanitizer.S(provider.ProviderName)}");
+            AdminOperationsMetricsService.RecordProviderOperation("create", provider.ProviderType.ToString(), "success");
+            AdminOperationsMetricsService.RecordConfigurationChange("provider", "create");
 
-                    return provider;
-                },
-                provider => CreatedAtAction(nameof(GetProviderById), new { id = provider.Id }, new
-                {
-                    provider.Id,
-                    provider.ProviderType,
-                    provider.ProviderName,
-                    provider.BaseUrl,
-                    provider.IsEnabled,
-                    provider.CreatedAt,
-                    provider.UpdatedAt,
-                    KeyCount = 0
-                }),
-                "CreateProvider");
+            return CreatedAtAction(nameof(GetProviderById), new { id = provider.Id }, new
+            {
+                provider.Id,
+                provider.ProviderType,
+                provider.ProviderName,
+                provider.BaseUrl,
+                provider.IsEnabled,
+                provider.CreatedAt,
+                provider.UpdatedAt,
+                KeyCount = 0
+            });
         }
 
         /// <summary>
@@ -188,59 +181,57 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> UpdateProvider(int id, [FromBody] UpdateProviderRequest request)
+        public async Task<IActionResult> UpdateProvider(int id, [FromBody] UpdateProviderRequest request)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _providerRepository.GetByIdAsync(id),
-                async provider =>
+            var provider = await _providerRepository.GetByIdAsync(id);
+            if (provider == null)
+            {
+                return this.NotFoundEntity("Provider", id);
+            }
+
+            var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+
+            if (!string.IsNullOrEmpty(request.ProviderName) && provider.ProviderName != request.ProviderName)
+            {
+                changes.Add(("ProviderName", provider.ProviderName, request.ProviderName));
+                provider.ProviderName = request.ProviderName;
+            }
+
+            if (provider.BaseUrl != request.BaseUrl)
+            {
+                changes.Add(("BaseUrl", provider.BaseUrl, request.BaseUrl));
+                provider.BaseUrl = request.BaseUrl;
+            }
+
+            if (provider.IsEnabled != request.IsEnabled)
+            {
+                changes.Add(("IsEnabled", provider.IsEnabled.ToString(), request.IsEnabled.ToString()));
+                provider.IsEnabled = request.IsEnabled;
+            }
+
+            provider.UpdatedAt = DateTime.UtcNow;
+
+            await _providerRepository.UpdateAsync(provider);
+
+            // Publish provider updated event
+            if (changes.Count > 0)
+            {
+                var changedProperties = changes.Select(c => c.Property).ToArray();
+                PublishEventFireAndForget(new ProviderUpdated
                 {
-                    var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+                    ProviderId = id,
+                    IsEnabled = provider.IsEnabled,
+                    ChangedProperties = changedProperties,
+                    CorrelationId = Guid.NewGuid().ToString()
+                }, "update provider", new { ProviderId = id, ChangedProperties = string.Join(", ", changedProperties) });
 
-                    if (!string.IsNullOrEmpty(request.ProviderName) && provider.ProviderName != request.ProviderName)
-                    {
-                        changes.Add(("ProviderName", provider.ProviderName, request.ProviderName));
-                        provider.ProviderName = request.ProviderName;
-                    }
+                LogAdminAuditWithChanges("Provider", id, changes);
+            }
 
-                    if (provider.BaseUrl != request.BaseUrl)
-                    {
-                        changes.Add(("BaseUrl", provider.BaseUrl, request.BaseUrl));
-                        provider.BaseUrl = request.BaseUrl;
-                    }
+            AdminOperationsMetricsService.RecordProviderOperation("update", provider.ProviderType.ToString(), "success");
+            AdminOperationsMetricsService.RecordConfigurationChange("provider", "update");
 
-                    if (provider.IsEnabled != request.IsEnabled)
-                    {
-                        changes.Add(("IsEnabled", provider.IsEnabled.ToString(), request.IsEnabled.ToString()));
-                        provider.IsEnabled = request.IsEnabled;
-                    }
-
-                    provider.UpdatedAt = DateTime.UtcNow;
-
-                    await _providerRepository.UpdateAsync(provider);
-
-                    // Publish provider updated event
-                    if (changes.Count > 0)
-                    {
-                        var changedProperties = changes.Select(c => c.Property).ToArray();
-                        PublishEventFireAndForget(new ProviderUpdated
-                        {
-                            ProviderId = id,
-                            IsEnabled = provider.IsEnabled,
-                            ChangedProperties = changedProperties,
-                            CorrelationId = Guid.NewGuid().ToString()
-                        }, "update provider", new { ProviderId = id, ChangedProperties = string.Join(", ", changedProperties) });
-
-                        LogAdminAuditWithChanges("Provider", id, changes);
-                    }
-
-                    AdminOperationsMetricsService.RecordProviderOperation("update", provider.ProviderType.ToString(), "success");
-                    AdminOperationsMetricsService.RecordConfigurationChange("provider", "update");
-
-                    return NoContent();
-                },
-                "Provider",
-                id,
-                "UpdateProvider");
+            return NoContent();
         }
 
         /// <summary>
@@ -252,30 +243,28 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> DeleteProvider(int id)
+        public async Task<IActionResult> DeleteProvider(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _providerRepository.GetByIdAsync(id),
-                async provider =>
-                {
-                    await _providerRepository.DeleteAsync(id);
+            var provider = await _providerRepository.GetByIdAsync(id);
+            if (provider == null)
+            {
+                return this.NotFoundEntity("Provider", id);
+            }
 
-                    // Publish provider deleted event
-                    PublishEventFireAndForget(new ProviderDeleted
-                    {
-                        ProviderId = id,
-                        CorrelationId = Guid.NewGuid().ToString()
-                    }, "delete provider", new { ProviderId = id });
+            await _providerRepository.DeleteAsync(id);
 
-                    LogAdminAudit("Deleted", "Provider", id, $"Name: {LoggingSanitizer.S(provider.ProviderName)}");
-                    AdminOperationsMetricsService.RecordProviderOperation("delete", provider.ProviderType.ToString(), "success");
-                    AdminOperationsMetricsService.RecordConfigurationChange("provider", "delete");
+            // Publish provider deleted event
+            PublishEventFireAndForget(new ProviderDeleted
+            {
+                ProviderId = id,
+                CorrelationId = Guid.NewGuid().ToString()
+            }, "delete provider", new { ProviderId = id });
 
-                    return NoContent();
-                },
-                "Provider",
-                id,
-                "DeleteProvider");
+            LogAdminAudit("Deleted", "Provider", id, $"Name: {LoggingSanitizer.S(provider.ProviderName)}");
+            AdminOperationsMetricsService.RecordProviderOperation("delete", provider.ProviderType.ToString(), "success");
+            AdminOperationsMetricsService.RecordConfigurationChange("provider", "delete");
+
+            return NoContent();
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Testing.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Testing.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Admin.Extensions;
 using ConduitLLM.Admin.Metrics;
 using ConduitLLM.Admin.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -17,63 +18,61 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> TestProviderConnection(int id)
+        public async Task<IActionResult> TestProviderConnection(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _providerRepository.GetByIdAsync(id),
-                async provider =>
-                {
-                    // Check if this provider type doesn't support testing
-                    var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
-                        new NotSupportedException("Provider does not support API key testing"),
-                        provider.ProviderType
-                    );
+            var provider = await _providerRepository.GetByIdAsync(id);
+            if (provider == null)
+            {
+                return this.NotFoundEntity("Provider", id);
+            }
 
-                    if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
-                    {
-                        return Ok(nonTestableResponse);
-                    }
+            // Check if this provider type doesn't support testing
+            var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
+                new NotSupportedException("Provider does not support API key testing"),
+                provider.ProviderType
+            );
 
-                    // Get a client for this provider to test
-                    var client = await _clientFactory.GetClientByProviderIdAsync(id);
+            if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
+            {
+                return Ok(nonTestableResponse);
+            }
 
-                    // Perform a simple test - list models
-                    using var activity = AdminRequestMetrics.StartProviderTestActivity(provider.ProviderType.ToString(), id);
-                    var startTime = DateTime.UtcNow;
-                    try
-                    {
-                        var models = await client.ListModelsAsync();
-                        var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                        var modelList = models?.Select(m => m.ToString()).ToArray();
+            // Get a client for this provider to test
+            var client = await _clientFactory.GetClientByProviderIdAsync(id);
 
-                        var response = ApiKeyTestResultService.CreateSuccessResponse(
-                            responseTime,
-                            modelList
-                        );
+            // Perform a simple test - list models
+            using var activity = AdminRequestMetrics.StartProviderTestActivity(provider.ProviderType.ToString(), id);
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                var models = await client.ListModelsAsync();
+                var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                var modelList = models?.Select(m => m.ToString()).ToArray();
 
-                        LogAdminAudit("Tested", "Provider", id,
-                            $"Type: {provider.ProviderType}, Result: Success, ResponseTime: {responseTime:F0}ms, Models: {modelList?.Length ?? 0}");
-                        AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "success", responseTime / 1000.0);
+                var response = ApiKeyTestResultService.CreateSuccessResponse(
+                    responseTime,
+                    modelList
+                );
 
-                        return Ok(response);
-                    }
-                    catch (Exception testEx)
-                    {
-                        var response = ApiKeyTestResultService.CreateErrorResponse(
-                            testEx,
-                            provider.ProviderType
-                        );
+                LogAdminAudit("Tested", "Provider", id,
+                    $"Type: {provider.ProviderType}, Result: Success, ResponseTime: {responseTime:F0}ms, Models: {modelList?.Length ?? 0}");
+                AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "success", responseTime / 1000.0);
 
-                        LogAdminAudit("Tested", "Provider", id,
-                            $"Type: {provider.ProviderType}, Result: {response.Result}, Error: {response.Message}");
-                        AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "failure");
+                return Ok(response);
+            }
+            catch (Exception testEx)
+            {
+                var response = ApiKeyTestResultService.CreateErrorResponse(
+                    testEx,
+                    provider.ProviderType
+                );
 
-                        return Ok(response);
-                    }
-                },
-                "Provider",
-                id,
-                "TestProviderConnection");
+                LogAdminAudit("Tested", "Provider", id,
+                    $"Type: {provider.ProviderType}, Result: {response.Result}, Error: {response.Message}");
+                AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "failure");
+
+                return Ok(response);
+            }
         }
 
         /// <summary>
@@ -84,85 +83,78 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> TestProviderConnectionWithCredentials([FromBody] TestProviderRequest testRequest)
+        public async Task<IActionResult> TestProviderConnectionWithCredentials([FromBody] TestProviderRequest testRequest)
         {
-            return ExecuteAsync(
-                async () =>
+            // Create a temporary provider for testing
+            var testProvider = new Provider
+            {
+                Id = -1, // Temporary ID
+                ProviderType = testRequest.ProviderType,
+                ProviderName = "Test Provider",
+                BaseUrl = testRequest.BaseUrl,
+                IsEnabled = true
+            };
+
+            // Create a temporary key if provided
+            if (!string.IsNullOrEmpty(testRequest.ApiKey))
+            {
+                testProvider.ProviderKeyCredentials = new List<ProviderKeyCredential>
                 {
-                    // Create a temporary provider for testing
-                    var testProvider = new Provider
-                    {
-                        Id = -1, // Temporary ID
-                        ProviderType = testRequest.ProviderType,
-                        ProviderName = "Test Provider",
-                        BaseUrl = testRequest.BaseUrl,
-                        IsEnabled = true
-                    };
-
-                    // Create a temporary key if provided
-                    if (!string.IsNullOrEmpty(testRequest.ApiKey))
-                    {
-                        testProvider.ProviderKeyCredentials = new List<ProviderKeyCredential>
-                        {
-                            new ProviderKeyCredential
-                            {
-                                ApiKey = testRequest.ApiKey,
-                                Organization = testRequest.Organization,
-                                IsPrimary = true,
-                                IsEnabled = true
-                            }
-                        };
-                    }
-
-                    // Check if this provider type doesn't support testing
-                    var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
-                        new NotSupportedException("Provider does not support API key testing"),
-                        testProvider.ProviderType
-                    );
-
-                    if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
-                    {
-                        return (IActionResult)Ok(nonTestableResponse);
-                    }
-
-                    // Test the connection
-                    var testKey = new ProviderKeyCredential
+                    new ProviderKeyCredential
                     {
                         ApiKey = testRequest.ApiKey,
-                        BaseUrl = testRequest.BaseUrl,
                         Organization = testRequest.Organization,
                         IsPrimary = true,
                         IsEnabled = true
-                    };
-                    var client = _clientFactory.CreateTestClient(testProvider, testKey);
-
-                    var startTime = DateTime.UtcNow;
-                    try
-                    {
-                        var models = await client.ListModelsAsync();
-                        var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                        var modelList = models?.Select(m => m.ToString()).ToArray();
-
-                        var response = ApiKeyTestResultService.CreateSuccessResponse(
-                            responseTime,
-                            modelList
-                        );
-
-                        return (IActionResult)Ok(response);
                     }
-                    catch (Exception testEx)
-                    {
-                        var response = ApiKeyTestResultService.CreateErrorResponse(
-                            testEx,
-                            testProvider.ProviderType
-                        );
+                };
+            }
 
-                        return (IActionResult)Ok(response);
-                    }
-                },
-                result => result,
-                "TestProviderConnectionWithCredentials",
-                new { ProviderType = testRequest?.ProviderType.ToString() ?? "unknown" });
+            // Check if this provider type doesn't support testing
+            var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
+                new NotSupportedException("Provider does not support API key testing"),
+                testProvider.ProviderType
+            );
+
+            if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
+            {
+                return Ok(nonTestableResponse);
+            }
+
+            // Test the connection
+            var testKey = new ProviderKeyCredential
+            {
+                ApiKey = testRequest.ApiKey,
+                BaseUrl = testRequest.BaseUrl,
+                Organization = testRequest.Organization,
+                IsPrimary = true,
+                IsEnabled = true
+            };
+            var client = _clientFactory.CreateTestClient(testProvider, testKey);
+
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                var models = await client.ListModelsAsync();
+                var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                var modelList = models?.Select(m => m.ToString()).ToArray();
+
+                var response = ApiKeyTestResultService.CreateSuccessResponse(
+                    responseTime,
+                    modelList
+                );
+
+                return Ok(response);
+            }
+            catch (Exception testEx)
+            {
+                var response = ApiKeyTestResultService.CreateErrorResponse(
+                    testEx,
+                    testProvider.ProviderType
+                );
+
+                return Ok(response);
+            }
         }
 
         /// <summary>
@@ -175,73 +167,66 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> TestProviderKeyCredential(int providerId, int keyId)
+        public async Task<IActionResult> TestProviderKeyCredential(int providerId, int keyId)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var key = await _keyRepository.GetByIdAsync(keyId);
-                    if (key == null || key.ProviderId != providerId)
-                    {
-                        return (IActionResult)NotFound(new ErrorResponseDto("Key credential not found"));
-                    }
+            var key = await _keyRepository.GetByIdAsync(keyId);
+            if (key == null || key.ProviderId != providerId)
+            {
+                return NotFound(new ErrorResponseDto("Key credential not found"));
+            }
 
-                    var provider = await _providerRepository.GetByIdAsync(providerId);
-                    if (provider == null)
-                    {
-                        return (IActionResult)NotFound(new ErrorResponseDto("Provider not found"));
-                    }
+            var provider = await _providerRepository.GetByIdAsync(providerId);
+            if (provider == null)
+            {
+                return NotFound(new ErrorResponseDto("Provider not found"));
+            }
 
-                    // Check if this provider type doesn't support testing
-                    var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
-                        new NotSupportedException("Provider does not support API key testing"),
-                        provider.ProviderType
-                    );
+            // Check if this provider type doesn't support testing
+            var nonTestableResponse = ApiKeyTestResultService.CreateErrorResponse(
+                new NotSupportedException("Provider does not support API key testing"),
+                provider.ProviderType
+            );
 
-                    if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
-                    {
-                        return (IActionResult)Ok(nonTestableResponse);
-                    }
+            if (nonTestableResponse.Result == ApiKeyTestResult.Ignored)
+            {
+                return Ok(nonTestableResponse);
+            }
 
-                    // Test the connection with this specific key
-                    var client = _clientFactory.CreateTestClient(provider, key);
+            // Test the connection with this specific key
+            var client = _clientFactory.CreateTestClient(provider, key);
 
-                    using var activity = AdminRequestMetrics.StartProviderTestActivity(provider.ProviderType.ToString(), providerId);
-                    var startTime = DateTime.UtcNow;
-                    try
-                    {
-                        var models = await client.ListModelsAsync();
-                        var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                        var modelList = models?.Select(m => m.ToString()).ToArray();
+            using var activity = AdminRequestMetrics.StartProviderTestActivity(provider.ProviderType.ToString(), providerId);
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                var models = await client.ListModelsAsync();
+                var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                var modelList = models?.Select(m => m.ToString()).ToArray();
 
-                        var response = ApiKeyTestResultService.CreateSuccessResponse(
-                            responseTime,
-                            modelList
-                        );
+                var response = ApiKeyTestResultService.CreateSuccessResponse(
+                    responseTime,
+                    modelList
+                );
 
-                        LogAdminAudit("Tested", "ProviderKeyCredential", keyId,
-                            $"ProviderId: {providerId}, Result: Success, ResponseTime: {responseTime:F0}ms");
-                        AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "success", responseTime / 1000.0);
+                LogAdminAudit("Tested", "ProviderKeyCredential", keyId,
+                    $"ProviderId: {providerId}, Result: Success, ResponseTime: {responseTime:F0}ms");
+                AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "success", responseTime / 1000.0);
 
-                        return (IActionResult)Ok(response);
-                    }
-                    catch (Exception testEx)
-                    {
-                        var response = ApiKeyTestResultService.CreateErrorResponse(
-                            testEx,
-                            provider.ProviderType
-                        );
+                return Ok(response);
+            }
+            catch (Exception testEx)
+            {
+                var response = ApiKeyTestResultService.CreateErrorResponse(
+                    testEx,
+                    provider.ProviderType
+                );
 
-                        LogAdminAudit("Tested", "ProviderKeyCredential", keyId,
-                            $"ProviderId: {providerId}, Result: {response.Result}, Error: {response.Message}");
-                        AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "failure");
+                LogAdminAudit("Tested", "ProviderKeyCredential", keyId,
+                    $"ProviderId: {providerId}, Result: {response.Result}, Error: {response.Message}");
+                AdminOperationsMetricsService.RecordProviderOperation("test", provider.ProviderType.ToString(), "failure");
 
-                        return (IActionResult)Ok(response);
-                    }
-                },
-                result => result,
-                "TestProviderKeyCredential",
-                new { ProviderId = providerId, KeyId = keyId });
+                return Ok(response);
+            }
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ProviderErrorsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderErrorsController.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration.Events;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
@@ -14,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/provider-errors")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ProviderErrorsController : AdminControllerBase
     {
         private readonly IProviderErrorTrackingService _errorService;
@@ -46,39 +48,33 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="limit">Maximum number of errors to return (default: 100)</param>
         /// <returns>List of recent provider errors</returns>
         [HttpGet("recent")]
-        public Task<IActionResult> GetRecentErrors(
+        public async Task<IActionResult> GetRecentErrors(
             [FromQuery] int? providerId = null,
             [FromQuery] int? keyId = null,
             [FromQuery] int limit = 100)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (limit > 1000)
-                        limit = 1000; // Cap at 1000 for performance
+            if (limit > 1000)
+                limit = 1000; // Cap at 1000 for performance
 
-                    var errors = await _errorService.GetRecentErrorsAsync(providerId, keyId, limit);
+            var errors = await _errorService.GetRecentErrorsAsync(providerId, keyId, limit);
 
-                    // Get provider names for display using efficient lookup
-                    var providerMap = await _providerRepo.GetProviderNameMapAsync();
+            // Get provider names for display using efficient lookup
+            var providerMap = await _providerRepo.GetProviderNameMapAsync();
 
-                    var dtos = errors.Select(e => new ProviderErrorDto
-                    {
-                        KeyCredentialId = e.KeyCredentialId,
-                        ProviderId = e.ProviderId,
-                        ProviderName = providerMap.GetValueOrDefault(e.ProviderId),
-                        ErrorType = e.ErrorType.ToString(),
-                        ErrorMessage = e.ErrorMessage,
-                        HttpStatusCode = e.HttpStatusCode,
-                        OccurredAt = e.OccurredAt,
-                        IsFatal = e.IsFatal,
-                        ModelName = e.ModelName
-                    }).ToList();
+            var dtos = errors.Select(e => new ProviderErrorDto
+            {
+                KeyCredentialId = e.KeyCredentialId,
+                ProviderId = e.ProviderId,
+                ProviderName = providerMap.GetValueOrDefault(e.ProviderId),
+                ErrorType = e.ErrorType.ToString(),
+                ErrorMessage = e.ErrorMessage,
+                HttpStatusCode = e.HttpStatusCode,
+                OccurredAt = e.OccurredAt,
+                IsFatal = e.IsFatal,
+                ModelName = e.ModelName
+            }).ToList();
 
-                    return dtos;
-                },
-                result => Ok(result),
-                "GetRecentErrors");
+            return Ok(dtos);
         }
 
         /// <summary>
@@ -86,52 +82,46 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>List of provider error summaries</returns>
         [HttpGet("summary")]
-        public Task<IActionResult> GetErrorSummary()
+        public async Task<IActionResult> GetErrorSummary()
         {
-            return ExecuteAsync(
-                async () =>
+            // Use paginated retrieval - get all providers in batches
+            var allProviders = new List<ConduitLLM.Configuration.Entities.Provider>();
+            var pageNumber = 1;
+            const int pageSize = 100;
+            int totalCount;
+
+            do
+            {
+                var (items, count) = await _providerRepo.GetPaginatedAsync(pageNumber, pageSize);
+                allProviders.AddRange(items);
+                totalCount = count;
+                pageNumber++;
+            } while (allProviders.Count < totalCount);
+
+            // Fetch all provider summaries in parallel to avoid N+1
+            var summaryTasks = allProviders.Select(async provider =>
+            {
+                var summary = await _errorService.GetProviderSummaryAsync(provider.Id);
+                return (provider, summary);
+            });
+
+            var results = await Task.WhenAll(summaryTasks);
+
+            var summaries = results
+                .Where(r => r.summary != null)
+                .Select(r => new ProviderErrorSummaryDto
                 {
-                    // Use paginated retrieval - get all providers in batches
-                    var allProviders = new List<ConduitLLM.Configuration.Entities.Provider>();
-                    var pageNumber = 1;
-                    const int pageSize = 100;
-                    int totalCount;
+                    ProviderId = r.provider.Id,
+                    ProviderName = r.provider.ProviderName,
+                    TotalErrors = r.summary!.TotalErrors,
+                    FatalErrors = r.summary.FatalErrors,
+                    Warnings = r.summary.Warnings,
+                    DisabledKeyIds = r.summary.DisabledKeyIds,
+                    LastError = r.summary.LastError
+                })
+                .ToList();
 
-                    do
-                    {
-                        var (items, count) = await _providerRepo.GetPaginatedAsync(pageNumber, pageSize);
-                        allProviders.AddRange(items);
-                        totalCount = count;
-                        pageNumber++;
-                    } while (allProviders.Count < totalCount);
-
-                    // Fetch all provider summaries in parallel to avoid N+1
-                    var summaryTasks = allProviders.Select(async provider =>
-                    {
-                        var summary = await _errorService.GetProviderSummaryAsync(provider.Id);
-                        return (provider, summary);
-                    });
-
-                    var results = await Task.WhenAll(summaryTasks);
-
-                    var summaries = results
-                        .Where(r => r.summary != null)
-                        .Select(r => new ProviderErrorSummaryDto
-                        {
-                            ProviderId = r.provider.Id,
-                            ProviderName = r.provider.ProviderName,
-                            TotalErrors = r.summary!.TotalErrors,
-                            FatalErrors = r.summary.FatalErrors,
-                            Warnings = r.summary.Warnings,
-                            DisabledKeyIds = r.summary.DisabledKeyIds,
-                            LastError = r.summary.LastError
-                        })
-                        .ToList();
-
-                    return summaries;
-                },
-                result => Ok(result),
-                "GetErrorSummary");
+            return Ok(summaries);
         }
 
         /// <summary>
@@ -140,50 +130,43 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="keyId">ID of the key</param>
         /// <returns>Detailed error information for the key</returns>
         [HttpGet("keys/{keyId}")]
-        public Task<IActionResult> GetKeyErrors(int keyId)
+        public async Task<IActionResult> GetKeyErrors(int keyId)
         {
-            return ExecuteAsync(
-                async () =>
+            var details = await _errorService.GetKeyErrorDetailsAsync(keyId);
+            if (details == null)
+            {
+                throw new KeyNotFoundException($"No error data found for key {keyId}");
+            }
+
+            var dto = new KeyErrorDetailsDto
+            {
+                KeyId = details.KeyId,
+                KeyName = details.KeyName,
+                IsDisabled = details.IsDisabled,
+                DisabledAt = details.DisabledAt
+            };
+
+            if (details.FatalError != null)
+            {
+                dto.FatalError = new FatalErrorDto
                 {
-                    var details = await _errorService.GetKeyErrorDetailsAsync(keyId);
-                    if (details == null)
-                    {
-                        throw new KeyNotFoundException($"No error data found for key {keyId}");
-                    }
+                    ErrorType = details.FatalError.ErrorType.ToString(),
+                    Count = details.FatalError.Count,
+                    FirstSeen = details.FatalError.FirstSeen,
+                    LastSeen = details.FatalError.LastSeen,
+                    LastErrorMessage = details.FatalError.LastErrorMessage,
+                    LastStatusCode = details.FatalError.LastStatusCode
+                };
+            }
 
-                    var dto = new KeyErrorDetailsDto
-                    {
-                        KeyId = details.KeyId,
-                        KeyName = details.KeyName,
-                        IsDisabled = details.IsDisabled,
-                        DisabledAt = details.DisabledAt
-                    };
+            dto.RecentWarnings = details.RecentWarnings.Select(w => new WarningErrorDto
+            {
+                Type = w.Type.ToString(),
+                Message = w.Message,
+                Timestamp = w.Timestamp
+            }).ToList();
 
-                    if (details.FatalError != null)
-                    {
-                        dto.FatalError = new FatalErrorDto
-                        {
-                            ErrorType = details.FatalError.ErrorType.ToString(),
-                            Count = details.FatalError.Count,
-                            FirstSeen = details.FatalError.FirstSeen,
-                            LastSeen = details.FatalError.LastSeen,
-                            LastErrorMessage = details.FatalError.LastErrorMessage,
-                            LastStatusCode = details.FatalError.LastStatusCode
-                        };
-                    }
-
-                    dto.RecentWarnings = details.RecentWarnings.Select(w => new WarningErrorDto
-                    {
-                        Type = w.Type.ToString(),
-                        Message = w.Message,
-                        Timestamp = w.Timestamp
-                    }).ToList();
-
-                    return dto;
-                },
-                result => Ok(result),
-                "GetKeyErrors",
-                new { KeyId = keyId });
+            return Ok(dto);
         }
 
         /// <summary>
@@ -193,61 +176,54 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="request">Clear errors request</param>
         /// <returns>Operation result</returns>
         [HttpPost("keys/{keyId}/clear")]
-        public Task<IActionResult> ClearKeyErrors(
+        public async Task<IActionResult> ClearKeyErrors(
             int keyId,
             [FromBody] ClearErrorsRequest request)
         {
             if (!request.ConfirmReenable && request.ReenableKey)
             {
-                return Task.FromResult<IActionResult>(BadRequest(new { error = "Must confirm re-enabling the key" }));
+                return BadRequest(new { error = "Must confirm re-enabling the key" });
             }
 
-            return ExecuteAsync(
-                async () =>
+            // Look up the key to get its providerId for proper cleanup
+            var key = await _keyRepo.GetByIdAsync(keyId);
+            int? providerId = key?.ProviderId;
+
+            // Clear errors from Redis (including provider disabled keys cleanup)
+            await _errorService.ClearErrorsForKeyAsync(keyId, providerId);
+
+            // Re-enable the key if requested
+            if (request.ReenableKey && key != null && !key.IsEnabled)
+            {
+                key.IsEnabled = true;
+                await _keyRepo.UpdateAsync(key);
+
+                // Publish event for UI update
+                PublishEventFireAndForget(new ProviderKeyReenabledEvent
                 {
-                    // Look up the key to get its providerId for proper cleanup
-                    var key = await _keyRepo.GetByIdAsync(keyId);
-                    int? providerId = key?.ProviderId;
+                    KeyId = keyId,
+                    ProviderId = key.ProviderId,
+                    ReenabledBy = User.Identity?.Name ?? "Admin",
+                    Reason = request.Reason ?? "Manual re-enable after error resolution",
+                    ReenabledAt = DateTime.UtcNow
+                }, "ClearKeyErrors");
 
-                    // Clear errors from Redis (including provider disabled keys cleanup)
-                    await _errorService.ClearErrorsForKeyAsync(keyId, providerId);
+                LogAdminAudit("ClearedErrorsAndReenabled", "ProviderKeyCredential", keyId,
+                    $"ProviderId: {key.ProviderId}");
+            }
+            else
+            {
+                LogAdminAudit("ClearedErrors", "ProviderKeyCredential", keyId);
+            }
 
-                    // Re-enable the key if requested
-                    if (request.ReenableKey && key != null && !key.IsEnabled)
-                    {
-                        key.IsEnabled = true;
-                        await _keyRepo.UpdateAsync(key);
-
-                        // Publish event for UI update
-                        PublishEventFireAndForget(new ProviderKeyReenabledEvent
-                        {
-                            KeyId = keyId,
-                            ProviderId = key.ProviderId,
-                            ReenabledBy = User.Identity?.Name ?? "Admin",
-                            Reason = request.Reason ?? "Manual re-enable after error resolution",
-                            ReenabledAt = DateTime.UtcNow
-                        }, "ClearKeyErrors");
-
-                        LogAdminAudit("ClearedErrorsAndReenabled", "ProviderKeyCredential", keyId,
-                            $"ProviderId: {key.ProviderId}");
-                    }
-                    else
-                    {
-                        LogAdminAudit("ClearedErrors", "ProviderKeyCredential", keyId);
-                    }
-
-                    return new
-                    {
-                        message = request.ReenableKey
-                            ? "Errors cleared and key re-enabled successfully"
-                            : "Errors cleared successfully",
-                        keyId = keyId,
-                        reenabled = request.ReenableKey
-                    };
-                },
-                result => Ok(result),
-                "ClearKeyErrors",
-                new { KeyId = keyId });
+            return Ok(new
+            {
+                message = request.ReenableKey
+                    ? "Errors cleared and key re-enabled successfully"
+                    : "Errors cleared successfully",
+                keyId = keyId,
+                reenabled = request.ReenableKey
+            });
         }
 
         /// <summary>
@@ -256,40 +232,34 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="hours">Time window in hours (default: 24)</param>
         /// <returns>Error statistics</returns>
         [HttpGet("stats")]
-        public Task<IActionResult> GetErrorStatistics(
+        public async Task<IActionResult> GetErrorStatistics(
             [FromQuery] int hours = 24)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (hours > 168) // Cap at 1 week
-                        hours = 168;
+            if (hours > 168) // Cap at 1 week
+                hours = 168;
 
-                    var window = TimeSpan.FromHours(hours);
-                    var stats = await _errorService.GetErrorStatisticsAsync(window);
+            var window = TimeSpan.FromHours(hours);
+            var stats = await _errorService.GetErrorStatisticsAsync(window);
 
-                    // Map provider IDs to names for the statistics
-                    var providerNameMap = await _providerRepo.GetProviderNameMapAsync();
-                    var errorsByProviderName = stats.ErrorsByProvider.ToDictionary(
-                        kvp => providerNameMap.GetValueOrDefault(int.Parse(kvp.Key), $"Provider {kvp.Key}"),
-                        kvp => kvp.Value);
+            // Map provider IDs to names for the statistics
+            var providerNameMap = await _providerRepo.GetProviderNameMapAsync();
+            var errorsByProviderName = stats.ErrorsByProvider.ToDictionary(
+                kvp => providerNameMap.GetValueOrDefault(int.Parse(kvp.Key), $"Provider {kvp.Key}"),
+                kvp => kvp.Value);
 
-                    var dto = new ErrorStatisticsDto
-                    {
-                        TotalErrors = stats.TotalErrors,
-                        FatalErrors = stats.FatalErrors,
-                        Warnings = stats.Warnings,
-                        DisabledKeys = stats.DisabledKeys,
-                        ErrorsByType = stats.ErrorsByType,
-                        ErrorsByProvider = errorsByProviderName,
-                        TimeWindow = window,
-                        GeneratedAt = DateTime.UtcNow
-                    };
+            var dto = new ErrorStatisticsDto
+            {
+                TotalErrors = stats.TotalErrors,
+                FatalErrors = stats.FatalErrors,
+                Warnings = stats.Warnings,
+                DisabledKeys = stats.DisabledKeys,
+                ErrorsByType = stats.ErrorsByType,
+                ErrorsByProvider = errorsByProviderName,
+                TimeWindow = window,
+                GeneratedAt = DateTime.UtcNow
+            };
 
-                    return dto;
-                },
-                result => Ok(result),
-                "GetErrorStatistics");
+            return Ok(dto);
         }
 
         /// <summary>
@@ -299,24 +269,17 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="hours">Time window in hours (default: 1)</param>
         /// <returns>Dictionary of key ID to error count</returns>
         [HttpGet("providers/{providerId}/key-errors")]
-        public Task<IActionResult> GetErrorCountsByKey(
+        public async Task<IActionResult> GetErrorCountsByKey(
             int providerId,
             [FromQuery] int hours = 1)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    if (hours > 24)
-                        hours = 24; // Cap at 24 hours
+            if (hours > 24)
+                hours = 24; // Cap at 24 hours
 
-                    var window = TimeSpan.FromHours(hours);
-                    var counts = await _errorService.GetErrorCountsByKeyAsync(providerId, window);
+            var window = TimeSpan.FromHours(hours);
+            var counts = await _errorService.GetErrorCountsByKeyAsync(providerId, window);
 
-                    return counts;
-                },
-                result => Ok(result),
-                "GetErrorCountsByKey",
-                new { ProviderId = providerId });
+            return Ok(counts);
         }
 
         /// <summary>
@@ -326,32 +289,25 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="reason">Reason for disabling</param>
         /// <returns>Operation result</returns>
         [HttpPost("keys/{keyId}/disable")]
-        public Task<IActionResult> DisableKey(
+        public async Task<IActionResult> DisableKey(
             int keyId,
             [FromBody] string reason)
         {
             if (string.IsNullOrWhiteSpace(reason))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new { error = "Reason is required for disabling a key" }));
+                return BadRequest(new { error = "Reason is required for disabling a key" });
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    await _errorService.DisableKeyAsync(keyId, $"Manual disable: {reason}");
+            await _errorService.DisableKeyAsync(keyId, $"Manual disable: {reason}");
 
-                    LogAdminAudit("Disabled", "ProviderKeyCredential", keyId,
-                        $"Reason: {reason}");
+            LogAdminAudit("Disabled", "ProviderKeyCredential", keyId,
+                $"Reason: {reason}");
 
-                    return new
-                    {
-                        message = "Key disabled successfully",
-                        keyId = keyId
-                    };
-                },
-                result => Ok(result),
-                "DisableKey",
-                new { KeyId = keyId });
+            return Ok(new
+            {
+                message = "Key disabled successfully",
+                keyId = keyId
+            });
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/ProviderToolsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderToolsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
@@ -15,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers
     /// </summary>
     [ApiController]
     [Route("api/admin/provider-tools")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class ProviderToolsController : AdminControllerBase
     {
         private readonly ConduitDbContext _context;
@@ -40,34 +42,28 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="isActive">Optional active status filter</param>
         /// <returns>List of provider tools</returns>
         [HttpGet]
-        public Task<IActionResult> GetProviderTools(
+        public async Task<IActionResult> GetProviderTools(
             [FromQuery] ProviderType? provider = null,
             [FromQuery] bool? isActive = null)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var query = _context.ProviderTools.AsQueryable();
+            var query = _context.ProviderTools.AsQueryable();
 
-                    if (provider.HasValue)
-                    {
-                        query = query.Where(pt => pt.Provider == provider.Value);
-                    }
+            if (provider.HasValue)
+            {
+                query = query.Where(pt => pt.Provider == provider.Value);
+            }
 
-                    if (isActive.HasValue)
-                    {
-                        query = query.Where(pt => pt.IsActive == isActive.Value);
-                    }
+            if (isActive.HasValue)
+            {
+                query = query.Where(pt => pt.IsActive == isActive.Value);
+            }
 
-                    var tools = await query
-                        .OrderBy(pt => pt.Provider)
-                        .ThenBy(pt => pt.ToolName)
-                        .ToListAsync();
+            var tools = await query
+                .OrderBy(pt => pt.Provider)
+                .ThenBy(pt => pt.ToolName)
+                .ToListAsync();
 
-                    return tools.Select(ProviderToolDto.FromEntity);
-                },
-                result => Ok(result),
-                "GetProviderTools");
+            return Ok(tools.Select(ProviderToolDto.FromEntity));
         }
 
         /// <summary>
@@ -76,22 +72,15 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="id">Tool ID</param>
         /// <returns>Provider tool details</returns>
         [HttpGet("{id}")]
-        public Task<IActionResult> GetProviderTool(int id)
+        public async Task<IActionResult> GetProviderTool(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var tool = await _context.ProviderTools.FindAsync(id);
-                    if (tool == null)
-                    {
-                        throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
-                    }
+            var tool = await _context.ProviderTools.FindAsync(id);
+            if (tool == null)
+            {
+                throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
+            }
 
-                    return ProviderToolDto.FromEntity(tool);
-                },
-                result => Ok(result),
-                "GetProviderTool",
-                new { Id = id });
+            return Ok(ProviderToolDto.FromEntity(tool));
         }
 
         /// <summary>
@@ -100,47 +89,42 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="dto">Provider tool creation data</param>
         /// <returns>Created provider tool</returns>
         [HttpPost]
-        public Task<IActionResult> CreateProviderTool([FromBody] CreateProviderToolDto dto)
+        public async Task<IActionResult> CreateProviderTool([FromBody] CreateProviderToolDto dto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Validate billing unit
-                    ValidateBillingUnit(dto.BillingUnit);
+            // Validate billing unit
+            ValidateBillingUnit(dto.BillingUnit);
 
-                    // Check if tool already exists for this provider
-                    var existingTool = await _context.ProviderTools
-                        .FirstOrDefaultAsync(pt => pt.Provider == dto.Provider && pt.ToolName == dto.ToolName);
+            // Check if tool already exists for this provider
+            var existingTool = await _context.ProviderTools
+                .FirstOrDefaultAsync(pt => pt.Provider == dto.Provider && pt.ToolName == dto.ToolName);
 
-                    if (existingTool != null)
-                    {
-                        throw new InvalidOperationException($"Tool '{dto.ToolName}' already exists for provider {dto.Provider}");
-                    }
+            if (existingTool != null)
+            {
+                throw new InvalidOperationException($"Tool '{dto.ToolName}' already exists for provider {dto.Provider}");
+            }
 
-                    var tool = new ProviderTool
-                    {
-                        Provider = dto.Provider,
-                        ToolName = dto.ToolName,
-                        ToolParameters = dto.ToolParameters,
-                        CostPerUnit = dto.CostPerUnit,
-                        BillingUnit = dto.BillingUnit,
-                        CostDescription = dto.CostDescription,
-                        IsActive = dto.IsActive,
-                        UpdatedAt = DateTime.UtcNow
-                    };
+            var tool = new ProviderTool
+            {
+                Provider = dto.Provider,
+                ToolName = dto.ToolName,
+                ToolParameters = dto.ToolParameters,
+                CostPerUnit = dto.CostPerUnit,
+                BillingUnit = dto.BillingUnit,
+                CostDescription = dto.CostDescription,
+                IsActive = dto.IsActive,
+                UpdatedAt = DateTime.UtcNow
+            };
 
-                    _context.ProviderTools.Add(tool);
-                    await _context.SaveChangesAsync();
+            _context.ProviderTools.Add(tool);
+            await _context.SaveChangesAsync();
 
-                    LogAdminAudit("Created", "ProviderTool", tool.Id,
-                        $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
+            LogAdminAudit("Created", "ProviderTool", tool.Id,
+                $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
 
-                    await PublishToolChangedEventAsync(tool, "Created");
+            await PublishToolChangedEventAsync(tool, "Created");
 
-                    return ProviderToolDto.FromEntity(tool);
-                },
-                result => CreatedAtAction(nameof(GetProviderTool), new { id = result.Id }, result),
-                "CreateProviderTool");
+            var result = ProviderToolDto.FromEntity(tool);
+            return CreatedAtAction(nameof(GetProviderTool), new { id = result.Id }, result);
         }
 
         /// <summary>
@@ -150,39 +134,32 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="dto">Updated tool data</param>
         /// <returns>Updated provider tool</returns>
         [HttpPut("{id}")]
-        public Task<IActionResult> UpdateProviderTool(int id, [FromBody] UpdateProviderToolDto dto)
+        public async Task<IActionResult> UpdateProviderTool(int id, [FromBody] UpdateProviderToolDto dto)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Validate billing unit
-                    ValidateBillingUnit(dto.BillingUnit);
+            // Validate billing unit
+            ValidateBillingUnit(dto.BillingUnit);
 
-                    var tool = await _context.ProviderTools.FindAsync(id);
-                    if (tool == null)
-                    {
-                        throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
-                    }
+            var tool = await _context.ProviderTools.FindAsync(id);
+            if (tool == null)
+            {
+                throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
+            }
 
-                    tool.IsActive = dto.IsActive;
-                    tool.ToolParameters = dto.ToolParameters;
-                    tool.CostPerUnit = dto.CostPerUnit;
-                    tool.BillingUnit = dto.BillingUnit;
-                    tool.CostDescription = dto.CostDescription;
-                    tool.UpdatedAt = DateTime.UtcNow;
+            tool.IsActive = dto.IsActive;
+            tool.ToolParameters = dto.ToolParameters;
+            tool.CostPerUnit = dto.CostPerUnit;
+            tool.BillingUnit = dto.BillingUnit;
+            tool.CostDescription = dto.CostDescription;
+            tool.UpdatedAt = DateTime.UtcNow;
 
-                    await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
 
-                    LogAdminAudit("Updated", "ProviderTool", id,
-                        $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
+            LogAdminAudit("Updated", "ProviderTool", id,
+                $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
 
-                    await PublishToolChangedEventAsync(tool, "Updated");
+            await PublishToolChangedEventAsync(tool, "Updated");
 
-                    return ProviderToolDto.FromEntity(tool);
-                },
-                result => Ok(result),
-                "UpdateProviderTool",
-                new { Id = id });
+            return Ok(ProviderToolDto.FromEntity(tool));
         }
 
         /// <summary>
@@ -191,28 +168,23 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="id">Tool ID</param>
         /// <returns>Success status</returns>
         [HttpDelete("{id}")]
-        public Task<IActionResult> DeleteProviderTool(int id)
+        public async Task<IActionResult> DeleteProviderTool(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var tool = await _context.ProviderTools.FindAsync(id);
-                    if (tool == null)
-                    {
-                        throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
-                    }
+            var tool = await _context.ProviderTools.FindAsync(id);
+            if (tool == null)
+            {
+                throw new KeyNotFoundException($"Provider tool with ID '{id}' not found");
+            }
 
-                    _context.ProviderTools.Remove(tool);
-                    await _context.SaveChangesAsync();
+            _context.ProviderTools.Remove(tool);
+            await _context.SaveChangesAsync();
 
-                    LogAdminAudit("Deleted", "ProviderTool", id,
-                        $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
+            LogAdminAudit("Deleted", "ProviderTool", id,
+                $"ToolName: {LoggingSanitizer.S(tool.ToolName)}, Provider: {tool.Provider}");
 
-                    await PublishToolChangedEventAsync(tool, "Deleted");
-                },
-                NoContent(),
-                "DeleteProviderTool",
-                new { Id = id });
+            await PublishToolChangedEventAsync(tool, "Deleted");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -250,86 +222,80 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="tools">Array of provider tools to import</param>
         /// <returns>Import results</returns>
         [HttpPost("import")]
-        public Task<IActionResult> ImportProviderTools([FromBody] List<CreateProviderToolDto> tools)
+        public async Task<IActionResult> ImportProviderTools([FromBody] List<CreateProviderToolDto> tools)
         {
-            return ExecuteAsync(
-                async () =>
+            var imported = 0;
+            var skipped = 0;
+            var errors = new List<string>();
+            var affectedProviders = new HashSet<ProviderType>();
+
+            foreach (var dto in tools)
+            {
+                try
                 {
-                    var imported = 0;
-                    var skipped = 0;
-                    var errors = new List<string>();
-                    var affectedProviders = new HashSet<ProviderType>();
-
-                    foreach (var dto in tools)
+                    // Validate billing unit
+                    if (!ProviderToolBillingUnits.IsValid(dto.BillingUnit))
                     {
-                        try
-                        {
-                            // Validate billing unit
-                            if (!ProviderToolBillingUnits.IsValid(dto.BillingUnit))
-                            {
-                                errors.Add($"Tool '{dto.ToolName}': Invalid billing unit '{dto.BillingUnit}'. " +
-                                    $"Must be one of: {string.Join(", ", ProviderToolBillingUnits.All)}");
-                                skipped++;
-                                continue;
-                            }
-
-                            // Check if tool already exists
-                            var exists = await _context.ProviderTools
-                                .AnyAsync(pt => pt.Provider == dto.Provider && pt.ToolName == dto.ToolName);
-
-                            if (exists)
-                            {
-                                skipped++;
-                                errors.Add($"Tool '{dto.ToolName}' already exists for {dto.Provider}");
-                                continue;
-                            }
-
-                            var tool = new ProviderTool
-                            {
-                                Provider = dto.Provider,
-                                ToolName = dto.ToolName,
-                                ToolParameters = dto.ToolParameters,
-                                CostPerUnit = dto.CostPerUnit,
-                                BillingUnit = dto.BillingUnit,
-                                CostDescription = dto.CostDescription,
-                                IsActive = dto.IsActive,
-                                UpdatedAt = DateTime.UtcNow
-                            };
-
-                            _context.ProviderTools.Add(tool);
-                            imported++;
-                            affectedProviders.Add(dto.Provider);
-                        }
-                        catch (Exception ex)
-                        {
-                            errors.Add($"Failed to import {dto.ToolName}: {ex.Message}");
-                        }
+                        errors.Add($"Tool '{dto.ToolName}': Invalid billing unit '{dto.BillingUnit}'. " +
+                            $"Must be one of: {string.Join(", ", ProviderToolBillingUnits.All)}");
+                        skipped++;
+                        continue;
                     }
 
-                    if (imported > 0)
-                    {
-                        await _context.SaveChangesAsync();
+                    // Check if tool already exists
+                    var exists = await _context.ProviderTools
+                        .AnyAsync(pt => pt.Provider == dto.Provider && pt.ToolName == dto.ToolName);
 
-                        // Publish events for each affected provider
-                        foreach (var provider in affectedProviders)
-                        {
-                            await PublishToolChangedEventAsync(provider, "BulkImport");
-                        }
+                    if (exists)
+                    {
+                        skipped++;
+                        errors.Add($"Tool '{dto.ToolName}' already exists for {dto.Provider}");
+                        continue;
                     }
 
-                    LogAdminAudit("Imported", "ProviderTool",
-                        detail: $"Imported: {imported}, Skipped: {skipped}, Total: {tools.Count}");
-
-                    return new
+                    var tool = new ProviderTool
                     {
-                        imported,
-                        skipped,
-                        total = tools.Count,
-                        errors = errors.Count > 0 ? errors : null
+                        Provider = dto.Provider,
+                        ToolName = dto.ToolName,
+                        ToolParameters = dto.ToolParameters,
+                        CostPerUnit = dto.CostPerUnit,
+                        BillingUnit = dto.BillingUnit,
+                        CostDescription = dto.CostDescription,
+                        IsActive = dto.IsActive,
+                        UpdatedAt = DateTime.UtcNow
                     };
-                },
-                result => Ok(result),
-                "ImportProviderTools");
+
+                    _context.ProviderTools.Add(tool);
+                    imported++;
+                    affectedProviders.Add(dto.Provider);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Failed to import {dto.ToolName}: {ex.Message}");
+                }
+            }
+
+            if (imported > 0)
+            {
+                await _context.SaveChangesAsync();
+
+                // Publish events for each affected provider
+                foreach (var provider in affectedProviders)
+                {
+                    await PublishToolChangedEventAsync(provider, "BulkImport");
+                }
+            }
+
+            LogAdminAudit("Imported", "ProviderTool",
+                detail: $"Imported: {imported}, Skipped: {skipped}, Total: {tools.Count}");
+
+            return Ok(new
+            {
+                imported,
+                skipped,
+                total = tools.Count,
+                errors = errors.Count > 0 ? errors : null
+            });
         }
 
         /// <summary>
@@ -337,23 +303,17 @@ namespace ConduitLLM.Admin.Controllers
         /// </summary>
         /// <returns>JSON array of all provider tools</returns>
         [HttpGet("export")]
-        public Task<IActionResult> ExportProviderTools()
+        public async Task<IActionResult> ExportProviderTools()
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var tools = await _context.ProviderTools
-                        .OrderBy(pt => pt.Provider)
-                        .ThenBy(pt => pt.ToolName)
-                        .ToListAsync();
+            var tools = await _context.ProviderTools
+                .OrderBy(pt => pt.Provider)
+                .ThenBy(pt => pt.ToolName)
+                .ToListAsync();
 
-                    var dtos = tools.Select(ProviderToolDto.FromEntity);
+            var dtos = tools.Select(ProviderToolDto.FromEntity);
 
-                    Response.Headers.Append("Content-Disposition", "attachment; filename=provider-tools.json");
-                    return dtos;
-                },
-                result => Ok(result),
-                "ExportProviderTools");
+            Response.Headers.Append("Content-Disposition", "attachment; filename=provider-tools.json");
+            return Ok(dtos);
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/SecurityMonitoringController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/SecurityMonitoringController.cs
@@ -1,3 +1,4 @@
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Configuration;
 
 using Microsoft.AspNetCore.Authorization;
@@ -13,6 +14,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("api/security")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class SecurityMonitoringController : AdminControllerBase
     {
         private readonly IDbContextFactory<ConduitDbContext> _dbContextFactory;
@@ -41,111 +43,105 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Security events data.</returns>
         [HttpGet("events")]
-        public Task<IActionResult> GetSecurityEvents(
+        public async Task<IActionResult> GetSecurityEvents(
             [FromQuery] int hours = 24,
             CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var startTime = DateTime.UtcNow.AddHours(-hours);
+
+            // Get authentication failures (401 status codes)
+            var authFailures = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= startTime && r.StatusCode == 401)
+                .Select(r => new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+                    Timestamp = r.Timestamp,
+                    Type = "auth_failure",
+                    Severity = "warning",
+                    Source = r.ClientIp ?? "Unknown",
+                    VirtualKeyId = r.VirtualKeyId.ToString(),
+                    Details = "Unauthorized access attempt",
+                    StatusCode = r.StatusCode
+                })
+                .ToListAsync(cancellationToken);
 
-                    var startTime = DateTime.UtcNow.AddHours(-hours);
+            // Get rate limit violations (429 status codes)
+            var rateLimitViolations = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= startTime && r.StatusCode == 429)
+                .Select(r => new
+                {
+                    Timestamp = r.Timestamp,
+                    Type = "rate_limit",
+                    Severity = "warning",
+                    Source = r.ClientIp ?? "Unknown",
+                    VirtualKeyId = r.VirtualKeyId.ToString(),
+                    Details = "Rate limit exceeded",
+                    StatusCode = r.StatusCode
+                })
+                .ToListAsync(cancellationToken);
 
-                    // Get authentication failures (401 status codes)
-                    var authFailures = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= startTime && r.StatusCode == 401)
-                        .Select(r => new
-                        {
-                            Timestamp = r.Timestamp,
-                            Type = "auth_failure",
-                            Severity = "warning",
-                            Source = r.ClientIp ?? "Unknown",
-                            VirtualKeyId = r.VirtualKeyId.ToString(),
-                            Details = "Unauthorized access attempt",
-                            StatusCode = r.StatusCode
-                        })
-                        .ToListAsync(cancellationToken);
-
-                    // Get rate limit violations (429 status codes)
-                    var rateLimitViolations = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= startTime && r.StatusCode == 429)
-                        .Select(r => new
-                        {
-                            Timestamp = r.Timestamp,
-                            Type = "rate_limit",
-                            Severity = "warning",
-                            Source = r.ClientIp ?? "Unknown",
-                            VirtualKeyId = r.VirtualKeyId.ToString(),
-                            Details = "Rate limit exceeded",
-                            StatusCode = r.StatusCode
-                        })
-                        .ToListAsync(cancellationToken);
-
-                    // Get blocked IP attempts
-                    var blockedIps = await dbContext.IpFilters
-                        .Where(f => f.FilterType == "blacklist" && f.IsEnabled)
-                        .Join(dbContext.RequestLogs.Where(r => r.Timestamp >= startTime),
-                            f => f.IpAddressOrCidr,
-                            r => r.ClientIp,
-                            (f, r) => new
-                            {
-                                Timestamp = r.Timestamp,
-                                Type = "blocked_ip",
-                                Severity = "high",
-                                Source = r.ClientIp ?? "Unknown",
-                                VirtualKeyId = r.VirtualKeyId.ToString(),
-                                Details = $"Blocked by rule: {f.Description ?? "IP Filter"}",
-                                StatusCode = 403
-                            })
-                        .ToListAsync(cancellationToken);
-
-                    // Get suspicious activity (multiple failed attempts from same IP)
-                    var suspiciousActivity = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= startTime && r.StatusCode >= 400 && r.ClientIp != null)
-                        .GroupBy(r => r.ClientIp)
-                        .Where(g => g.Count() >= 5)
-                        .Select(g => new
-                        {
-                            Timestamp = g.Max(r => r.Timestamp),
-                            Type = "suspicious_activity",
-                            Severity = "high",
-                            Source = g.Key ?? "Unknown",
-                            VirtualKeyId = (string?)null!, // null-forgiving operator added to suppress CS8600
-                            Details = $"Multiple failed requests: {g.Count()} attempts",
-                            StatusCode = 0
-                        })
-                        .ToListAsync(cancellationToken);
-
-                    // Combine all events - cast to common base type
-                    var allEvents = authFailures.Cast<dynamic>()
-                        .Concat(rateLimitViolations.Cast<dynamic>())
-                        .Concat(blockedIps.Cast<dynamic>())
-                        .Concat(suspiciousActivity.Cast<dynamic>())
-                        .OrderByDescending(e => e.Timestamp)
-                        .Take(1000)
-                        .ToList();
-
-                    return new
+            // Get blocked IP attempts
+            var blockedIps = await dbContext.IpFilters
+                .Where(f => f.FilterType == "blacklist" && f.IsEnabled)
+                .Join(dbContext.RequestLogs.Where(r => r.Timestamp >= startTime),
+                    f => f.IpAddressOrCidr,
+                    r => r.ClientIp,
+                    (f, r) => new
                     {
-                        Timestamp = DateTime.UtcNow,
-                        TimeRange = new { Start = startTime, End = DateTime.UtcNow },
-                        TotalEvents = allEvents.Count,
-                        EventsByType = allEvents.GroupBy(e => (string)e.Type).Select(g => new
-                        {
-                            Type = g.Key,
-                            Count = g.Count()
-                        }),
-                        EventsBySeverity = allEvents.GroupBy(e => (string)e.Severity).Select(g => new
-                        {
-                            Severity = g.Key,
-                            Count = g.Count()
-                        }),
-                        Events = allEvents
-                    };
-                },
-                Ok,
-                "GetSecurityEvents");
+                        Timestamp = r.Timestamp,
+                        Type = "blocked_ip",
+                        Severity = "high",
+                        Source = r.ClientIp ?? "Unknown",
+                        VirtualKeyId = r.VirtualKeyId.ToString(),
+                        Details = $"Blocked by rule: {f.Description ?? "IP Filter"}",
+                        StatusCode = 403
+                    })
+                .ToListAsync(cancellationToken);
+
+            // Get suspicious activity (multiple failed attempts from same IP)
+            var suspiciousActivity = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= startTime && r.StatusCode >= 400 && r.ClientIp != null)
+                .GroupBy(r => r.ClientIp)
+                .Where(g => g.Count() >= 5)
+                .Select(g => new
+                {
+                    Timestamp = g.Max(r => r.Timestamp),
+                    Type = "suspicious_activity",
+                    Severity = "high",
+                    Source = g.Key ?? "Unknown",
+                    VirtualKeyId = (string?)null!, // null-forgiving operator added to suppress CS8600
+                    Details = $"Multiple failed requests: {g.Count()} attempts",
+                    StatusCode = 0
+                })
+                .ToListAsync(cancellationToken);
+
+            // Combine all events - cast to common base type
+            var allEvents = authFailures.Cast<dynamic>()
+                .Concat(rateLimitViolations.Cast<dynamic>())
+                .Concat(blockedIps.Cast<dynamic>())
+                .Concat(suspiciousActivity.Cast<dynamic>())
+                .OrderByDescending(e => e.Timestamp)
+                .Take(1000)
+                .ToList();
+
+            return Ok(new
+            {
+                Timestamp = DateTime.UtcNow,
+                TimeRange = new { Start = startTime, End = DateTime.UtcNow },
+                TotalEvents = allEvents.Count,
+                EventsByType = allEvents.GroupBy(e => (string)e.Type).Select(g => new
+                {
+                    Type = g.Key,
+                    Count = g.Count()
+                }),
+                EventsBySeverity = allEvents.GroupBy(e => (string)e.Severity).Select(g => new
+                {
+                    Severity = g.Key,
+                    Count = g.Count()
+                }),
+                Events = allEvents
+            });
         }
 
         /// <summary>
@@ -154,104 +150,98 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Threat analytics information.</returns>
         [HttpGet("threats")]
-        public Task<IActionResult> GetThreatAnalytics(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetThreatAnalytics(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            var cacheKey = "security:threats";
+            if (_cache.TryGetValue(cacheKey, out var cachedData) && cachedData != null)
+            {
+                return Ok(cachedData);
+            }
+
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var now = DateTime.UtcNow;
+            var oneDayAgo = now.AddDays(-1);
+            var oneWeekAgo = now.AddDays(-7);
+
+            // Analyze threat patterns
+            var threatPatterns = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= oneWeekAgo && r.StatusCode >= 400 && r.ClientIp != null)
+                .GroupBy(r => new { r.ClientIp, Date = r.Timestamp.Date })
+                .Select(g => new
                 {
-                    var cacheKey = "security:threats";
-                    if (_cache.TryGetValue(cacheKey, out var cachedData) && cachedData != null)
-                    {
-                        return cachedData;
-                    }
+                    ClientIp = g.Key.ClientIp,
+                    Date = g.Key.Date,
+                    FailedAttempts = g.Count(),
+                    ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
+                })
+                .ToListAsync(cancellationToken);
 
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+            // Get top threat sources
+            var topThreats = threatPatterns
+                .GroupBy(t => t.ClientIp)
+                .Select(g => new
+                {
+                    IpAddress = g.Key,
+                    TotalFailures = g.Sum(t => t.FailedAttempts),
+                    DaysActive = g.Select(t => t.Date).Distinct().Count(),
+                    LastSeen = g.Max(t => t.Date),
+                    RiskScore = CalculateRiskScore(g.Sum(t => t.FailedAttempts), g.Count())
+                })
+                .OrderByDescending(t => t.RiskScore)
+                .Take(20)
+                .ToList();
 
-                    var now = DateTime.UtcNow;
-                    var oneDayAgo = now.AddDays(-1);
-                    var oneWeekAgo = now.AddDays(-7);
+            // Get threat distribution by type
+            var threatDistribution = await dbContext.RequestLogs
+                .Where(r => r.Timestamp >= oneDayAgo && r.StatusCode >= 400)
+                .GroupBy(r => GetThreatTypeByStatusCode(r.StatusCode ?? 0))
+                .Select(g => new
+                {
+                    Type = g.Key,
+                    Count = g.Count(),
+                    UniqueIPs = g.Where(r => r.ClientIp != null).Select(r => r.ClientIp).Distinct().Count()
+                })
+                .ToListAsync(cancellationToken);
 
-                    // Analyze threat patterns
-                    var threatPatterns = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= oneWeekAgo && r.StatusCode >= 400 && r.ClientIp != null)
-                        .GroupBy(r => new { r.ClientIp, Date = r.Timestamp.Date })
-                        .Select(g => new
-                        {
-                            ClientIp = g.Key.ClientIp,
-                            Date = g.Key.Date,
-                            FailedAttempts = g.Count(),
-                            ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
-                        })
-                        .ToListAsync(cancellationToken);
+            // Calculate security metrics
+            var securityMetrics = new
+            {
+                TotalThreatsToday = await dbContext.RequestLogs
+                    .CountAsync(r => r.Timestamp >= DateTime.UtcNow.Date && r.StatusCode >= 400, cancellationToken),
+                UniqueThreatsToday = await dbContext.RequestLogs
+                    .Where(r => r.Timestamp >= DateTime.UtcNow.Date && r.StatusCode >= 400 && r.ClientIp != null)
+                    .Select(r => r.ClientIp)
+                    .Distinct()
+                    .CountAsync(cancellationToken),
+                BlockedIPs = await dbContext.IpFilters.CountAsync(f => f.FilterType == "blacklist", cancellationToken),
+                ComplianceScore = 85.0 // Simplified compliance score
+            };
 
-                    // Get top threat sources
-                    var topThreats = threatPatterns
-                        .GroupBy(t => t.ClientIp)
-                        .Select(g => new
-                        {
-                            IpAddress = g.Key,
-                            TotalFailures = g.Sum(t => t.FailedAttempts),
-                            DaysActive = g.Select(t => t.Date).Distinct().Count(),
-                            LastSeen = g.Max(t => t.Date),
-                            RiskScore = CalculateRiskScore(g.Sum(t => t.FailedAttempts), g.Count())
-                        })
-                        .OrderByDescending(t => t.RiskScore)
-                        .Take(20)
-                        .ToList();
+            // Get threat trend
+            var threatTrend = threatPatterns
+                .GroupBy(t => t.Date)
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    Threats = g.Sum(t => t.FailedAttempts)
+                })
+                .OrderBy(t => t.Date)
+                .ToList();
 
-                    // Get threat distribution by type
-                    var threatDistribution = await dbContext.RequestLogs
-                        .Where(r => r.Timestamp >= oneDayAgo && r.StatusCode >= 400)
-                        .GroupBy(r => GetThreatTypeByStatusCode(r.StatusCode ?? 0))
-                        .Select(g => new
-                        {
-                            Type = g.Key,
-                            Count = g.Count(),
-                            UniqueIPs = g.Where(r => r.ClientIp != null).Select(r => r.ClientIp).Distinct().Count()
-                        })
-                        .ToListAsync(cancellationToken);
+            var result = new
+            {
+                Timestamp = now,
+                Metrics = securityMetrics,
+                TopThreats = topThreats,
+                ThreatDistribution = threatDistribution,
+                ThreatTrend = threatTrend
+            };
 
-                    // Calculate security metrics
-                    var securityMetrics = new
-                    {
-                        TotalThreatsToday = await dbContext.RequestLogs
-                            .CountAsync(r => r.Timestamp >= DateTime.UtcNow.Date && r.StatusCode >= 400, cancellationToken),
-                        UniqueThreatsToday = await dbContext.RequestLogs
-                            .Where(r => r.Timestamp >= DateTime.UtcNow.Date && r.StatusCode >= 400 && r.ClientIp != null)
-                            .Select(r => r.ClientIp)
-                            .Distinct()
-                            .CountAsync(cancellationToken),
-                        BlockedIPs = await dbContext.IpFilters.CountAsync(f => f.FilterType == "blacklist", cancellationToken),
-                        ComplianceScore = 85.0 // Simplified compliance score
-                    };
+            // Cache for 5 minutes
+            _cache.Set(cacheKey, result, TimeSpan.FromMinutes(5));
 
-                    // Get threat trend
-                    var threatTrend = threatPatterns
-                        .GroupBy(t => t.Date)
-                        .Select(g => new
-                        {
-                            Date = g.Key,
-                            Threats = g.Sum(t => t.FailedAttempts)
-                        })
-                        .OrderBy(t => t.Date)
-                        .ToList();
-
-                    var result = new
-                    {
-                        Timestamp = now,
-                        Metrics = securityMetrics,
-                        TopThreats = topThreats,
-                        ThreatDistribution = threatDistribution,
-                        ThreatTrend = threatTrend
-                    };
-
-                    // Cache for 5 minutes
-                    _cache.Set(cacheKey, result, TimeSpan.FromMinutes(5));
-
-                    return (object)result;
-                },
-                Ok,
-                "GetThreatAnalytics");
+            return Ok(result);
         }
 
         /// <summary>
@@ -260,44 +250,38 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Compliance information.</returns>
         [HttpGet("compliance")]
-        public Task<IActionResult> GetComplianceMetrics(CancellationToken cancellationToken = default)
+        public async Task<IActionResult> GetComplianceMetrics(CancellationToken cancellationToken = default)
         {
-            return ExecuteAsync(
-                async () =>
+            using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+            var complianceData = new
+            {
+                Timestamp = DateTime.UtcNow,
+                DataProtection = new
                 {
-                    using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
-
-                    var complianceData = new
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        DataProtection = new
-                        {
-                            EncryptedKeys = await dbContext.VirtualKeys.CountAsync(k => k.IsEnabled, cancellationToken),
-                            SecureEndpoints = true, // Assuming HTTPS is enforced
-                            DataRetentionDays = 90,
-                            LastAudit = DateTime.UtcNow.AddDays(-7)
-                        },
-                        AccessControl = new
-                        {
-                            ActiveKeys = await dbContext.VirtualKeys.CountAsync(k => k.IsEnabled, cancellationToken),
-                            KeysWithBudgets = await dbContext.VirtualKeyGroups.CountAsync(g => g.Balance > 0, cancellationToken),
-                            IpWhitelistEnabled = await dbContext.IpFilters.AnyAsync(f => f.FilterType == "whitelist", cancellationToken),
-                            RateLimitingEnabled = true
-                        },
-                        Monitoring = new
-                        {
-                            LogRetentionDays = 90,
-                            RequestLoggingEnabled = true,
-                            SecurityAlertsEnabled = true,
-                            LastSecurityReview = DateTime.UtcNow.AddDays(-30)
-                        },
-                        ComplianceScore = await CalculateDetailedComplianceScore(dbContext, cancellationToken)
-                    };
-
-                    return complianceData;
+                    EncryptedKeys = await dbContext.VirtualKeys.CountAsync(k => k.IsEnabled, cancellationToken),
+                    SecureEndpoints = true, // Assuming HTTPS is enforced
+                    DataRetentionDays = 90,
+                    LastAudit = DateTime.UtcNow.AddDays(-7)
                 },
-                Ok,
-                "GetComplianceMetrics");
+                AccessControl = new
+                {
+                    ActiveKeys = await dbContext.VirtualKeys.CountAsync(k => k.IsEnabled, cancellationToken),
+                    KeysWithBudgets = await dbContext.VirtualKeyGroups.CountAsync(g => g.Balance > 0, cancellationToken),
+                    IpWhitelistEnabled = await dbContext.IpFilters.AnyAsync(f => f.FilterType == "whitelist", cancellationToken),
+                    RateLimitingEnabled = true
+                },
+                Monitoring = new
+                {
+                    LogRetentionDays = 90,
+                    RequestLoggingEnabled = true,
+                    SecurityAlertsEnabled = true,
+                    LastSecurityReview = DateTime.UtcNow.AddDays(-30)
+                },
+                ComplianceScore = await CalculateDetailedComplianceScore(dbContext, cancellationToken)
+            };
+
+            return Ok(complianceData);
         }
 
         private static string GetThreatTypeByStatusCode(int statusCode)

--- a/Services/ConduitLLM.Admin/Controllers/SystemInfoController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/SystemInfoController.cs
@@ -1,3 +1,4 @@
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Configuration.DTOs.Monitoring;
 using ConduitLLM.Core.Events;
@@ -14,6 +15,7 @@ namespace ConduitLLM.Admin.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "MasterKeyPolicy")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class SystemInfoController : AdminControllerBase
 {
     private readonly IAdminSystemInfoService _systemInfoService;
@@ -46,12 +48,10 @@ public class SystemInfoController : AdminControllerBase
     [HttpGet("info")]
     [ProducesResponseType(typeof(SystemInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetSystemInfo()
+    public async Task<IActionResult> GetSystemInfo()
     {
-        return ExecuteAsync(
-            () => _systemInfoService.GetSystemInfoAsync(),
-            result => Ok(result),
-            "GetSystemInfo");
+        var result = await _systemInfoService.GetSystemInfoAsync();
+        return Ok(result);
     }
 
     /// <summary>
@@ -61,12 +61,10 @@ public class SystemInfoController : AdminControllerBase
     [HttpGet("health")]
     [ProducesResponseType(typeof(HealthStatusDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetHealthStatus()
+    public async Task<IActionResult> GetHealthStatus()
     {
-        return ExecuteAsync(
-            () => _systemInfoService.GetHealthStatusAsync(),
-            result => Ok(result),
-            "GetHealthStatus");
+        var result = await _systemInfoService.GetHealthStatusAsync();
+        return Ok(result);
     }
 
     /// <summary>
@@ -76,30 +74,24 @@ public class SystemInfoController : AdminControllerBase
     [HttpPost("cache/invalidate-discovery")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> InvalidateDiscoveryCache()
+    public async Task<IActionResult> InvalidateDiscoveryCache()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // Publish event to all Gateway API instances via MassTransit
-                await _publishEndpoint.Publish(new DiscoveryCacheInvalidationRequested
-                {
-                    Reason = "Manual invalidation via Admin API",
-                    RequestedBy = "Admin User",
-                    CorrelationId = Guid.NewGuid().ToString()
-                });
+        // Publish event to all Gateway API instances via MassTransit
+        await _publishEndpoint.Publish(new DiscoveryCacheInvalidationRequested
+        {
+            Reason = "Manual invalidation via Admin API",
+            RequestedBy = "Admin User",
+            CorrelationId = Guid.NewGuid().ToString()
+        });
 
-                LogAdminAudit("Invalidated", "DiscoveryCache");
+        LogAdminAudit("Invalidated", "DiscoveryCache");
 
-                return new
-                {
-                    message = "Discovery cache invalidation request published successfully",
-                    timestamp = DateTime.UtcNow,
-                    note = "Cache invalidation is being processed asynchronously across all Gateway API instances"
-                };
-            },
-            result => Ok(result),
-            "InvalidateDiscoveryCache");
+        return Ok(new
+        {
+            message = "Discovery cache invalidation request published successfully",
+            timestamp = DateTime.UtcNow,
+            note = "Cache invalidation is being processed asynchronously across all Gateway API instances"
+        });
     }
 
     /// <summary>
@@ -110,21 +102,19 @@ public class SystemInfoController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetFunctionDiscoveryCacheStats()
+    public async Task<IActionResult> GetFunctionDiscoveryCacheStats()
     {
         if (_functionDiscoveryCacheService == null)
         {
-            return Task.FromResult<IActionResult>(NotFound(new
+            return NotFound(new
             {
                 message = "Function discovery cache service is not configured",
                 note = "The cache service must be registered in the DI container"
-            }));
+            });
         }
 
-        return ExecuteAsync(
-            () => _functionDiscoveryCacheService.GetStatisticsAsync(),
-            result => Ok(result),
-            "GetFunctionDiscoveryCacheStats");
+        var result = await _functionDiscoveryCacheService.GetStatisticsAsync();
+        return Ok(result);
     }
 
     /// <summary>
@@ -134,29 +124,23 @@ public class SystemInfoController : AdminControllerBase
     [HttpPost("cache/invalidate-function-discovery")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> InvalidateFunctionDiscoveryCache()
+    public async Task<IActionResult> InvalidateFunctionDiscoveryCache()
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // Publish event to all Gateway API instances via MassTransit
-                await _publishEndpoint.Publish(new FunctionDiscoveryCacheInvalidationRequested
-                {
-                    Reason = "Manual invalidation via Admin API",
-                    RequestedBy = "Admin User",
-                    CorrelationId = Guid.NewGuid().ToString()
-                });
+        // Publish event to all Gateway API instances via MassTransit
+        await _publishEndpoint.Publish(new FunctionDiscoveryCacheInvalidationRequested
+        {
+            Reason = "Manual invalidation via Admin API",
+            RequestedBy = "Admin User",
+            CorrelationId = Guid.NewGuid().ToString()
+        });
 
-                LogAdminAudit("Invalidated", "FunctionDiscoveryCache");
+        LogAdminAudit("Invalidated", "FunctionDiscoveryCache");
 
-                return new
-                {
-                    message = "Function discovery cache invalidation request published successfully",
-                    timestamp = DateTime.UtcNow,
-                    note = "Cache invalidation is being processed asynchronously across all Gateway API instances"
-                };
-            },
-            result => Ok(result),
-            "InvalidateFunctionDiscoveryCache");
+        return Ok(new
+        {
+            message = "Function discovery cache invalidation request published successfully",
+            timestamp = DateTime.UtcNow,
+            note = "Cache invalidation is being processed asynchronously across all Gateway API instances"
+        });
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/TasksController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/TasksController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Core.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 
@@ -10,6 +11,7 @@ namespace ConduitLLM.Admin.Controllers
     [ApiController]
     [Route("v1/admin/tasks")]
     [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class TasksController : AdminControllerBase
     {
         private readonly IAsyncTaskService _taskService;
@@ -36,21 +38,15 @@ namespace ConduitLLM.Admin.Controllers
         /// permanently deletes archived tasks older than 30 days.
         /// </remarks>
         [HttpPost("cleanup")]
-        public Task<IActionResult> CleanupOldTasks([FromQuery] int olderThanHours = 24)
+        public async Task<IActionResult> CleanupOldTasks([FromQuery] int olderThanHours = 24)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    olderThanHours = Math.Max(olderThanHours, 1); // Min 1 hour
-                    var count = await _taskService.CleanupOldTasksAsync(TimeSpan.FromHours(olderThanHours));
+            olderThanHours = Math.Max(olderThanHours, 1); // Min 1 hour
+            var count = await _taskService.CleanupOldTasksAsync(TimeSpan.FromHours(olderThanHours));
 
-                    LogAdminAudit("CleanedUp", "Tasks", null,
-                        $"Removed {count} tasks older than {olderThanHours} hours");
+            LogAdminAudit("CleanedUp", "Tasks", null,
+                $"Removed {count} tasks older than {olderThanHours} hours");
 
-                    return new { cleaned_up = count, older_than_hours = olderThanHours };
-                },
-                Ok,
-                "CleanupOldTasks");
+            return Ok(new { cleaned_up = count, older_than_hours = olderThanHours });
         }
     }
 }

--- a/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
@@ -17,6 +19,7 @@ namespace ConduitLLM.Admin.Controllers
     [Authorize]
     [ApiController]
     [Route("api/[controller]")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
     public class VirtualKeyGroupsController : AdminControllerBase
     {
         private readonly IVirtualKeyGroupRepository _groupRepository;
@@ -50,7 +53,7 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(PagedResult<VirtualKeyGroupDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetAllGroups(
+        public async Task<IActionResult> GetAllGroups(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50,
             CancellationToken cancellationToken = default)
@@ -60,213 +63,184 @@ namespace ConduitLLM.Admin.Controllers
             if (pageSize < 1) pageSize = 50;
             if (pageSize > 100) pageSize = 100;
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    var (groups, totalCount) = await _groupRepository.GetPaginatedAsync(page, pageSize, cancellationToken);
+            var (groups, totalCount) = await _groupRepository.GetPaginatedAsync(page, pageSize, cancellationToken);
 
-                    var dtos = groups.Select(g => new VirtualKeyGroupDto
-                    {
-                        Id = g.Id,
-                        ExternalGroupId = g.ExternalGroupId,
-                        GroupName = g.GroupName,
-                        Balance = g.Balance,
-                        LifetimeCreditsAdded = g.LifetimeCreditsAdded,
-                        LifetimeSpent = g.LifetimeSpent,
-                        CreatedAt = g.CreatedAt,
-                        UpdatedAt = g.UpdatedAt,
-                        VirtualKeyCount = g.VirtualKeys?.Count ?? 0
-                    }).ToList();
+            var dtos = groups.Select(g => new VirtualKeyGroupDto
+            {
+                Id = g.Id,
+                ExternalGroupId = g.ExternalGroupId,
+                GroupName = g.GroupName,
+                Balance = g.Balance,
+                LifetimeCreditsAdded = g.LifetimeCreditsAdded,
+                LifetimeSpent = g.LifetimeSpent,
+                CreatedAt = g.CreatedAt,
+                UpdatedAt = g.UpdatedAt,
+                VirtualKeyCount = g.VirtualKeys?.Count ?? 0
+            }).ToList();
 
-                    return (object)new PagedResult<VirtualKeyGroupDto>
-                    {
-                        Items = dtos,
-                        TotalCount = totalCount,
-                        CurrentPage = page,
-                        PageSize = pageSize,
-                        TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize)
-                    };
-                },
-                Ok,
-                "GetAllGroups");
+            return Ok(new PagedResult<VirtualKeyGroupDto>
+            {
+                Items = dtos,
+                TotalCount = totalCount,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize)
+            });
         }
 
         /// <summary>
         /// Get a specific virtual key group by ID
         /// </summary>
         [HttpGet("{id}")]
-        public Task<IActionResult> GetGroup(int id)
+        public async Task<IActionResult> GetGroup(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _groupRepository.GetByIdWithKeysAsync(id),
-                group => Ok(new VirtualKeyGroupDto
-                {
-                    Id = group.Id,
-                    ExternalGroupId = group.ExternalGroupId,
-                    GroupName = group.GroupName,
-                    Balance = group.Balance,
-                    LifetimeCreditsAdded = group.LifetimeCreditsAdded,
-                    LifetimeSpent = group.LifetimeSpent,
-                    CreatedAt = group.CreatedAt,
-                    UpdatedAt = group.UpdatedAt,
-                    VirtualKeyCount = group.VirtualKeys?.Count ?? 0
-                }),
-                "VirtualKeyGroup",
-                id,
-                "GetGroup");
+            var group = await _groupRepository.GetByIdWithKeysAsync(id);
+            if (group == null)
+            {
+                return this.NotFoundEntity("VirtualKeyGroup", id);
+            }
+            return Ok(new VirtualKeyGroupDto
+            {
+                Id = group.Id,
+                ExternalGroupId = group.ExternalGroupId,
+                GroupName = group.GroupName,
+                Balance = group.Balance,
+                LifetimeCreditsAdded = group.LifetimeCreditsAdded,
+                LifetimeSpent = group.LifetimeSpent,
+                CreatedAt = group.CreatedAt,
+                UpdatedAt = group.UpdatedAt,
+                VirtualKeyCount = group.VirtualKeys?.Count ?? 0
+            });
         }
 
         /// <summary>
         /// Create a new virtual key group
         /// </summary>
         [HttpPost]
-        public Task<IActionResult> CreateGroup([FromBody] CreateVirtualKeyGroupRequestDto request)
+        public async Task<IActionResult> CreateGroup([FromBody] CreateVirtualKeyGroupRequestDto request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var group = new VirtualKeyGroup
-                    {
-                        ExternalGroupId = request.ExternalGroupId,
-                        GroupName = request.GroupName,
-                        Balance = request.InitialBalance ?? 0,
-                        LifetimeCreditsAdded = request.InitialBalance ?? 0,
-                        LifetimeSpent = 0
-                    };
+            var group = new VirtualKeyGroup
+            {
+                ExternalGroupId = request.ExternalGroupId,
+                GroupName = request.GroupName,
+                Balance = request.InitialBalance ?? 0,
+                LifetimeCreditsAdded = request.InitialBalance ?? 0,
+                LifetimeSpent = 0
+            };
 
-                    var id = await _groupRepository.CreateAsync(group);
-                    group.Id = id;
+            var id = await _groupRepository.CreateAsync(group);
+            group.Id = id;
 
-                    LogAdminAudit("Created", "VirtualKeyGroup", id,
-                        $"Name: {group.GroupName}, InitialBalance: {group.Balance}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "create");
+            LogAdminAudit("Created", "VirtualKeyGroup", id,
+                $"Name: {group.GroupName}, InitialBalance: {group.Balance}");
+            AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "create");
 
-                    var dto = new VirtualKeyGroupDto
-                    {
-                        Id = group.Id,
-                        ExternalGroupId = group.ExternalGroupId,
-                        GroupName = group.GroupName,
-                        Balance = group.Balance,
-                        LifetimeCreditsAdded = group.LifetimeCreditsAdded,
-                        LifetimeSpent = group.LifetimeSpent,
-                        CreatedAt = group.CreatedAt,
-                        UpdatedAt = group.UpdatedAt,
-                        VirtualKeyCount = 0
-                    };
+            var dto = new VirtualKeyGroupDto
+            {
+                Id = group.Id,
+                ExternalGroupId = group.ExternalGroupId,
+                GroupName = group.GroupName,
+                Balance = group.Balance,
+                LifetimeCreditsAdded = group.LifetimeCreditsAdded,
+                LifetimeSpent = group.LifetimeSpent,
+                CreatedAt = group.CreatedAt,
+                UpdatedAt = group.UpdatedAt,
+                VirtualKeyCount = 0
+            };
 
-                    return (IActionResult)CreatedAtAction(nameof(GetGroup), new { id = group.Id }, dto);
-                },
-                r => r,
-                "CreateGroup");
+            return CreatedAtAction(nameof(GetGroup), new { id = group.Id }, dto);
         }
 
         /// <summary>
         /// Update a virtual key group
         /// </summary>
         [HttpPut("{id}")]
-        public Task<IActionResult> UpdateGroup(int id, [FromBody] UpdateVirtualKeyGroupRequestDto request)
+        public async Task<IActionResult> UpdateGroup(int id, [FromBody] UpdateVirtualKeyGroupRequestDto request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var group = await _groupRepository.GetByIdAsync(id);
-                    if (group == null)
-                        throw new KeyNotFoundException();
+            var group = await _groupRepository.GetByIdAsync(id);
+            if (group == null)
+                throw new KeyNotFoundException();
 
-                    var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+            var changes = new List<(string Property, string? OldValue, string? NewValue)>();
 
-                    if (!string.IsNullOrEmpty(request.GroupName))
-                    {
-                        changes.Add(("GroupName", group.GroupName, request.GroupName));
-                        group.GroupName = request.GroupName;
-                    }
+            if (!string.IsNullOrEmpty(request.GroupName))
+            {
+                changes.Add(("GroupName", group.GroupName, request.GroupName));
+                group.GroupName = request.GroupName;
+            }
 
-                    if (!string.IsNullOrEmpty(request.ExternalGroupId))
-                    {
-                        changes.Add(("ExternalGroupId", group.ExternalGroupId, request.ExternalGroupId));
-                        group.ExternalGroupId = request.ExternalGroupId;
-                    }
+            if (!string.IsNullOrEmpty(request.ExternalGroupId))
+            {
+                changes.Add(("ExternalGroupId", group.ExternalGroupId, request.ExternalGroupId));
+                group.ExternalGroupId = request.ExternalGroupId;
+            }
 
-                    await _groupRepository.UpdateAsync(group);
+            await _groupRepository.UpdateAsync(group);
 
-                    LogAdminAuditWithChanges("VirtualKeyGroup", id, changes);
-                    AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "update");
-                },
-                NoContent(),
-                "UpdateGroup",
-                new { Id = id });
+            LogAdminAuditWithChanges("VirtualKeyGroup", id, changes);
+            AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "update");
+
+            return NoContent();
         }
 
         /// <summary>
         /// Adjust the balance of a virtual key group
         /// </summary>
         [HttpPost("{id}/adjust-balance")]
-        public Task<IActionResult> AdjustBalance(int id, [FromBody] AdjustBalanceDto request)
+        public async Task<IActionResult> AdjustBalance(int id, [FromBody] AdjustBalanceDto request)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Get the authenticated user's identity
-                    var initiatedBy = User.Identity?.Name ?? "System";
+            // Get the authenticated user's identity
+            var initiatedBy = User.Identity?.Name ?? "System";
 
-                    var newBalance = await _groupRepository.AdjustBalanceAsync(
-                        id,
-                        request.Amount,
-                        request.Description,
-                        initiatedBy
-                    );
+            var newBalance = await _groupRepository.AdjustBalanceAsync(
+                id,
+                request.Amount,
+                request.Description,
+                initiatedBy
+            );
 
-                    LogAdminAudit("AdjustedBalance", "VirtualKeyGroup", id,
-                        $"Amount: {request.Amount}, Description: {request.Description}, NewBalance: {newBalance}");
+            LogAdminAudit("AdjustedBalance", "VirtualKeyGroup", id,
+                $"Amount: {request.Amount}, Description: {request.Description}, NewBalance: {newBalance}");
 
-                    var group = await _groupRepository.GetByIdAsync(id);
-                    if (group == null)
-                        throw new KeyNotFoundException();
+            var group = await _groupRepository.GetByIdAsync(id);
+            if (group == null)
+                throw new KeyNotFoundException();
 
-                    return (object)new VirtualKeyGroupDto
-                    {
-                        Id = group.Id,
-                        ExternalGroupId = group.ExternalGroupId,
-                        GroupName = group.GroupName,
-                        Balance = group.Balance,
-                        LifetimeCreditsAdded = group.LifetimeCreditsAdded,
-                        LifetimeSpent = group.LifetimeSpent,
-                        CreatedAt = group.CreatedAt,
-                        UpdatedAt = group.UpdatedAt,
-                        VirtualKeyCount = group.VirtualKeys?.Count ?? 0
-                    };
-                },
-                Ok,
-                "AdjustBalance",
-                new { Id = id });
+            return Ok(new VirtualKeyGroupDto
+            {
+                Id = group.Id,
+                ExternalGroupId = group.ExternalGroupId,
+                GroupName = group.GroupName,
+                Balance = group.Balance,
+                LifetimeCreditsAdded = group.LifetimeCreditsAdded,
+                LifetimeSpent = group.LifetimeSpent,
+                CreatedAt = group.CreatedAt,
+                UpdatedAt = group.UpdatedAt,
+                VirtualKeyCount = group.VirtualKeys?.Count ?? 0
+            });
         }
 
         /// <summary>
         /// Delete a virtual key group
         /// </summary>
         [HttpDelete("{id}")]
-        public Task<IActionResult> DeleteGroup(int id)
+        public async Task<IActionResult> DeleteGroup(int id)
         {
-            return ExecuteAsync(
-                async () =>
-                {
-                    var group = await _groupRepository.GetByIdAsync(id);
-                    if (group == null)
-                        throw new KeyNotFoundException();
+            var group = await _groupRepository.GetByIdAsync(id);
+            if (group == null)
+                throw new KeyNotFoundException();
 
-                    // Check if group has any keys
-                    if (group.VirtualKeys?.Count > 0)
-                        throw new InvalidOperationException("Cannot delete group with existing virtual keys");
+            // Check if group has any keys
+            if (group.VirtualKeys?.Count > 0)
+                throw new InvalidOperationException("Cannot delete group with existing virtual keys");
 
-                    await _groupRepository.DeleteAsync(id);
+            await _groupRepository.DeleteAsync(id);
 
-                    LogAdminAudit("Deleted", "VirtualKeyGroup", id,
-                        $"Name: {group.GroupName}");
-                    AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "delete");
-                },
-                NoContent(),
-                "DeleteGroup",
-                new { Id = id });
+            LogAdminAudit("Deleted", "VirtualKeyGroup", id,
+                $"Name: {group.GroupName}");
+            AdminOperationsMetricsService.RecordConfigurationChange("virtualkeygroup", "delete");
+
+            return NoContent();
         }
 
         /// <summary>
@@ -276,7 +250,7 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(PagedResult<VirtualKeyGroupTransactionDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> GetTransactionHistory(
+        public async Task<IActionResult> GetTransactionHistory(
             int id,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
@@ -286,90 +260,81 @@ namespace ConduitLLM.Admin.Controllers
             if (pageSize < 1) pageSize = 50;
             if (pageSize > 100) pageSize = 100;
 
-            return ExecuteAsync(
-                async () =>
+            var group = await _groupRepository.GetByIdAsync(id);
+            if (group == null)
+                throw new KeyNotFoundException();
+
+            // Get total count (soft delete filter applied automatically via named query filter)
+            var totalCount = await _context.VirtualKeyGroupTransactions
+                .Where(t => t.VirtualKeyGroupId == id)
+                .CountAsync();
+
+            // Calculate pagination
+            var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
+            var skip = (page - 1) * pageSize;
+
+            // Get paginated transactions (soft delete filter applied automatically via named query filter)
+            var transactions = await _context.VirtualKeyGroupTransactions
+                .Where(t => t.VirtualKeyGroupId == id)
+                .OrderByDescending(t => t.CreatedAt)
+                .Skip(skip)
+                .Take(pageSize)
+                .Select(t => new VirtualKeyGroupTransactionDto
                 {
-                    var group = await _groupRepository.GetByIdAsync(id);
-                    if (group == null)
-                        throw new KeyNotFoundException();
+                    Id = t.Id,
+                    VirtualKeyGroupId = t.VirtualKeyGroupId,
+                    TransactionType = t.TransactionType,
+                    Amount = t.Amount,
+                    BalanceAfter = t.BalanceAfter,
+                    Description = t.Description,
+                    ReferenceId = t.ReferenceId,
+                    ReferenceType = t.ReferenceType,
+                    InitiatedBy = t.InitiatedBy,
+                    InitiatedByUserId = t.InitiatedByUserId,
+                    CreatedAt = t.CreatedAt
+                })
+                .ToListAsync();
 
-                    // Get total count (soft delete filter applied automatically via named query filter)
-                    var totalCount = await _context.VirtualKeyGroupTransactions
-                        .Where(t => t.VirtualKeyGroupId == id)
-                        .CountAsync();
-
-                    // Calculate pagination
-                    var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
-                    var skip = (page - 1) * pageSize;
-
-                    // Get paginated transactions (soft delete filter applied automatically via named query filter)
-                    var transactions = await _context.VirtualKeyGroupTransactions
-                        .Where(t => t.VirtualKeyGroupId == id)
-                        .OrderByDescending(t => t.CreatedAt)
-                        .Skip(skip)
-                        .Take(pageSize)
-                        .Select(t => new VirtualKeyGroupTransactionDto
-                        {
-                            Id = t.Id,
-                            VirtualKeyGroupId = t.VirtualKeyGroupId,
-                            TransactionType = t.TransactionType,
-                            Amount = t.Amount,
-                            BalanceAfter = t.BalanceAfter,
-                            Description = t.Description,
-                            ReferenceId = t.ReferenceId,
-                            ReferenceType = t.ReferenceType,
-                            InitiatedBy = t.InitiatedBy,
-                            InitiatedByUserId = t.InitiatedByUserId,
-                            CreatedAt = t.CreatedAt
-                        })
-                        .ToListAsync();
-
-                    return (object)new PagedResult<VirtualKeyGroupTransactionDto>
-                    {
-                        Items = transactions,
-                        TotalCount = totalCount,
-                        CurrentPage = page,
-                        PageSize = pageSize,
-                        TotalPages = totalPages
-                    };
-                },
-                Ok,
-                "GetTransactionHistory",
-                new { Id = id });
+            return Ok(new PagedResult<VirtualKeyGroupTransactionDto>
+            {
+                Items = transactions,
+                TotalCount = totalCount,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalPages = totalPages
+            });
         }
 
         /// <summary>
         /// Get virtual keys in a group
         /// </summary>
         [HttpGet("{id}/keys")]
-        public Task<IActionResult> GetKeysInGroup(int id)
+        public async Task<IActionResult> GetKeysInGroup(int id)
         {
-            return ExecuteWithNotFoundAsync(
-                () => _groupRepository.GetByIdWithKeysAsync(id),
-                group =>
-                {
-                    var keys = group.VirtualKeys?.Select(k => new VirtualKeyDto
-                    {
-                        Id = k.Id,
-                        KeyName = k.KeyName,
-                        KeyPrefix = k.KeyHash?.Length > 10 ? k.KeyHash.Substring(0, 10) + "..." : k.KeyHash,
-                        AllowedModels = k.AllowedModels,
-                        VirtualKeyGroupId = k.VirtualKeyGroupId,
-                        IsEnabled = k.IsEnabled,
-                        ExpiresAt = k.ExpiresAt,
-                        CreatedAt = k.CreatedAt,
-                        UpdatedAt = k.UpdatedAt,
-                        Metadata = k.Metadata,
-                        RateLimitRpm = k.RateLimitRpm,
-                        RateLimitRpd = k.RateLimitRpd,
-                        Description = k.Description
-                    }).ToList() ?? new List<VirtualKeyDto>();
+            var group = await _groupRepository.GetByIdWithKeysAsync(id);
+            if (group == null)
+            {
+                return this.NotFoundEntity("VirtualKeyGroup", id);
+            }
 
-                    return Ok(keys);
-                },
-                "VirtualKeyGroup",
-                id,
-                "GetKeysInGroup");
+            var keys = group.VirtualKeys?.Select(k => new VirtualKeyDto
+            {
+                Id = k.Id,
+                KeyName = k.KeyName,
+                KeyPrefix = k.KeyHash?.Length > 10 ? k.KeyHash.Substring(0, 10) + "..." : k.KeyHash,
+                AllowedModels = k.AllowedModels,
+                VirtualKeyGroupId = k.VirtualKeyGroupId,
+                IsEnabled = k.IsEnabled,
+                ExpiresAt = k.ExpiresAt,
+                CreatedAt = k.CreatedAt,
+                UpdatedAt = k.UpdatedAt,
+                Metadata = k.Metadata,
+                RateLimitRpm = k.RateLimitRpm,
+                RateLimitRpd = k.RateLimitRpd,
+                Description = k.Description
+            }).ToList() ?? new List<VirtualKeyDto>();
+
+            return Ok(keys);
         }
 
         /// <summary>
@@ -383,57 +348,50 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public Task<IActionResult> ProcessRefund(int id, [FromBody] ProcessRefundRequestDto request)
+        public async Task<IActionResult> ProcessRefund(int id, [FromBody] ProcessRefundRequestDto request)
         {
             // Validate request
             if (string.IsNullOrEmpty(request.ModelId))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new { message = "Model ID is required" }));
+                return BadRequest(new { message = "Model ID is required" });
             }
 
             if (string.IsNullOrEmpty(request.RefundReason))
             {
-                return Task.FromResult<IActionResult>(BadRequest(new { message = "Refund reason is required" }));
+                return BadRequest(new { message = "Refund reason is required" });
             }
 
-            return ExecuteAsync(
-                async () =>
-                {
-                    // Get user info for audit trail
-                    var initiatedBy = User.Identity?.Name ?? "System";
-                    var initiatedByUserId = User.FindFirst("sub")?.Value; // Clerk user ID from JWT
+            // Get user info for audit trail
+            var initiatedBy = User.Identity?.Name ?? "System";
+            var initiatedByUserId = User.FindFirst("sub")?.Value; // Clerk user ID from JWT
 
-                    // Convert DTOs to core models
-                    var originalUsage = MapToUsage(request.OriginalUsage);
-                    var refundUsage = MapToUsage(request.RefundUsage);
+            // Convert DTOs to core models
+            var originalUsage = MapToUsage(request.OriginalUsage);
+            var refundUsage = MapToUsage(request.RefundUsage);
 
-                    // Process the refund
-                    var refundResult = await _refundService.ProcessRefundAsync(
-                        id,
-                        request.ModelId,
-                        originalUsage,
-                        refundUsage,
-                        request.RefundReason,
-                        request.OriginalTransactionId,
-                        initiatedBy,
-                        initiatedByUserId);
+            // Process the refund
+            var refundResult = await _refundService.ProcessRefundAsync(
+                id,
+                request.ModelId,
+                originalUsage,
+                refundUsage,
+                request.RefundReason,
+                request.OriginalTransactionId,
+                initiatedBy,
+                initiatedByUserId);
 
-                    // Get updated group info for balance
-                    var group = await _groupRepository.GetByIdAsync(id);
-                    if (group == null)
-                        throw new KeyNotFoundException();
+            // Get updated group info for balance
+            var group = await _groupRepository.GetByIdAsync(id);
+            if (group == null)
+                throw new KeyNotFoundException();
 
-                    // Map to response DTO
-                    var responseDto = MapToRefundResultDto(refundResult, group.Balance);
+            // Map to response DTO
+            var responseDto = MapToRefundResultDto(refundResult, group.Balance);
 
-                    LogAdminAudit("Refunded", "VirtualKeyGroup", id,
-                        $"Amount: {refundResult.RefundAmount:C}, Model: {request.ModelId}, Reason: {request.RefundReason}, TransactionId: {refundResult.OriginalTransactionId}");
+            LogAdminAudit("Refunded", "VirtualKeyGroup", id,
+                $"Amount: {refundResult.RefundAmount:C}, Model: {request.ModelId}, Reason: {request.RefundReason}, TransactionId: {refundResult.OriginalTransactionId}");
 
-                    return (object)responseDto;
-                },
-                Ok,
-                "ProcessRefund",
-                new { Id = id });
+            return Ok(responseDto);
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/VirtualKeysController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/VirtualKeysController.cs
@@ -1,4 +1,6 @@
 using ConduitLLM.Core.Extensions;
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
@@ -14,6 +16,7 @@ namespace ConduitLLM.Admin.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[ServiceFilter(typeof(OperationLoggingFilter))]
 public class VirtualKeysController : AdminControllerBase
 {
     private readonly IAdminVirtualKeyService _virtualKeyService;
@@ -43,19 +46,13 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GenerateKey([FromBody] CreateVirtualKeyRequestDto request)
+    public async Task<IActionResult> GenerateKey([FromBody] CreateVirtualKeyRequestDto request)
     {
-        return ExecuteAsync(
-            () => _virtualKeyService.GenerateVirtualKeyAsync(request),
-            response =>
-            {
-                LogAdminAudit("Created", "VirtualKey", response.KeyInfo.Id, $"Name: {LoggingSanitizer.S(request.KeyName)}");
-                AdminOperationsMetricsService.RecordVirtualKeyOperation("create", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "create");
-                return CreatedAtAction(nameof(GetKeyById), new { id = response.KeyInfo.Id }, response);
-            },
-            "GenerateKey",
-            new { KeyName = LoggingSanitizer.S(request.KeyName) });
+        var response = await _virtualKeyService.GenerateVirtualKeyAsync(request);
+        LogAdminAudit("Created", "VirtualKey", response.KeyInfo.Id, $"Name: {LoggingSanitizer.S(request.KeyName)}");
+        AdminOperationsMetricsService.RecordVirtualKeyOperation("create", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "create");
+        return CreatedAtAction(nameof(GetKeyById), new { id = response.KeyInfo.Id }, response);
     }
 
     /// <summary>
@@ -67,12 +64,10 @@ public class VirtualKeysController : AdminControllerBase
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(List<VirtualKeyDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> ListKeys([FromQuery] int? virtualKeyGroupId = null)
+    public async Task<IActionResult> ListKeys([FromQuery] int? virtualKeyGroupId = null)
     {
-        return ExecuteAsync(
-            () => _virtualKeyService.ListVirtualKeysAsync(virtualKeyGroupId),
-            Ok,
-            "ListKeys");
+        var result = await _virtualKeyService.ListVirtualKeysAsync(virtualKeyGroupId);
+        return Ok(result);
     }
 
     /// <summary>
@@ -85,14 +80,14 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(typeof(VirtualKeyDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetKeyById(int id)
+    public async Task<IActionResult> GetKeyById(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _virtualKeyService.GetVirtualKeyInfoAsync(id),
-            Ok,
-            "Virtual key",
-            id,
-            "GetKeyById");
+        var result = await _virtualKeyService.GetVirtualKeyInfoAsync(id);
+        if (result == null)
+        {
+            return this.NotFoundEntity("Virtual key", id);
+        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -109,51 +104,45 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> UpdateKey(int id, [FromBody] UpdateVirtualKeyRequestDto request)
+    public async Task<IActionResult> UpdateKey(int id, [FromBody] UpdateVirtualKeyRequestDto request)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                // Fetch pre-state for change tracking
-                var preState = await _virtualKeyService.GetVirtualKeyInfoAsync(id);
-                if (preState == null)
-                    throw new KeyNotFoundException();
+        // Fetch pre-state for change tracking
+        var preState = await _virtualKeyService.GetVirtualKeyInfoAsync(id);
+        if (preState == null)
+            throw new KeyNotFoundException();
 
-                if (!await _virtualKeyService.UpdateVirtualKeyAsync(id, request))
-                    throw new KeyNotFoundException();
+        if (!await _virtualKeyService.UpdateVirtualKeyAsync(id, request))
+            throw new KeyNotFoundException();
 
-                // Build change list from pre-state vs request
-                var changes = new List<(string Property, string? OldValue, string? NewValue)>();
+        // Build change list from pre-state vs request
+        var changes = new List<(string Property, string? OldValue, string? NewValue)>();
 
-                if (request.KeyName != null && preState.KeyName != request.KeyName)
-                    changes.Add(("KeyName", preState.KeyName, request.KeyName));
-                if (request.IsEnabled.HasValue && preState.IsEnabled != request.IsEnabled.Value)
-                    changes.Add(("IsEnabled", preState.IsEnabled.ToString(), request.IsEnabled.Value.ToString()));
-                if (request.AllowedModels != null && preState.AllowedModels != request.AllowedModels)
-                    changes.Add(("AllowedModels", preState.AllowedModels ?? "null", request.AllowedModels));
-                if (request.ExpiresAt.HasValue && preState.ExpiresAt != request.ExpiresAt)
-                    changes.Add(("ExpiresAt", preState.ExpiresAt?.ToString("o") ?? "null", request.ExpiresAt?.ToString("o") ?? "null"));
-                if (request.RateLimitRpm.HasValue && preState.RateLimitRpm != request.RateLimitRpm)
-                    changes.Add(("RateLimitRpm", preState.RateLimitRpm?.ToString() ?? "null", request.RateLimitRpm?.ToString() ?? "null"));
-                if (request.RateLimitRpd.HasValue && preState.RateLimitRpd != request.RateLimitRpd)
-                    changes.Add(("RateLimitRpd", preState.RateLimitRpd?.ToString() ?? "null", request.RateLimitRpd?.ToString() ?? "null"));
-                if (request.VirtualKeyGroupId.HasValue && preState.VirtualKeyGroupId != request.VirtualKeyGroupId.Value)
-                    changes.Add(("VirtualKeyGroupId", preState.VirtualKeyGroupId.ToString(), request.VirtualKeyGroupId.Value.ToString()));
+        if (request.KeyName != null && preState.KeyName != request.KeyName)
+            changes.Add(("KeyName", preState.KeyName, request.KeyName));
+        if (request.IsEnabled.HasValue && preState.IsEnabled != request.IsEnabled.Value)
+            changes.Add(("IsEnabled", preState.IsEnabled.ToString(), request.IsEnabled.Value.ToString()));
+        if (request.AllowedModels != null && preState.AllowedModels != request.AllowedModels)
+            changes.Add(("AllowedModels", preState.AllowedModels ?? "null", request.AllowedModels));
+        if (request.ExpiresAt.HasValue && preState.ExpiresAt != request.ExpiresAt)
+            changes.Add(("ExpiresAt", preState.ExpiresAt?.ToString("o") ?? "null", request.ExpiresAt?.ToString("o") ?? "null"));
+        if (request.RateLimitRpm.HasValue && preState.RateLimitRpm != request.RateLimitRpm)
+            changes.Add(("RateLimitRpm", preState.RateLimitRpm?.ToString() ?? "null", request.RateLimitRpm?.ToString() ?? "null"));
+        if (request.RateLimitRpd.HasValue && preState.RateLimitRpd != request.RateLimitRpd)
+            changes.Add(("RateLimitRpd", preState.RateLimitRpd?.ToString() ?? "null", request.RateLimitRpd?.ToString() ?? "null"));
+        if (request.VirtualKeyGroupId.HasValue && preState.VirtualKeyGroupId != request.VirtualKeyGroupId.Value)
+            changes.Add(("VirtualKeyGroupId", preState.VirtualKeyGroupId.ToString(), request.VirtualKeyGroupId.Value.ToString()));
 
-                if (changes.Count > 0)
-                {
-                    LogAdminAuditWithChanges("VirtualKey", id, changes);
-                }
-                else
-                {
-                    LogAdminAudit("Updated", "VirtualKey", id, "No changes detected");
-                }
-                AdminOperationsMetricsService.RecordVirtualKeyOperation("update", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "update");
-            },
-            NoContent(),
-            "UpdateKey",
-            new { Id = id });
+        if (changes.Count > 0)
+        {
+            LogAdminAuditWithChanges("VirtualKey", id, changes);
+        }
+        else
+        {
+            LogAdminAudit("Updated", "VirtualKey", id, "No changes detected");
+        }
+        AdminOperationsMetricsService.RecordVirtualKeyOperation("update", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "update");
+        return NoContent();
     }
 
     /// <summary>
@@ -168,20 +157,14 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DeleteKey(int id)
+    public async Task<IActionResult> DeleteKey(int id)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                if (!await _virtualKeyService.DeleteVirtualKeyAsync(id))
-                    throw new KeyNotFoundException();
-                LogAdminAudit("Deleted", "VirtualKey", id);
-                AdminOperationsMetricsService.RecordVirtualKeyOperation("delete", "success");
-                AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "delete");
-            },
-            NoContent(),
-            "DeleteKey",
-            new { Id = id });
+        if (!await _virtualKeyService.DeleteVirtualKeyAsync(id))
+            throw new KeyNotFoundException();
+        LogAdminAudit("Deleted", "VirtualKey", id);
+        AdminOperationsMetricsService.RecordVirtualKeyOperation("delete", "success");
+        AdminOperationsMetricsService.RecordConfigurationChange("virtualkey", "delete");
+        return NoContent();
     }
 
 
@@ -195,12 +178,10 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     // lgtm [cs/web/missing-function-level-access-control]
-    public Task<IActionResult> ValidateKey([FromBody] ValidateVirtualKeyRequest request)
+    public async Task<IActionResult> ValidateKey([FromBody] ValidateVirtualKeyRequest request)
     {
-        return ExecuteAsync(
-            () => _virtualKeyService.ValidateVirtualKeyAsync(request.Key, request.RequestedModel),
-            Ok,
-            "ValidateKey");
+        var result = await _virtualKeyService.ValidateVirtualKeyAsync(request.Key, request.RequestedModel);
+        return Ok(result);
     }
 
 
@@ -216,14 +197,14 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(typeof(VirtualKeyValidationInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetValidationInfo(int id)
+    public async Task<IActionResult> GetValidationInfo(int id)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _virtualKeyService.GetValidationInfoAsync(id),
-            Ok,
-            "Virtual key",
-            id,
-            "GetValidationInfo");
+        var result = await _virtualKeyService.GetValidationInfoAsync(id);
+        if (result == null)
+        {
+            return this.NotFoundEntity("Virtual key", id);
+        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -242,12 +223,10 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> PerformMaintenance()
+    public async Task<IActionResult> PerformMaintenance()
     {
-        return ExecuteAsync(
-            () => _virtualKeyService.PerformMaintenanceAsync(),
-            NoContent(),
-            "PerformMaintenance");
+        await _virtualKeyService.PerformMaintenanceAsync();
+        return NoContent();
     }
 
     /// <summary>
@@ -261,14 +240,14 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(typeof(VirtualKeyDiscoveryPreviewDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> PreviewDiscovery(int id, [FromQuery] string? capability = null)
+    public async Task<IActionResult> PreviewDiscovery(int id, [FromQuery] string? capability = null)
     {
-        return ExecuteWithNotFoundAsync(
-            () => _virtualKeyService.PreviewDiscoveryAsync(id, capability),
-            Ok,
-            "Virtual key",
-            id,
-            "PreviewDiscovery");
+        var result = await _virtualKeyService.PreviewDiscoveryAsync(id, capability);
+        if (result == null)
+        {
+            return this.NotFoundEntity("Virtual key", id);
+        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -281,28 +260,21 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(typeof(VirtualKeyGroupDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetKeyGroup(int id)
+    public async Task<IActionResult> GetKeyGroup(int id)
     {
-        return ExecuteAsync(
-            async () =>
-            {
-                var key = await _virtualKeyService.GetVirtualKeyByIdAsync(id);
-                if (key == null)
-                {
-                    throw new KeyNotFoundException("Virtual key not found");
-                }
+        var key = await _virtualKeyService.GetVirtualKeyByIdAsync(id);
+        if (key == null)
+        {
+            throw new KeyNotFoundException("Virtual key not found");
+        }
 
-                var groupInfo = await _virtualKeyService.GetKeyGroupAsync(id);
-                if (groupInfo == null)
-                {
-                    throw new KeyNotFoundException("Virtual key group not found");
-                }
+        var groupInfo = await _virtualKeyService.GetKeyGroupAsync(id);
+        if (groupInfo == null)
+        {
+            throw new KeyNotFoundException("Virtual key group not found");
+        }
 
-                return groupInfo;
-            },
-            Ok,
-            "GetKeyGroup",
-            new { Id = id });
+        return Ok(groupInfo);
     }
 
     /// <summary>
@@ -323,18 +295,18 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> GetUsageByKey(string key)
+    public async Task<IActionResult> GetUsageByKey(string key)
     {
         if (string.IsNullOrEmpty(key))
         {
-            return Task.FromResult<IActionResult>(BadRequest(new { message = "Key value is required" }));
+            return BadRequest(new { message = "Key value is required" });
         }
 
-        return ExecuteWithNotFoundAsync(
-            () => _virtualKeyService.GetUsageByKeyAsync(key),
-            Ok,
-            "Virtual key",
-            null,
-            "GetUsageByKey");
+        var result = await _virtualKeyService.GetUsageByKeyAsync(key);
+        if (result == null)
+        {
+            return this.NotFoundEntity("Virtual key", null);
+        }
+        return Ok(result);
     }
 }

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ConfigurationControllerTests.LLMCache.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ConfigurationControllerTests.LLMCache.cs
@@ -94,7 +94,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetLLMCacheStatus_ServiceThrowsException_Returns500()
+        public async Task GetLLMCacheStatus_ServiceThrowsException_ShouldPropagateException()
         {
             // Arrange
             _mockLLMCacheManagementService
@@ -102,19 +102,14 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(new Exception("Database connection failed"));
 
             // Act
-            var result = await _controller.GetLLMCacheStatus();
+            var act = async () => await _controller.GetLLMCacheStatus();
 
-            // Assert - AdminControllerBase returns ObjectResult with ErrorResponseDto
-            var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusResult.StatusCode.Should().Be(500);
-
-            var errorResponse = statusResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.Should().Be("An unexpected error occurred");
-            errorResponse.Code.Should().Be("internal_error");
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping/logging
+            await act.Should().ThrowAsync<Exception>();
         }
 
         [Fact]
-        public async Task GetLLMCacheStatus_LogsError_WhenExceptionOccurs()
+        public async Task GetLLMCacheStatus_WhenExceptionOccurs_ShouldPropagateException()
         {
             // Arrange
             var exception = new Exception("Test error");
@@ -123,17 +118,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(exception);
 
             // Act
-            await _controller.GetLLMCacheStatus();
+            var act = async () => await _controller.GetLLMCacheStatus();
 
-            // Assert
-            _mockLogger.Verify(
-                x => x.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((o, t) => true),
-                    exception,
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once);
+            // Assert - controller no longer logs; AdminExceptionMiddleware logs and the exception propagates
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion
@@ -292,7 +280,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task ToggleLLMCache_ServiceThrowsException_Returns500()
+        public async Task ToggleLLMCache_ServiceThrowsException_ShouldPropagateException()
         {
             // Arrange
             SetupControllerUser("admin");
@@ -308,19 +296,14 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(new Exception("Event bus unavailable"));
 
             // Act
-            var result = await _controller.ToggleLLMCache(request);
+            var act = async () => await _controller.ToggleLLMCache(request);
 
-            // Assert - AdminControllerBase returns ObjectResult with ErrorResponseDto
-            var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusResult.StatusCode.Should().Be(500);
-
-            var errorResponse = statusResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.Should().Be("An unexpected error occurred");
-            errorResponse.Code.Should().Be("internal_error");
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping/logging
+            await act.Should().ThrowAsync<Exception>();
         }
 
         [Fact]
-        public async Task ToggleLLMCache_LogsError_WhenExceptionOccurs()
+        public async Task ToggleLLMCache_WhenExceptionOccurs_ShouldPropagateException()
         {
             // Arrange
             SetupControllerUser("admin");
@@ -336,17 +319,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(exception);
 
             // Act
-            await _controller.ToggleLLMCache(request);
+            var act = async () => await _controller.ToggleLLMCache(request);
 
-            // Assert
-            _mockLogger.Verify(
-                x => x.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((o, t) => true),
-                    exception,
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-                Times.Once);
+            // Assert - controller no longer logs; AdminExceptionMiddleware logs and the exception propagates
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Create.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Create.cs
@@ -45,7 +45,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreateSetting_WithDuplicateKey_ShouldReturnBadRequest()
+        public async Task CreateSetting_WithDuplicateKey_ShouldPropagateException()
         {
             // Arrange
             var createDto = new CreateGlobalSettingDto
@@ -57,14 +57,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockService.Setup(x => x.CreateSettingAsync(It.IsAny<CreateGlobalSettingDto>()))
                 .ThrowsAsync(new InvalidOperationException("Setting with key already exists"));
 
-            // Act
-            var result = await _controller.CreateSetting(createDto);
-
-            // Assert
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.Should().Be("The requested operation is not valid");
-            errorResponse.Code.Should().Be("invalid_operation");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.CreateSetting(createDto);
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Delete.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Delete.cs
@@ -2,7 +2,6 @@ using ConduitLLM.Configuration.DTOs;
 
 using FluentAssertions;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using Moq;
@@ -28,19 +27,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteSetting_WithNonExistingId_ShouldReturnNotFound()
+        public async Task DeleteSetting_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.DeleteSettingAsync(999))
                 .ReturnsAsync(false);
 
-            // Act
-            var result = await _controller.DeleteSetting(999);
-
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.DeleteSetting(999);
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion
@@ -62,36 +57,27 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteSettingByKey_WithNonExistingKey_ShouldReturnNotFound()
+        public async Task DeleteSettingByKey_WithNonExistingKey_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.DeleteSettingByKeyAsync("non_existing"))
                 .ReturnsAsync(false);
 
-            // Act
-            var result = await _controller.DeleteSettingByKey("non_existing");
-
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.DeleteSettingByKey("non_existing");
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         [Fact]
-        public async Task DeleteSettingByKey_WithException_ShouldReturn500()
+        public async Task DeleteSettingByKey_WithException_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.DeleteSettingByKeyAsync(It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await _controller.DeleteSettingByKey("test_key");
-
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.DeleteSettingByKey("test_key");
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.GetAllSettings.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.GetAllSettings.cs
@@ -1,6 +1,5 @@
 using ConduitLLM.Configuration.DTOs;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -51,20 +50,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetAllSettings_WithException_ShouldReturn500()
+        public async Task GetAllSettings_WithException_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.GetAllSettingsAsync())
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await _controller.GetAllSettings();
-
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.GetAllSettings();
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.GetByKey.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.GetByKey.cs
@@ -1,6 +1,5 @@
 using ConduitLLM.Configuration.DTOs;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -52,20 +51,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetSettingByKey_WithException_ShouldReturn500()
+        public async Task GetSettingByKey_WithException_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.GetSettingByKeyAsync(It.IsAny<string>()))
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await _controller.GetSettingByKey("test_key");
-
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.GetSettingByKey("test_key");
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Update.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/GlobalSettingsControllerTests.Update.cs
@@ -1,6 +1,5 @@
 using ConduitLLM.Configuration.DTOs;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -52,7 +51,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task UpdateSetting_WithNonExistingId_ShouldReturnNotFound()
+        public async Task UpdateSetting_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             var updateDto = new UpdateGlobalSettingDto
@@ -64,13 +63,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockService.Setup(x => x.GetSettingByIdAsync(999))
                 .ReturnsAsync((GlobalSettingDto?)null);
 
-            // Act
-            var result = await _controller.UpdateSetting(999, updateDto);
-
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.UpdateSetting(999, updateDto);
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion
@@ -99,7 +94,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task UpdateSettingByKey_WithFailure_ShouldReturnBadRequest()
+        public async Task UpdateSettingByKey_WithFailure_ShouldPropagateException()
         {
             // Arrange
             var updateDto = new UpdateGlobalSettingByKeyDto
@@ -111,20 +106,14 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockService.Setup(x => x.UpdateSettingByKeyAsync(It.IsAny<UpdateGlobalSettingByKeyDto>()))
                 .ReturnsAsync(false);
 
-            // Act
-            var result = await _controller.UpdateSettingByKey(updateDto);
-
-            // Assert
-            // Controller throws InvalidOperationException when service returns false,
-            // which AdminControllerBase maps to 400 Bad Request
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.Should().Be("The requested operation is not valid");
-            errorResponse.Code.Should().Be("invalid_operation");
+            // Act + Assert — controller throws InvalidOperationException when service returns false;
+            // error mapping is now owned by AdminExceptionMiddleware, so the action propagates.
+            var act = async () => await _controller.UpdateSettingByKey(updateDto);
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         [Fact]
-        public async Task UpdateSettingByKey_WithException_ShouldReturn500()
+        public async Task UpdateSettingByKey_WithException_ShouldPropagateException()
         {
             // Arrange
             var updateDto = new UpdateGlobalSettingByKeyDto
@@ -136,14 +125,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockService.Setup(x => x.UpdateSettingByKeyAsync(It.IsAny<UpdateGlobalSettingByKeyDto>()))
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await _controller.UpdateSettingByKey(updateDto);
-
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.UpdateSettingByKey(updateDto);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.CrudOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.CrudOperations.cs
@@ -219,7 +219,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreateModel_WhenRepositoryThrows_ShouldReturn500()
+        public async Task CreateModel_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var createDto = new CreateModelDto
@@ -234,14 +234,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.CreateModelAsync(It.IsAny<Model>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.CreateModel(createDto);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.CreateModel(createDto);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion
@@ -458,7 +453,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task UpdateModel_WhenGetByIdFails_ShouldReturn500()
+        public async Task UpdateModel_WhenGetByIdFails_ShouldPropagateException()
         {
             // Arrange
             var modelId = 1;
@@ -472,20 +467,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByIdWithDetailsAsync(modelId))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.UpdateModel(modelId, updateDto);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.UpdateModel(modelId, updateDto);
+            await act.Should().ThrowAsync<Exception>();
 
             _mockRepository.Verify(r => r.UpdateModelAsync(It.IsAny<Model>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]
-        public async Task UpdateModel_WhenRepositoryThrows_ShouldReturn500()
+        public async Task UpdateModel_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var modelId = 1;
@@ -499,14 +489,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByIdWithDetailsAsync(modelId))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.UpdateModel(modelId, updateDto);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.UpdateModel(modelId, updateDto);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion
@@ -568,7 +553,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteModel_WhenRepositoryThrows_ShouldReturn500()
+        public async Task DeleteModel_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var modelId = 1;
@@ -576,14 +561,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByIdAsync(modelId))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.DeleteModel(modelId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.DeleteModel(modelId);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.GetOperations.cs
@@ -114,21 +114,16 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetAllModels_WhenRepositoryThrows_ShouldReturn500()
+        public async Task GetAllModels_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var exception = new Exception("Database connection failed");
             _mockRepository.Setup(r => r.GetPaginatedWithFilterAsync(null, null, null, null, null))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.GetAllModels();
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.GetAllModels();
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion
@@ -192,7 +187,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetModelById_WhenRepositoryThrows_ShouldReturn500()
+        public async Task GetModelById_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var modelId = 1;
@@ -200,14 +195,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByIdWithDetailsAsync(modelId))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.GetModelById(modelId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.GetModelById(modelId);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion
@@ -339,7 +329,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetModelIdentifiers_WhenRepositoryThrows_ShouldReturn500()
+        public async Task GetModelIdentifiers_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var modelId = 1;
@@ -347,14 +337,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByIdWithDetailsAsync(modelId))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.GetModelIdentifiers(modelId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.GetModelIdentifiers(modelId);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelControllerTests.ProviderOperations.cs
@@ -290,7 +290,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetModelsByProvider_WhenRepositoryThrows_ShouldReturn500()
+        public async Task GetModelsByProvider_WhenRepositoryThrows_ShouldPropagateException()
         {
             // Arrange
             var provider = "groq";
@@ -299,14 +299,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockRepository.Setup(r => r.GetByProviderAsync(ProviderType.Groq))
                 .ThrowsAsync(exception);
 
-            // Act
-            var result = await _controller.GetModelsByProvider(provider);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = objectResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.GetModelsByProvider(provider);
+            await act.Should().ThrowAsync<Exception>();
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.CRUD.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.CRUD.cs
@@ -3,7 +3,6 @@ using ConduitLLM.Configuration.DTOs;
 
 using FluentAssertions;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using Moq;
@@ -77,7 +76,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreateModelCost_WithDuplicateCostName_ShouldReturnBadRequest()
+        public async Task CreateModelCost_WithDuplicateCostName_ShouldPropagateException()
         {
             // Arrange
             var createDto = new CreateModelCostDto
@@ -90,13 +89,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(new InvalidOperationException("Model cost with this name already exists"));
 
             // Act
-            var result = await _controller.CreateModelCost(createDto);
+            var act = async () => await _controller.CreateModelCost(createDto);
 
-            // Assert
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.ToString().Should().Be("The requested operation is not valid");
-            errorResponse.Code.Should().Be("invalid_operation");
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         #endregion
@@ -145,7 +141,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task UpdateModelCost_WithNonExistingId_ShouldReturnNotFound()
+        public async Task UpdateModelCost_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             var updateDto = new UpdateModelCostDto
@@ -159,12 +155,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ReturnsAsync(false);
 
             // Act
-            var result = await _controller.UpdateModelCost(999, updateDto);
+            var act = async () => await _controller.UpdateModelCost(999, updateDto);
 
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Assert - controller throws KeyNotFoundException; AdminExceptionMiddleware maps it to 404
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion
@@ -186,19 +180,17 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteModelCost_WithNonExistingId_ShouldReturnNotFound()
+        public async Task DeleteModelCost_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.DeleteModelCostAsync(999))
                 .ReturnsAsync(false);
 
             // Act
-            var result = await _controller.DeleteModelCost(999);
+            var act = async () => await _controller.DeleteModelCost(999);
 
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Assert - controller throws KeyNotFoundException; AdminExceptionMiddleware maps it to 404
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.ImportExport.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.ImportExport.cs
@@ -149,7 +149,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task ImportJson_WithFailedImport_ShouldReturnBadRequest()
+        public async Task ImportJson_WithFailedImport_ShouldPropagateException()
         {
             // Arrange
             var jsonContent = "[{\"invalidField\":\"data\"}]";
@@ -171,12 +171,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ReturnsAsync(importResult);
 
             // Act
-            var result = await _controller.ImportJson(formFile);
+            var act = async () => await _controller.ImportJson(formFile);
 
-            // Assert
-            // The test should just verify it returns BadRequest - the exact format depends on the controller implementation
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            badRequestResult.Value.Should().NotBeNull();
+            // Assert - controller throws InvalidOperationException on failed import; AdminExceptionMiddleware owns mapping
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.Read.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelCostsControllerTests.Read.cs
@@ -1,6 +1,5 @@
 using ConduitLLM.Configuration.DTOs;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -138,20 +137,17 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetAllModelCosts_WithException_ShouldReturn500()
+        public async Task GetAllModelCosts_WithException_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.GetAllModelCostsAsync())
                 .ThrowsAsync(new Exception("Database error"));
 
             // Act
-            var result = await _controller.GetAllModelCosts();
+            var act = async () => await _controller.GetAllModelCosts();
 
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.DeleteMapping.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.DeleteMapping.cs
@@ -34,19 +34,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteMapping_WithNonExistingId_ShouldReturnNotFound()
+        public async Task DeleteMapping_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.GetMappingByIdAsync(999))
                 .ReturnsAsync((ModelProviderMapping?)null);
 
-            // Act
-            var result = await _controller.DeleteMapping(999);
-
-            // Assert
-            var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Act & Assert — not-found now throws KeyNotFoundException, mapped in AdminExceptionMiddleware
+            var act = async () => await _controller.DeleteMapping(999);
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.GetMappings.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.GetMappings.cs
@@ -57,20 +57,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetAllMappings_WithException_ShouldReturn500()
+        public async Task GetAllMappings_WithException_ShouldPropagateException()
         {
             // Arrange
             _mockService.Setup(x => x.GetAllMappingsAsync())
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await _controller.GetAllMappings();
-
-            // Assert
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("internal_error");
+            // Act & Assert — error→HTTP mapping now happens in AdminExceptionMiddleware
+            var act = async () => await _controller.GetAllMappings();
+            await act.Should().ThrowAsync<Exception>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.UpdateMapping.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.UpdateMapping.cs
@@ -45,7 +45,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task UpdateMapping_WithNonExistingId_ShouldReturnNotFound()
+        public async Task UpdateMapping_WithNonExistingId_ShouldPropagateException()
         {
             // Arrange
             var mapping = new ModelProviderMapping
@@ -61,13 +61,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockService.Setup(x => x.GetMappingByIdAsync(999))
                 .ReturnsAsync((ModelProviderMapping?)null);
 
-            // Act
-            var actionResult = await _controller.UpdateMapping(999, mapping.ToDto());
-
-            // Assert
-            var notFoundResult = actionResult.Should().BeOfType<NotFoundObjectResult>().Subject;
-            var errorResponse = notFoundResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.Code.Should().Be("not_found");
+            // Act & Assert — not-found now throws KeyNotFoundException, mapped in AdminExceptionMiddleware
+            var act = async () => await _controller.UpdateMapping(999, mapping.ToDto());
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/PricingControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/PricingControllerTests.cs
@@ -141,7 +141,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task SimulatePricing_InvalidJson_ReturnsBadRequest()
+        public async Task SimulatePricing_InvalidJson_ShouldPropagateException()
         {
             // Arrange
             var request = new PricingSimulationRequest
@@ -149,11 +149,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 PricingConfiguration = "bad json"
             };
 
-            // Act
-            var result = await _controller.SimulatePricing(request);
-
-            // Assert
-            result.Should().BeOfType<BadRequestObjectResult>();
+            // Act & Assert — invalid JSON now throws ArgumentException, mapped in AdminExceptionMiddleware
+            var act = async () => await _controller.SimulatePricing(request);
+            await act.Should().ThrowAsync<ArgumentException>();
         }
 
         #endregion
@@ -250,17 +248,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
         #region GetPricingAuditByRequestId Tests
 
         [Fact]
-        public async Task GetPricingAuditByRequestId_NoEvents_ReturnsNotFound()
+        public async Task GetPricingAuditByRequestId_NoEvents_ShouldPropagateException()
         {
             // Arrange
             _mockAuditService.Setup(s => s.GetByRequestIdAsync("req-123"))
                 .ReturnsAsync(new List<ConduitLLM.Configuration.Entities.PricingAuditEvent>());
 
-            // Act
-            var result = await _controller.GetPricingAuditByRequestId("req-123");
-
-            // Assert
-            result.Should().BeOfType<NotFoundObjectResult>();
+            // Act & Assert — not-found now throws KeyNotFoundException, mapped in AdminExceptionMiddleware
+            var act = async () => await _controller.GetPricingAuditByRequestId("req-123");
+            await act.Should().ThrowAsync<KeyNotFoundException>();
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ProviderCredentialsControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ProviderCredentialsControllerTests.cs
@@ -202,7 +202,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task TestProviderConnectionWithCredentials_WithEmptyApiKey_ShouldReturnBadRequest()
+        public async Task TestProviderConnectionWithCredentials_WithEmptyApiKey_ShouldPropagateException()
         {
             // Arrange
             var testRequest = new TestProviderRequest
@@ -212,21 +212,19 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 BaseUrl = "https://api.openai.com/v1"
             };
 
-            // Mock the client factory to throw when creating client with empty key
+            // Mock the client factory to throw when creating client with empty key.
+            // CreateTestClient is invoked outside the action's try/catch, so the
+            // ArgumentException propagates and is mapped to 400 in AdminExceptionMiddleware.
             _mockClientFactory.Setup(x => x.CreateTestClient(It.IsAny<Provider>(), It.IsAny<ProviderKeyCredential>()))
                 .Throws(new ArgumentException("API key is required for testing credentials"));
 
-            // Act
-            var result = await _controller.TestProviderConnectionWithCredentials(testRequest);
-
-            // Assert - ExceptionToResponseMapper maps ArgumentException to 400 Bad Request
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            Assert.Equal("invalid_parameter", errorResponse.Code);
+            // Act & Assert
+            var act = async () => await _controller.TestProviderConnectionWithCredentials(testRequest);
+            await act.Should().ThrowAsync<ArgumentException>();
         }
 
         [Fact]
-        public async Task TestProviderConnectionWithCredentials_WithNullApiKey_ShouldReturnBadRequest()
+        public async Task TestProviderConnectionWithCredentials_WithNullApiKey_ShouldPropagateException()
         {
             // Arrange
             var testRequest = new TestProviderRequest
@@ -236,17 +234,15 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 BaseUrl = "https://api.openai.com/v1"
             };
 
-            // Mock the client factory to throw when creating client with null key
+            // Mock the client factory to throw when creating client with null key.
+            // CreateTestClient is invoked outside the action's try/catch, so the
+            // ArgumentException propagates and is mapped to 400 in AdminExceptionMiddleware.
             _mockClientFactory.Setup(x => x.CreateTestClient(It.IsAny<Provider>(), It.IsAny<ProviderKeyCredential>()))
                 .Throws(new ArgumentException("API key is required for testing credentials"));
 
-            // Act
-            var result = await _controller.TestProviderConnectionWithCredentials(testRequest);
-
-            // Assert - ExceptionToResponseMapper maps ArgumentException to 400 Bad Request
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            Assert.Equal("invalid_parameter", errorResponse.Code);
+            // Act & Assert
+            var act = async () => await _controller.TestProviderConnectionWithCredentials(testRequest);
+            await act.Should().ThrowAsync<ArgumentException>();
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/SystemInfoControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/SystemInfoControllerTests.cs
@@ -58,7 +58,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task InvalidateDiscoveryCache_WhenPublishThrowsException_ReturnsInternalServerError()
+        public async Task InvalidateDiscoveryCache_WhenPublishThrowsException_ShouldPropagateException()
         {
             // Arrange
             var exceptionMessage = "Event publishing failed";
@@ -67,21 +67,10 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 .ThrowsAsync(new System.Exception(exceptionMessage));
 
             // Act
-            var result = await _controller.InvalidateDiscoveryCache();
+            var act = async () => await _controller.InvalidateDiscoveryCache();
 
-            // Assert
-            var statusResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(StatusCodes.Status500InternalServerError, statusResult.StatusCode);
-
-            // Verify error was logged
-            _mockLogger.Verify(
-                x => x.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => true),
-                    It.IsAny<Exception>(),
-                    It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
-                Times.Once);
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping and logging
+            await act.Should().ThrowAsync<System.Exception>();
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/TasksControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/TasksControllerTests.cs
@@ -100,24 +100,17 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task CleanupOldTasks_WithServiceException_ShouldReturn500()
+        public async Task CleanupOldTasks_WithServiceException_ShouldPropagateException()
         {
             // Arrange
             _mockTaskService.Setup(x => x.CleanupOldTasksAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Service error"));
 
             // Act
-            var result = await _controller.CleanupOldTasks();
+            var act = async () => await _controller.CleanupOldTasks();
 
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            Assert.NotNull(objectResult.Value);
-
-            // Verify standardized error response structure from AdminControllerBase
-            var errorResponse = objectResult.Value.Should().BeOfType<ConduitLLM.Configuration.DTOs.ErrorResponseDto>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.error);
-            Assert.Equal("internal_error", errorResponse.Code);
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping
+            await act.Should().ThrowAsync<Exception>();
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/VirtualKeyGroupsControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/VirtualKeyGroupsControllerTests.cs
@@ -127,7 +127,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
             // Act
             var result = await _controller.GetKeysInGroup(groupId);
 
-            // Assert - ExecuteWithNotFoundAsync returns NotFoundObjectResult with ErrorResponseDto
+            // Assert - NotFoundEntity returns NotFoundObjectResult with ErrorResponseDto
             result.Should().BeOfType<NotFoundObjectResult>();
 
             // Verify the correct repository method was called
@@ -168,22 +168,18 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GetKeysInGroup_ShouldReturnBadRequest_WhenInvalidOperationExceptionOccurs()
+        public async Task GetKeysInGroup_ShouldPropagateException_WhenInvalidOperationExceptionOccurs()
         {
             // Arrange
             var groupId = 1;
             _mockGroupRepository.Setup(r => r.GetByIdWithKeysAsync(groupId))
                               .ThrowsAsync(new InvalidOperationException("Database error"));
 
-            // Act
-            var result = await _controller.GetKeysInGroup(groupId);
-
-            // Assert - ExceptionToResponseMapper maps InvalidOperationException to 400 Bad Request
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            Assert.Equal("The requested operation is not valid", errorResponse.error);
-            Assert.Equal("invalid_operation", errorResponse.Code);
+            // Act + Assert - error handling is delegated to the global AdminExceptionMiddleware,
+            // which maps InvalidOperationException to a 400 response. The action itself lets the
+            // exception propagate rather than catching it in a per-action wrapper.
+            var act = async () => await _controller.GetKeysInGroup(groupId);
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("Database error");
 
             // Verify the repository method was called
             _mockGroupRepository.Verify(r => r.GetByIdWithKeysAsync(groupId), Times.Once);

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/VirtualKeysControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/VirtualKeysControllerTests.cs
@@ -90,7 +90,7 @@ namespace ConduitLLM.Tests.Admin.Controllers
         }
 
         [Fact]
-        public async Task GenerateKey_ServiceThrowsInvalidOperation_ReturnsBadRequest()
+        public async Task GenerateKey_ServiceThrowsInvalidOperation_ShouldPropagateException()
         {
             // Arrange
             var request = new CreateVirtualKeyRequestDto
@@ -102,11 +102,9 @@ namespace ConduitLLM.Tests.Admin.Controllers
             _mockVirtualKeyService.Setup(x => x.GenerateVirtualKeyAsync(It.IsAny<CreateVirtualKeyRequestDto>()))
                 .ThrowsAsync(new InvalidOperationException("Virtual key group 999 not found. Ensure the group exists before creating keys."));
 
-            // Act
-            var result = await _controller.GenerateKey(request);
-
-            // Assert - AdminControllerBase maps InvalidOperationException to 400 Bad Request
-            result.Should().BeOfType<BadRequestObjectResult>();
+            // Act + Assert — error mapping is now owned by AdminExceptionMiddleware; the action propagates.
+            var act = async () => await _controller.GenerateKey(request);
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Create.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelCostIntegrationTests.Create.cs
@@ -60,11 +60,11 @@ namespace ConduitLLM.Tests.Admin.Integration
         }
 
         [Fact]
-        public async Task CreateModelCost_DuplicateName_ShouldReturnBadRequest()
+        public async Task CreateModelCost_DuplicateName_ShouldPropagateException()
         {
             // Arrange
             await SetupTestDataAsync();
-            
+
             // Create first cost
             var firstCost = new CreateModelCostDto
             {
@@ -83,13 +83,10 @@ namespace ConduitLLM.Tests.Admin.Integration
             };
 
             // Act
-            var result = await _controller.CreateModelCost(duplicateCost);
+            var act = async () => await _controller.CreateModelCost(duplicateCost);
 
-            // Assert
-            var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-            var errorResponse = badRequestResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.Should().Be("The requested operation is not valid");
-            errorResponse.Code.Should().Be("invalid_operation");
+            // Assert - exception propagates to AdminExceptionMiddleware, which owns error mapping
+            await act.Should().ThrowAsync<InvalidOperationException>();
         }
 
         #endregion


### PR DESCRIPTION
## Why this PR exists (corrective)

The Admin Tier 1a rollout (originally **#935**) was a *stacked* PR: its base was `refactor/admin-operation-logging-filter` (the pilot #908's branch), not `dev`. When #908 merged into `dev` first, GitHub did **not** re-target #935 — so when #935 was then merged, its **30 converted Admin controllers landed back in the pilot branch instead of `dev`**.

Result: `dev` currently has the pilot (`ModelAuthorController`) + the Gateway conversion (#936) + Tier 1b (#907), but is **missing the other 30 Admin controllers** — it still has ~215 `ExecuteAsync` wrapper call sites.

This PR re-lands that exact content (the 6 batch commits `1c5b4cac…119730f4`) **directly into `dev`**.

## What's in it

The 30 remaining Admin controllers converted off the per-action `ExecuteAsync`/`ExecuteWithNotFoundAsync` wrappers (batches 1–6), plus ~38 throw-path unit/integration test updates. Same behavior-preserving pattern as the already-merged pilot: thrown exceptions propagate to the global `AdminExceptionMiddleware` (same `ExceptionToResponseMapper` → identical responses); `[ServiceFilter(typeof(OperationLoggingFilter))]` per controller for success logging.

Net **−1,046 lines** across 58 files. Disjoint from `dev`'s other merges (Gateway, WebAdmin), so it merges cleanly.

## Verification (from the rollout)

Each batch was verified: Admin builds **0/0** and the full `ConduitLLM.Tests.Admin` namespace passes **552/552**. After this merges, `dev` will have **all 31 Admin controller classes** converted (Admin wrapper call sites → 0), unblocking the final-cleanup PR (global filter promotion + base-class wrapper-method removal).

Re-lands #935. Part of #902. Epic: #901.
