### PR TITLE
refactor(admin): drop 151 boilerplate [ProducesResponseType(500)] attributes + document 500 globally (Tier 2b)

### DIFF
--- a/Services/ConduitLLM.Admin/Controllers/AnalyticsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/AnalyticsController.cs
@@ -54,7 +54,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("logs")]
     [ProducesResponseType(typeof(PagedResult<LogRequestDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetLogs(
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50,
@@ -88,7 +87,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("logs/{id:int}")]
     [ProducesResponseType(typeof(LogRequestDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetLogById(int id)
     {
         var log = await _analyticsService.GetLogByIdAsync(id);
@@ -105,7 +103,6 @@ public class AnalyticsController : AdminControllerBase
     /// <returns>List of model names</returns>
     [HttpGet("logs/models")]
     [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetDistinctModels()
     {
         var models = await _analyticsService.GetDistinctModelsAsync();
@@ -126,7 +123,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("costs/summary")]
     [ProducesResponseType(typeof(CostDashboardDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCostSummary(
         [FromQuery] string timeframe = "daily",
         [FromQuery] DateTime? startDate = null,
@@ -151,7 +147,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("costs/trends")]
     [ProducesResponseType(typeof(CostTrendDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCostTrends(
         [FromQuery] string period = "daily",
         [FromQuery] DateTime? startDate = null,
@@ -175,7 +170,6 @@ public class AnalyticsController : AdminControllerBase
     /// <returns>Model cost breakdown</returns>
     [HttpGet("costs/models")]
     [ProducesResponseType(typeof(ModelCostBreakdownDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetModelCosts(
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null,
@@ -194,7 +188,6 @@ public class AnalyticsController : AdminControllerBase
     /// <returns>Virtual key cost breakdown</returns>
     [HttpGet("costs/virtualkeys")]
     [ProducesResponseType(typeof(VirtualKeyCostBreakdownDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetVirtualKeyCosts(
         [FromQuery] DateTime? startDate = null,
         [FromQuery] DateTime? endDate = null,
@@ -218,7 +211,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("summary")]
     [ProducesResponseType(typeof(AnalyticsSummaryDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAnalyticsSummary(
         [FromQuery] string timeframe = "daily",
         [FromQuery] DateTime? startDate = null,
@@ -242,7 +234,6 @@ public class AnalyticsController : AdminControllerBase
     /// <returns>Usage statistics</returns>
     [HttpGet("virtualkeys/{virtualKeyId:int}/usage")]
     [ProducesResponseType(typeof(UsageStatisticsDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetVirtualKeyUsage(
         int virtualKeyId,
         [FromQuery] DateTime? startDate = null,
@@ -264,7 +255,6 @@ public class AnalyticsController : AdminControllerBase
     [HttpGet("export")]
     [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ExportAnalytics(
         [FromQuery] string format = "csv",
         [FromQuery] DateTime? startDate = null,
@@ -336,7 +326,6 @@ public class AnalyticsController : AdminControllerBase
     /// <returns>Success response</returns>
     [HttpPost("cache/invalidate")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> InvalidateCache([FromQuery] string reason = "Manual invalidation")
     {
         // TODO: Implement cache invalidation logic

--- a/Services/ConduitLLM.Admin/Controllers/AuthController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/AuthController.cs
@@ -40,7 +40,6 @@ namespace ConduitLLM.Admin.Controllers
         [Authorize(Policy = "MasterKeyPolicy")]
         [ProducesResponseType(typeof(EphemeralMasterKeyResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GenerateEphemeralMasterKey()
         {
             // Create ephemeral master key

--- a/Services/ConduitLLM.Admin/Controllers/FunctionConfigurationsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionConfigurationsController.cs
@@ -40,7 +40,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     /// <returns>List of all function configurations</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllConfigurations()
     {
         var configurations = await _configurationRepository.GetAllUnboundedAsync();
@@ -55,7 +54,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetConfigurationById(int id)
     {
         var configuration = await _configurationRepository.GetByIdAsync(id);
@@ -73,7 +71,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     /// <returns>List of function configurations for the specified provider</returns>
     [HttpGet("provider/{providerType}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetConfigurationsByProvider(string providerType)
     {
         if (!Enum.TryParse<ConduitLLM.Functions.Enums.FunctionProviderType>(providerType, true, out var providerEnum))
@@ -92,7 +89,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     /// <returns>List of function configurations for the specified purpose</returns>
     [HttpGet("purpose/{purpose}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetConfigurationsByPurpose(string purpose)
     {
         if (!Enum.TryParse<ConduitLLM.Functions.Enums.FunctionPurpose>(purpose, true, out var purposeEnum))
@@ -112,7 +108,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateConfiguration(
         [FromBody] ConduitLLM.Functions.Entities.FunctionConfiguration configuration)
     {
@@ -162,7 +157,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateConfiguration(
         int id,
         [FromBody] ConduitLLM.Functions.Entities.FunctionConfiguration configuration)
@@ -241,7 +235,6 @@ public class FunctionConfigurationsController : AdminControllerBase
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteConfiguration(int id)
     {
         var toDelete = await _configurationRepository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/FunctionCostsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionCostsController.cs
@@ -38,7 +38,6 @@ public class FunctionCostsController : AdminControllerBase
     /// <returns>List of all function costs</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllFunctionCosts()
     {
         var functionCosts = await _functionCostService.ListCostsAsync();
@@ -53,7 +52,6 @@ public class FunctionCostsController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetFunctionCostById(int id)
     {
         var functionCost = await _functionCostService.GetCostByIdAsync(id);
@@ -73,7 +71,6 @@ public class FunctionCostsController : AdminControllerBase
     [HttpGet("configuration/{functionConfigurationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCostForConfiguration(int functionConfigurationId)
     {
         var functionCost = await _functionCostService.GetCostForConfigurationAsync(
@@ -94,7 +91,6 @@ public class FunctionCostsController : AdminControllerBase
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateFunctionCost(
         [FromBody] CreateFunctionCostDto createDto)
     {
@@ -127,7 +123,6 @@ public class FunctionCostsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateFunctionCost(
         int id,
         [FromBody] UpdateFunctionCostDto updateDto)
@@ -167,7 +162,6 @@ public class FunctionCostsController : AdminControllerBase
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteFunctionCost(int id)
     {
         var existing = await _functionCostService.GetCostByIdAsync(id);
@@ -182,7 +176,6 @@ public class FunctionCostsController : AdminControllerBase
     /// <returns>Success message</returns>
     [HttpPost("cache/clear")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ClearCache()
     {
         await _functionCostService.ClearCacheAsync();

--- a/Services/ConduitLLM.Admin/Controllers/FunctionCredentialsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionCredentialsController.cs
@@ -42,7 +42,6 @@ public class FunctionCredentialsController : AdminControllerBase
     /// <returns>List of all credentials</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllCredentials()
     {
         var credentials = await _credentialRepository.GetAllUnboundedAsync();
@@ -57,7 +56,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpGet("configuration/{functionConfigurationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCredentialsByConfiguration(int functionConfigurationId)
     {
         // Get the configuration to determine its provider type
@@ -81,7 +79,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCredentialById(int id)
     {
         var credential = await _credentialRepository.GetByIdAsync(id);
@@ -100,7 +97,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateCredential(
         [FromBody] ConduitLLM.Functions.Entities.FunctionCredential credential)
     {
@@ -131,7 +127,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateCredential(
         int id,
         [FromBody] ConduitLLM.Functions.Entities.FunctionCredential credential)
@@ -168,7 +163,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteCredential(int id)
     {
         var credential = await _credentialRepository.GetByIdAsync(id);
@@ -185,7 +179,6 @@ public class FunctionCredentialsController : AdminControllerBase
     [HttpPost("test")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> TestCredential([FromBody] TestCredentialRequest testRequest)
     {
         if (testRequest == null)

--- a/Services/ConduitLLM.Admin/Controllers/FunctionExecutionsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/FunctionExecutionsController.cs
@@ -41,7 +41,6 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetExecutionById(Guid id)
     {
         var execution = await _executionRepository.GetByIdAsync(id);
@@ -60,7 +59,6 @@ public class FunctionExecutionsController : AdminControllerBase
     /// <returns>List of executions</returns>
     [HttpGet("virtualkey/{virtualKeyId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetExecutionsByVirtualKey(int virtualKeyId)
     {
         var executions = await _executionRepository.GetByVirtualKeyIdAsync(virtualKeyId);
@@ -74,7 +72,6 @@ public class FunctionExecutionsController : AdminControllerBase
     /// <returns>List of executions</returns>
     [HttpGet("configuration/{functionConfigurationId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetExecutionsByConfiguration(int functionConfigurationId)
     {
         var executions = await _executionRepository.GetByFunctionConfigurationIdAsync(
@@ -90,7 +87,6 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpGet("state/{state}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetExecutionsByState(string state)
     {
         if (!Enum.TryParse<ExecutionState>(state, true, out var stateEnum))
@@ -108,7 +104,6 @@ public class FunctionExecutionsController : AdminControllerBase
     /// <returns>List of executions with expired leases</returns>
     [HttpGet("expired-leases")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetExpiredLeases()
     {
         var executions = await _executionRepository.GetExpiredLeasesAsync();
@@ -121,7 +116,6 @@ public class FunctionExecutionsController : AdminControllerBase
     /// <returns>List of executions ready for retry</returns>
     [HttpGet("ready-for-retry")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetReadyForRetry()
     {
         var executions = await _executionRepository.GetReadyForRetryAsync();
@@ -136,7 +130,6 @@ public class FunctionExecutionsController : AdminControllerBase
     [HttpDelete("cleanup")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CleanupOldExecutions([FromQuery] int olderThanDays = 30)
     {
         if (olderThanDays < 1)

--- a/Services/ConduitLLM.Admin/Controllers/GlobalSettingsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/GlobalSettingsController.cs
@@ -45,7 +45,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all global settings</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<GlobalSettingDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllSettings()
         {
             var settings = await _globalSettingService.GetAllSettingsAsync();
@@ -60,7 +59,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetSettingById(int id)
         {
             var setting = await _globalSettingService.GetSettingByIdAsync(id);
@@ -79,7 +77,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("by-key/{key}")]
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetSettingByKey(string key)
         {
             var setting = await _globalSettingService.GetSettingByKeyAsync(key);
@@ -98,7 +95,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(GlobalSettingDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateSetting([FromBody] CreateGlobalSettingDto setting)
         {
             var createdSetting = await _globalSettingService.CreateSettingAsync(setting);
@@ -117,7 +113,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateSetting(int id, [FromBody] UpdateGlobalSettingDto setting)
         {
             // Ensure ID in route matches ID in body
@@ -164,7 +159,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPut("by-key")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateSettingByKey([FromBody] UpdateGlobalSettingByKeyDto setting)
         {
             if (!await _globalSettingService.UpdateSettingByKeyAsync(setting))
@@ -183,7 +177,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteSetting(int id)
         {
             if (!await _globalSettingService.DeleteSettingAsync(id))
@@ -202,7 +195,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("by-key/{key}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteSettingByKey(string key)
         {
             if (!await _globalSettingService.DeleteSettingByKeyAsync(key))
@@ -219,7 +211,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>Cache statistics including hit rate, size, and invalidation count</returns>
         [HttpGet("cache/stats")]
         [ProducesResponseType(typeof(GlobalSettingCacheStatsDto), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetCacheStats()
         {
             var stats = await _cacheService.GetCacheStatsAsync();
@@ -242,7 +233,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>No content if successful</returns>
         [HttpPost("cache/reload")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ReloadCache()
         {
             await _cacheService.ReloadAllSettingsAsync();
@@ -258,7 +248,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>No content if successful</returns>
         [HttpPost("cache/invalidate/{key}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> InvalidateCacheSetting(string key)
         {
             await _cacheService.InvalidateSettingAsync(key);

--- a/Services/ConduitLLM.Admin/Controllers/IpFilterController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/IpFilterController.cs
@@ -39,7 +39,6 @@ public class IpFilterController : AdminControllerBase
     /// <returns>List of all IP filters</returns>
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<IpFilterDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllFilters()
     {
         var filters = await _ipFilterService.GetAllFiltersAsync();
@@ -52,7 +51,6 @@ public class IpFilterController : AdminControllerBase
     /// <returns>List of all enabled IP filters</returns>
     [HttpGet("enabled")]
     [ProducesResponseType(typeof(IEnumerable<IpFilterDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetEnabledFilters()
     {
         var filters = await _ipFilterService.GetEnabledFiltersAsync();
@@ -67,7 +65,6 @@ public class IpFilterController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(IpFilterDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetFilterById(int id)
     {
         var filter = await _ipFilterService.GetFilterByIdAsync(id);
@@ -89,7 +86,6 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateFilter([FromBody] CreateIpFilterDto filter)
     {
         var (success, errorMessage, createdFilter) = await _ipFilterService.CreateFilterAsync(filter);
@@ -116,7 +112,6 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateFilter(int id, [FromBody] UpdateIpFilterDto filter)
     {
         // Ensure ID in route matches ID in body
@@ -152,7 +147,6 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteFilter(int id)
     {
         var (success, errorMessage) = await _ipFilterService.DeleteFilterAsync(id);
@@ -177,7 +171,6 @@ public class IpFilterController : AdminControllerBase
     /// <returns>The current IP filter settings</returns>
     [HttpGet("settings")]
     [ProducesResponseType(typeof(IpFilterSettingsDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetSettings()
     {
         var settings = await _ipFilterService.GetIpFilterSettingsAsync();
@@ -195,7 +188,6 @@ public class IpFilterController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateSettings([FromBody] IpFilterSettingsDto settings)
     {
         var (success, errorMessage) = await _ipFilterService.UpdateIpFilterSettingsAsync(settings);
@@ -218,7 +210,6 @@ public class IpFilterController : AdminControllerBase
     [AllowAnonymous] // This needs to be accessible without authentication for performance
     [ProducesResponseType(typeof(IpCheckResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CheckIpAddress(string ipAddress)
     {
         if (string.IsNullOrWhiteSpace(ipAddress))

--- a/Services/ConduitLLM.Admin/Controllers/ModelAuthorController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelAuthorController.cs
@@ -45,7 +45,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all model authors</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelAuthorDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAll()
         {
             var authors = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
@@ -61,7 +60,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(ModelAuthorDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetById(int id)
         {
             var author = await _repository.GetByIdAsync(id);
@@ -81,7 +79,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/series")]
         [ProducesResponseType(typeof(IEnumerable<SimpleModelSeriesDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetSeriesByAuthor(int id)
         {
             var series = await _repository.GetSeriesByAuthorAsync(id);
@@ -110,7 +107,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelAuthorDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Create([FromBody] CreateModelAuthorDto dto)
         {
             // Check if author with same name already exists
@@ -147,7 +143,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Update(int id, [FromBody] UpdateModelAuthorDto dto)
         {
             if (id != dto.Id)
@@ -192,7 +187,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Delete(int id)
         {
             var author = await _repository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.Identifiers.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.Identifiers.cs
@@ -18,7 +18,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/identifiers")]
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelIdentifiers(int id)
         {
             var model = await _modelRepository.GetByIdWithDetailsAsync(id);
@@ -53,7 +52,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/available-providers")]
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAvailableProviders(int id)
         {
             var model = await _modelRepository.GetByIdWithDetailsAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.ProviderMappings.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.ProviderMappings.cs
@@ -15,7 +15,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/provider-mappings")]
         [ProducesResponseType(typeof(IEnumerable<ModelProviderMappingDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelProviderMappings(int id)
         {
             var model = await _modelRepository.GetByIdAsync(id);
@@ -42,7 +41,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateModelProviderMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
         {
             // Skip ModelId validation since it's no longer on the DTO
@@ -96,7 +94,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateModelProviderMapping(int id, int mappingId, [FromBody] ModelProviderMappingDto mappingDto)
         {
             if (mappingDto.Id != mappingId)
@@ -148,7 +145,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}/provider-mappings/{mappingId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteModelProviderMapping(int id, int mappingId)
         {
             // Check if model exists

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.cs
@@ -65,7 +65,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all models, or paginated result when page/pageSize are provided</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllModels(
             [FromQuery] int? page = null,
             [FromQuery] int? pageSize = null,
@@ -111,7 +110,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(ModelDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelById(int id)
         {
             var model = await _modelRepository.GetByIdWithDetailsAsync(id);
@@ -131,7 +129,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of matching models</returns>
         [HttpGet("search")]
         [ProducesResponseType(typeof(IEnumerable<ModelDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> SearchModels([FromQuery] string query)
         {
             if (string.IsNullOrWhiteSpace(query))
@@ -151,7 +148,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("provider/{provider}")]
         [ProducesResponseType(typeof(IEnumerable<ModelWithProviderIdDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelsByProvider(string provider)
         {
             if (string.IsNullOrWhiteSpace(provider))
@@ -212,7 +208,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateModel([FromBody] CreateModelDto dto)
         {
             if (dto == null)
@@ -282,7 +277,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateModel(int id, [FromBody] UpdateModelDto dto)
         {
             if (dto == null)
@@ -438,7 +432,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteModel(int id)
         {
             var model = await _modelRepository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/ModelCostsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelCostsController.cs
@@ -50,7 +50,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all model costs or paginated response</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelCostDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllModelCosts(
             [FromQuery] int? page = null,
             [FromQuery] int? pageSize = null,
@@ -96,7 +95,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelCostById(int id)
         {
             var modelCost = await _modelCostService.GetModelCostByIdAsync(id);
@@ -114,7 +112,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of model costs for the specified provider</returns>
         [HttpGet("provider/{providerId}")]
         [ProducesResponseType(typeof(IEnumerable<ModelCostDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelCostsByProvider(int providerId)
         {
             var result = await _modelCostService.GetModelCostsByProviderAsync(providerId);
@@ -129,7 +126,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("name/{costName}")]
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelCostByCostName(string costName)
         {
             var modelCost = await _modelCostService.GetModelCostByCostNameAsync(costName);
@@ -148,7 +144,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(ModelCostDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateModelCost([FromBody] CreateModelCostDto modelCost)
         {
             var result = await _modelCostService.CreateModelCostAsync(modelCost);
@@ -166,7 +161,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateModelCost(int id, [FromBody] UpdateModelCostDto modelCost)
         {
             // Ensure ID in route matches ID in body
@@ -195,7 +189,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteModelCost(int id)
         {
             var existing = await _modelCostService.GetModelCostByIdAsync(id);
@@ -220,7 +213,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("overview")]
         [ProducesResponseType(typeof(IEnumerable<ModelCostOverviewDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelCostOverview(
             [FromQuery] DateTime startDate,
             [FromQuery] DateTime endDate)
@@ -242,7 +234,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("import")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ImportModelCosts([FromBody] IEnumerable<CreateModelCostDto> modelCosts)
         {
             if (modelCosts == null || !modelCosts.Any())
@@ -262,7 +253,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>CSV file containing model costs</returns>
         [HttpGet("export/csv")]
         [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ExportCsv([FromQuery] int? providerId = null)
         {
             var result = await _modelCostService.ExportModelCostsAsync("csv", providerId);
@@ -278,7 +268,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>JSON file containing model costs</returns>
         [HttpGet("export/json")]
         [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ExportJson([FromQuery] int? providerId = null)
         {
             var result = await _modelCostService.ExportModelCostsAsync("json", providerId);
@@ -295,7 +284,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("import/csv")]
         // [ProducesResponseType(typeof(BulkImportResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ImportCsv(IFormFile file)
         {
             if (file == null || file.Length == 0)
@@ -336,7 +324,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("import/json")]
         // [ProducesResponseType(typeof(BulkImportResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ImportJson(IFormFile file)
         {
             if (file == null || file.Length == 0)
@@ -379,7 +366,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ValidationResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ValidatePricingRules(
             int id,
             [FromBody] ValidatePricingRulesRequest request)
@@ -418,7 +404,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("validate-pricing-rules")]
         [ProducesResponseType(typeof(ValidationResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ValidatePricingRulesStandalone([FromBody] ValidatePricingRulesRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.PricingConfiguration))

--- a/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
@@ -48,7 +48,6 @@ public class ModelProviderMappingController : AdminControllerBase
     /// <returns>A list of all model provider mappings</returns>
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<ModelProviderMappingDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllMappings()
     {
         var mappings = await _mappingService.GetAllMappingsAsync();
@@ -64,7 +63,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(ModelProviderMappingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetMappingById(int id)
     {
         var mapping = await _mappingService.GetMappingByIdAsync(id);
@@ -81,7 +79,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(typeof(ModelProviderMappingDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateMapping([FromBody] ModelProviderMappingDto mappingDto)
     {
         // Check if a mapping with the same model alias already exists
@@ -120,7 +117,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateMapping(int id, [FromBody] ModelProviderMappingDto mappingDto)
     {
         if (id != mappingDto.Id)
@@ -157,7 +153,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteMapping(int id)
     {
         var existingMapping = await _mappingService.GetMappingByIdAsync(id);
@@ -186,7 +181,6 @@ public class ModelProviderMappingController : AdminControllerBase
     /// <returns>List of providers with IDs and names</returns>
     [HttpGet("providers")]
     [ProducesResponseType(typeof(IEnumerable<Provider>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetProviders()
     {
         var result = await _mappingService.GetProvidersAsync();
@@ -201,7 +195,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpPost("bulk")]
     [ProducesResponseType(typeof(BulkMappingResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateBulkMappings([FromBody] List<ModelProviderMappingDto> mappingDtos)
     {
         if (mappingDtos == null || !mappingDtos.Any())
@@ -235,7 +228,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpPost("bulk/delete")]
     [ProducesResponseType(typeof(BulkDeleteResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteBulkMappings([FromBody] List<int> ids)
     {
         if (ids == null || ids.Count == 0)
@@ -297,7 +289,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpPost("bulk/enable")]
     [ProducesResponseType(typeof(BulkUpdateResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> EnableBulkMappings([FromBody] List<int> ids)
     {
         return await UpdateBulkMappingsStatus(ids, true);
@@ -311,7 +302,6 @@ public class ModelProviderMappingController : AdminControllerBase
     [HttpPost("bulk/disable")]
     [ProducesResponseType(typeof(BulkUpdateResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DisableBulkMappings([FromBody] List<int> ids)
     {
         return await UpdateBulkMappingsStatus(ids, false);

--- a/Services/ConduitLLM.Admin/Controllers/ModelSeriesController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelSeriesController.cs
@@ -38,7 +38,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all model series</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<ModelSeriesDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAll()
         {
             var series = await _repository.GetAllWithAuthorAsync();
@@ -53,7 +52,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(ModelSeriesDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetById(int id)
         {
             var series = await _repository.GetByIdWithAuthorAsync(id);
@@ -73,7 +71,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/models")]
         [ProducesResponseType(typeof(IEnumerable<SeriesSimpleModelDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetModelsInSeries(int id)
         {
             var models = await _repository.GetModelsInSeriesAsync(id);
@@ -102,7 +99,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(ModelSeriesDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Create([FromBody] CreateModelSeriesDto dto)
         {
             // Check if series with same name and author already exists
@@ -149,7 +145,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Update(int id, [FromBody] UpdateModelSeriesDto dto)
         {
             if (id != dto.Id)
@@ -196,7 +191,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> Delete(int id)
         {
             var series = await _repository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/NotificationsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/NotificationsController.cs
@@ -39,7 +39,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of all notifications</returns>
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<NotificationDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllNotifications()
         {
             var notifications = await _notificationService.GetAllNotificationsAsync();
@@ -52,7 +51,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>List of unread notifications</returns>
         [HttpGet("unread")]
         [ProducesResponseType(typeof(IEnumerable<NotificationDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetUnreadNotifications()
         {
             var notifications = await _notificationService.GetUnreadNotificationsAsync();
@@ -67,7 +65,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(NotificationDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetNotificationById(int id)
         {
             var notification = await _notificationService.GetNotificationByIdAsync(id);
@@ -86,7 +83,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(NotificationDto), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateNotification([FromBody] CreateNotificationDto notification)
         {
             var result = await _notificationService.CreateNotificationAsync(notification);
@@ -104,7 +100,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateNotification(int id, [FromBody] UpdateNotificationDto notification)
         {
             // Ensure ID in route matches ID in body
@@ -127,7 +122,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("{id}/read")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> MarkAsRead(int id)
         {
             if (!await _notificationService.MarkNotificationAsReadAsync(id))
@@ -142,7 +136,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>The number of notifications marked as read</returns>
         [HttpPost("mark-all-read")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> MarkAllAsRead()
         {
             var count = await _notificationService.MarkAllNotificationsAsReadAsync();
@@ -158,7 +151,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteNotification(int id)
         {
             if (!await _notificationService.DeleteNotificationAsync(id))

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Keys.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Keys.cs
@@ -18,7 +18,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{providerId}/keys")]
         [ProducesResponseType(typeof(IEnumerable<object>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetProviderKeyCredentials(int providerId)
         {
             var keys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
@@ -50,7 +49,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{providerId}/keys/{keyId}")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetProviderKeyCredential(int providerId, int keyId)
         {
             var key = await _keyRepository.GetByIdAsync(keyId);
@@ -87,7 +85,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateProviderKeyCredential(int providerId, [FromBody] CreateKeyRequest request)
         {
             // Verify provider exists
@@ -157,7 +154,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateProviderKeyCredential(int providerId, int keyId, [FromBody] UpdateKeyRequest request)
         {
             var key = await _keyRepository.GetByIdAsync(keyId);
@@ -245,7 +241,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{providerId}/keys/{keyId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteProviderKeyCredential(int providerId, int keyId)
         {
             var key = await _keyRepository.GetByIdAsync(keyId);
@@ -281,7 +276,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> SetPrimaryKey(int providerId, int keyId)
         {
             var key = await _keyRepository.GetByIdAsync(keyId);

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
@@ -52,7 +52,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <returns>Paginated list of providers</returns>
         [HttpGet]
         [ProducesResponseType(typeof(Configuration.DTOs.PagedResult<object>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllProviders(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50,
@@ -96,7 +95,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetProviderById(int id)
         {
             var provider = await _providerRepository.GetByIdAsync(id);
@@ -125,7 +123,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CreateProvider([FromBody] CreateProviderRequest request)
         {
             var provider = new Provider
@@ -180,7 +177,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateProvider(int id, [FromBody] UpdateProviderRequest request)
         {
             var provider = await _providerRepository.GetByIdAsync(id);
@@ -242,7 +238,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> DeleteProvider(int id)
         {
             var provider = await _providerRepository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Testing.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Testing.cs
@@ -17,7 +17,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("test/{id}")]
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> TestProviderConnection(int id)
         {
             var provider = await _providerRepository.GetByIdAsync(id);
@@ -82,7 +81,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("test")]
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> TestProviderConnectionWithCredentials([FromBody] TestProviderRequest testRequest)
         {
             // Create a temporary provider for testing
@@ -166,7 +164,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpPost("{providerId}/keys/{keyId}/test")]
         [ProducesResponseType(typeof(StandardApiKeyTestResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> TestProviderKeyCredential(int providerId, int keyId)
         {
             var key = await _keyRepository.GetByIdAsync(keyId);

--- a/Services/ConduitLLM.Admin/Controllers/SystemInfoController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/SystemInfoController.cs
@@ -47,7 +47,6 @@ public class SystemInfoController : AdminControllerBase
     /// <returns>System information details</returns>
     [HttpGet("info")]
     [ProducesResponseType(typeof(SystemInfoDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetSystemInfo()
     {
         var result = await _systemInfoService.GetSystemInfoAsync();
@@ -60,7 +59,6 @@ public class SystemInfoController : AdminControllerBase
     /// <returns>Health status information</returns>
     [HttpGet("health")]
     [ProducesResponseType(typeof(HealthStatusDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetHealthStatus()
     {
         var result = await _systemInfoService.GetHealthStatusAsync();
@@ -73,7 +71,6 @@ public class SystemInfoController : AdminControllerBase
     /// <returns>Success response with cache invalidation details</returns>
     [HttpPost("cache/invalidate-discovery")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> InvalidateDiscoveryCache()
     {
         // Publish event to all Gateway API instances via MassTransit
@@ -101,7 +98,6 @@ public class SystemInfoController : AdminControllerBase
     [HttpGet("cache/function-discovery/stats")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetFunctionDiscoveryCacheStats()
     {
         if (_functionDiscoveryCacheService == null)
@@ -123,7 +119,6 @@ public class SystemInfoController : AdminControllerBase
     /// <returns>Success response with cache invalidation details</returns>
     [HttpPost("cache/invalidate-function-discovery")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> InvalidateFunctionDiscoveryCache()
     {
         // Publish event to all Gateway API instances via MassTransit

--- a/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
@@ -52,7 +52,6 @@ namespace ConduitLLM.Admin.Controllers
         /// <param name="cancellationToken">Cancellation token</param>
         [HttpGet]
         [ProducesResponseType(typeof(PagedResult<VirtualKeyGroupDto>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAllGroups(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50,
@@ -249,7 +248,6 @@ namespace ConduitLLM.Admin.Controllers
         [HttpGet("{id}/transactions")]
         [ProducesResponseType(typeof(PagedResult<VirtualKeyGroupTransactionDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetTransactionHistory(
             int id,
             [FromQuery] int page = 1,
@@ -347,7 +345,6 @@ namespace ConduitLLM.Admin.Controllers
         [ProducesResponseType(typeof(RefundResultDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> ProcessRefund(int id, [FromBody] ProcessRefundRequestDto request)
         {
             // Validate request

--- a/Services/ConduitLLM.Admin/Controllers/VirtualKeysController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/VirtualKeysController.cs
@@ -45,7 +45,6 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GenerateKey([FromBody] CreateVirtualKeyRequestDto request)
     {
         var response = await _virtualKeyService.GenerateVirtualKeyAsync(request);
@@ -63,7 +62,6 @@ public class VirtualKeysController : AdminControllerBase
     [HttpGet]
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(List<VirtualKeyDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ListKeys([FromQuery] int? virtualKeyGroupId = null)
     {
         var result = await _virtualKeyService.ListVirtualKeysAsync(virtualKeyGroupId);
@@ -79,7 +77,6 @@ public class VirtualKeysController : AdminControllerBase
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(VirtualKeyDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetKeyById(int id)
     {
         var result = await _virtualKeyService.GetVirtualKeyInfoAsync(id);
@@ -103,7 +100,6 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateKey(int id, [FromBody] UpdateVirtualKeyRequestDto request)
     {
         // Fetch pre-state for change tracking
@@ -156,7 +152,6 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteKey(int id)
     {
         if (!await _virtualKeyService.DeleteVirtualKeyAsync(id))
@@ -176,7 +171,6 @@ public class VirtualKeysController : AdminControllerBase
     [HttpPost("validate")]
     [ProducesResponseType(typeof(VirtualKeyValidationResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     // lgtm [cs/web/missing-function-level-access-control]
     public async Task<IActionResult> ValidateKey([FromBody] ValidateVirtualKeyRequest request)
     {
@@ -196,7 +190,6 @@ public class VirtualKeysController : AdminControllerBase
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(VirtualKeyValidationInfoDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetValidationInfo(int id)
     {
         var result = await _virtualKeyService.GetValidationInfoAsync(id);
@@ -222,7 +215,6 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> PerformMaintenance()
     {
         await _virtualKeyService.PerformMaintenanceAsync();
@@ -239,7 +231,6 @@ public class VirtualKeysController : AdminControllerBase
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(VirtualKeyDiscoveryPreviewDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> PreviewDiscovery(int id, [FromQuery] string? capability = null)
     {
         var result = await _virtualKeyService.PreviewDiscoveryAsync(id, capability);
@@ -259,7 +250,6 @@ public class VirtualKeysController : AdminControllerBase
     [Authorize(Policy = "MasterKeyPolicy")]
     [ProducesResponseType(typeof(VirtualKeyGroupDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetKeyGroup(int id)
     {
         var key = await _virtualKeyService.GetVirtualKeyByIdAsync(id);
@@ -294,7 +284,6 @@ public class VirtualKeysController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetUsageByKey(string key)
     {
         if (string.IsNullOrEmpty(key))

--- a/Services/ConduitLLM.Admin/OpenApi/DefaultErrorResponsesOperationTransformer.cs
+++ b/Services/ConduitLLM.Admin/OpenApi/DefaultErrorResponsesOperationTransformer.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace ConduitLLM.Admin.OpenApi;
+
+/// <summary>
+/// Adds a default "500 Internal Server Error" response to every operation in the OpenAPI document,
+/// documenting the Admin API's universal error behavior (the global <c>AdminExceptionMiddleware</c>
+/// maps unhandled exceptions to a standardized <c>ErrorResponseDto</c>).
+/// </summary>
+/// <remarks>
+/// This lets controllers drop the per-action
+/// <c>[ProducesResponseType(StatusCodes.Status500InternalServerError)]</c> boilerplate — every
+/// endpoint can return 500, so it's documented once here instead of ~150 times (Tier 2b, #905).
+/// </remarks>
+public sealed class DefaultErrorResponsesOperationTransformer : IOpenApiOperationTransformer
+{
+    /// <inheritdoc/>
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        operation.Responses ??= new OpenApiResponses();
+
+        if (!operation.Responses.ContainsKey("500"))
+        {
+            operation.Responses["500"] = new OpenApiResponse
+            {
+                Description = "Internal server error. Returns a standardized ErrorResponseDto."
+            };
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -67,6 +67,9 @@ public partial class Program
         {
             options.AddDocumentTransformer<ConduitLLM.Admin.OpenApi.AdminApiDocumentTransformer>();
             options.AddOperationTransformer<ConduitLLM.Admin.OpenApi.ApiKeySecurityOperationTransformer>();
+            // Tier 2b (#905): document the universal 500 once, so controllers can drop the per-action
+            // [ProducesResponseType(Status500InternalServerError)] boilerplate.
+            options.AddOperationTransformer<ConduitLLM.Admin.OpenApi.DefaultErrorResponsesOperationTransformer>();
         });
 
         // Configure services (partial class methods)


### PR DESCRIPTION
## What

Trims the boilerplate `[ProducesResponseType(StatusCodes.Status500InternalServerError)]` attributes (Tier 2b, #905). Every endpoint can return 500 (the global `AdminExceptionMiddleware` maps unhandled exceptions to a standardized `ErrorResponseDto`), so documenting it ~150× per action is pure noise.

- **New `DefaultErrorResponsesOperationTransformer`** (OpenAPI operation transformer) — documents a `500` response on **every** Admin operation, registered alongside the existing transformers in `AddOpenApi(...)`. So the 500 stays in the OpenAPI doc / Scalar UI, declared once.
- **Removed 151** per-action `[ProducesResponseType(Status500InternalServerError)]` attributes across **22 controllers**.

## Scope (deliberately narrow)

- **Admin only.** All 151 Admin 500 attributes were the untyped standalone form (verified: 0 typed 500s in Admin), so removal is clean and the transformer (description-only) fully preserves their documentation fidelity.
- **Gateway left as-is** — its 7 `500`s are *typed* (`OpenAIErrorResponse`) and few; not worth a schema-aware transformer.
- **400 / 404 / 409 attributes kept** — those are meaningful per-endpoint (a GET-by-id genuinely 404s; a create 400/409s), not universal boilerplate.
- The one **code-level** `StatusCode(Status500InternalServerError, ...)` in `ModelController` is untouched (the removal pattern matched standalone attribute lines only).

## Behavior

**None.** `[ProducesResponseType]` is OpenAPI/metadata only — it has no runtime effect. Removing it changes the generated docs, not the API's behavior.

## Verification

- `dotnet build` (Admin): **0 warnings, 0 errors** — the transformer compiles against the `Microsoft.OpenApi` v2 API (`Microsoft.AspNetCore.OpenApi` 10.0.9) and follows the standard .NET 10 operation-transformer pattern.
- `dotnet test` (`ConduitLLM.Tests.Admin`): **534/534 passing**.
- ⚠️ I could not run the full Admin app here, so a quick **spot-check of `/openapi/v1.json` (or the Scalar UI)** to confirm endpoints still list a `500` is worth doing before merge. (The transformer is 3 trivial lines, so the risk is low.)

Net: **−151 lines** of attribute boilerplate, **+1** small transformer.

Resolves #905. Epic: #901.
