### PR TITLE
feat(admin): unify [ApiController] validation errors to ErrorResponseDto (Tier 2a)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Admin.Extensions;
 using ConduitLLM.Admin.Filters;
+using ConduitLLM.Admin.Validation;
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Core.Converters;
@@ -40,6 +41,14 @@ public partial class Program
                 // Ensure all DateTime values serialize as UTC with 'Z' suffix
                 options.JsonSerializerOptions.Converters.Add(new UtcDateTimeConverter());
                 options.JsonSerializerOptions.Converters.Add(new NullableUtcDateTimeConverter());
+            })
+            .ConfigureApiBehaviorOptions(options =>
+            {
+                // Tier 2a (#904): return the Admin API's standard ErrorResponseDto for automatic
+                // [ApiController] model-validation failures instead of the default
+                // ValidationProblemDetails — unifying the validation error shape with the rest of
+                // the Admin API (AdminExceptionMiddleware also emits ErrorResponseDto).
+                options.InvalidModelStateResponseFactory = InvalidModelStateResponse.Create;
             });
 
         // Operation-logging action filter — replaces the per-action success logging that used to

--- a/Services/ConduitLLM.Admin/Validation/InvalidModelStateResponse.cs
+++ b/Services/ConduitLLM.Admin/Validation/InvalidModelStateResponse.cs
@@ -1,0 +1,53 @@
+using ConduitLLM.Configuration.DTOs;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ConduitLLM.Admin.Validation
+{
+    /// <summary>
+    /// Produces the Admin API's standard <see cref="ErrorResponseDto"/> for automatic
+    /// <c>[ApiController]</c> model-state (DataAnnotation) validation failures, instead of the
+    /// framework default <c>ValidationProblemDetails</c>.
+    /// </summary>
+    /// <remarks>
+    /// This unifies validation error responses with the rest of the Admin API — the global
+    /// <c>AdminExceptionMiddleware</c> and controller error helpers also emit
+    /// <see cref="ErrorResponseDto"/>. Wired via
+    /// <c>AddControllers().ConfigureApiBehaviorOptions(o =&gt; o.InvalidModelStateResponseFactory = Create)</c>
+    /// (Tier 2a, #904).
+    /// </remarks>
+    public static class InvalidModelStateResponse
+    {
+        /// <summary>
+        /// Builds a standardized <see cref="ErrorResponseDto"/> describing the model-state errors.
+        /// Field errors are aggregated as <c>"{field}: {message}"</c> entries joined by "; ".
+        /// </summary>
+        public static ErrorResponseDto BuildErrorResponse(ModelStateDictionary modelState)
+        {
+            var errors = modelState
+                .Where(kvp => kvp.Value != null && kvp.Value.Errors.Count > 0)
+                .SelectMany(kvp => kvp.Value!.Errors.Select(e =>
+                {
+                    var msg = string.IsNullOrWhiteSpace(e.ErrorMessage)
+                        ? "The value is invalid."
+                        : e.ErrorMessage;
+                    return string.IsNullOrEmpty(kvp.Key) ? msg : $"{kvp.Key}: {msg}";
+                }))
+                .ToList();
+
+            var message = errors.Count > 0
+                ? string.Join("; ", errors)
+                : "One or more validation errors occurred.";
+
+            return new ErrorResponseDto(message) { Code = "validation_error" };
+        }
+
+        /// <summary>
+        /// <c>InvalidModelStateResponseFactory</c> implementation: returns a 400 Bad Request with the
+        /// standardized <see cref="ErrorResponseDto"/>.
+        /// </summary>
+        public static IActionResult Create(ActionContext context)
+            => new BadRequestObjectResult(BuildErrorResponse(context.ModelState));
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/Validation/InvalidModelStateResponseTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Validation/InvalidModelStateResponseTests.cs
@@ -1,0 +1,50 @@
+using ConduitLLM.Admin.Validation;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ConduitLLM.Tests.Admin.Validation
+{
+    /// <summary>
+    /// Unit tests for <see cref="InvalidModelStateResponse"/> — the custom
+    /// <c>InvalidModelStateResponseFactory</c> that maps [ApiController] validation failures to
+    /// the Admin API's standard <c>ErrorResponseDto</c> (Tier 2a, #904).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "AdminController")]
+    public class InvalidModelStateResponseTests
+    {
+        [Fact]
+        public void BuildErrorResponse_AggregatesFieldErrors_WithValidationErrorCode()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("Name", "The Name field is required.");
+            modelState.AddModelError("Age", "The field Age must be between 1 and 120.");
+
+            // Act
+            var dto = InvalidModelStateResponse.BuildErrorResponse(modelState);
+
+            // Assert
+            dto.Code.Should().Be("validation_error");
+            var message = dto.error.ToString()!;
+            message.Should().Contain("Name").And.Contain("required");
+            message.Should().Contain("Age");
+        }
+
+        [Fact]
+        public void BuildErrorResponse_WhenNoSpecificErrors_ReturnsGenericMessage()
+        {
+            // Arrange
+            var modelState = new ModelStateDictionary();
+
+            // Act
+            var dto = InvalidModelStateResponse.BuildErrorResponse(modelState);
+
+            // Assert
+            dto.Code.Should().Be("validation_error");
+            dto.error.ToString().Should().Contain("validation");
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a custom `InvalidModelStateResponseFactory` to the Admin service so automatic `[ApiController]` DataAnnotation validation failures return the Admin API's standard **`ErrorResponseDto`** (with `Code = "validation_error"`) instead of the framework-default **`ValidationProblemDetails`**.

This unifies the validation error shape with the rest of the Admin API — the global `AdminExceptionMiddleware`, the controller error helpers, and the inline business-rule checks all already emit `ErrorResponseDto`. Previously, annotation failures were the one path returning a different (`ValidationProblemDetails`) shape.

## ⚠️ Contract change

This changes the **400 response body** for Admin annotation-validation failures from `ValidationProblemDetails` (`{ "type", "title", "status", "errors": {...} }`) to `ErrorResponseDto` (`{ "error", "code": "validation_error", "details" }`). Field-level messages are aggregated into `error` as `"{field}: {message}"` entries. Please confirm the WebAdmin SDK / any Admin-API consumer is fine with `ErrorResponseDto` here (it already handles that shape for every other Admin error).

## Why this is the whole of Tier 2a

Investigation for #904 found the original "replace ~131 redundant manual checks" premise **did not hold**:
- **Zero `ModelState` checks** in any controller, and no pre-existing `InvalidModelStateResponseFactory`.
- The manual `BadRequest`/`OpenAIError` calls are **genuine business rules** (pagination bounds, ID-mismatch, null-body guards, DB-state checks like "function-config IDs not found") — not annotation re-checks, so there's nothing redundant to remove.
- **Gateway left entirely as-is**: its request DTOs carry no DataAnnotations, so it never triggers auto-validation; its manual `OpenAIError` validation is correctly OpenAI-compatible and must stay.

So the only real, high-value change was this single central consistency fix (the option chosen from the investigation).

## Changes

- New `ConduitLLM.Admin.Validation.InvalidModelStateResponse` — a static, testable factory (`BuildErrorResponse(ModelStateDictionary)` + `Create(ActionContext)`).
- Wired via `AddControllers().ConfigureApiBehaviorOptions(...)` in `Program.cs`.
- 2 unit tests for the factory.

## Verification

- `dotnet build` (Admin): **0 warnings, 0 errors**.
- `dotnet test` (`ConduitLLM.Tests.Admin`): **534/534 passing** (incl. the 2 new tests).

Resolves #904 (re-scoped per investigation). Epic: #901.
