### PR TITLE
test(admin): verify Tier 2b OpenAPI 500s + Tier 3 ModelAuthor endpoints (#905, #906)

### DIFF
--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelAuthorEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelAuthorEndpointsTests.cs
@@ -1,0 +1,347 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+using ConduitLLM.Admin.Endpoints;
+using ConduitLLM.Admin.Middleware;
+using ConduitLLM.Admin.Models.ModelAuthors;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Interfaces;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Admin.Integration
+{
+    /// <summary>
+    /// HTTP-level integration tests for the Tier 3 Minimal-API <see cref="ModelAuthorEndpoints"/>
+    /// (#906), which replaced the MVC <c>ModelAuthorController</c>. These lock down the migrated
+    /// behavior end-to-end — routing, model binding, the not-found/conflict branches, and the
+    /// throw → <c>AdminExceptionMiddleware</c> → standardized <c>ErrorResponseDto</c> mapping that
+    /// the endpoints rely on (previously only unit-level controller coverage, now none existed).
+    /// </summary>
+    /// <remarks>
+    /// Uses an in-process <see cref="TestServer"/> with the real <see cref="AdminExceptionMiddleware"/>,
+    /// the real <see cref="OperationLoggingEndpointFilter"/>, an always-authenticated test scheme, and
+    /// a mocked <see cref="IModelAuthorRepository"/>. This mirrors the existing
+    /// <c>EphemeralMasterKeyIntegrationTests</c> harness pattern (the repo has no
+    /// <c>WebApplicationFactory&lt;Program&gt;</c> suite — Program runs Postgres migrations inline at startup).
+    /// </remarks>
+    [Trait("Category", "Integration")]
+    [Trait("Component", "ModelAuthor")]
+    public class ModelAuthorEndpointsTests : IDisposable
+    {
+        private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+        private readonly Mock<IModelAuthorRepository> _repository = new();
+        private readonly TestServer _server;
+        private readonly HttpClient _client;
+
+        public ModelAuthorEndpointsTests()
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost =>
+                {
+                    webHost.UseTestServer();
+                    webHost.UseEnvironment("Production");
+                    webHost.ConfigureServices(services =>
+                    {
+                        services.AddLogging();
+                        services.AddRouting();
+                        services.AddSingleton(_repository.Object);
+
+                        services.AddAuthentication("Test")
+                            .AddScheme<AuthenticationSchemeOptions, AlwaysAuthenticatedHandler>("Test", null);
+                        services.AddAuthorization(options =>
+                            options.AddPolicy("MasterKeyPolicy", policy => policy.RequireAuthenticatedUser()));
+                    });
+                    webHost.Configure(app =>
+                    {
+                        app.UseRouting();
+                        // Real global handler: endpoint throws map to ErrorResponseDto exactly as in production.
+                        app.UseAdminExceptionHandling();
+                        app.UseAuthentication();
+                        app.UseAuthorization();
+                        app.UseEndpoints(endpoints => endpoints.MapModelAuthorEndpoints());
+                    });
+                })
+                .Start();
+
+            _server = host.GetTestServer();
+            _client = _server.CreateClient();
+        }
+
+        // ---- GetAll -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetAll_ReturnsOk_WithMappedAuthors()
+        {
+            _repository
+                .Setup(r => r.GetPaginatedAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new List<ModelAuthor>
+                {
+                    new() { Id = 1, Name = "OpenAI" },
+                    new() { Id = 2, Name = "Anthropic" }
+                }, 2));
+
+            var response = await _client.GetAsync("/api/ModelAuthor");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var authors = await response.Content.ReadFromJsonAsync<List<ModelAuthorDto>>(Json);
+            authors.Should().HaveCount(2);
+            authors!.Select(a => a.Name).Should().Contain(new[] { "OpenAI", "Anthropic" });
+        }
+
+        // ---- GetById ------------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetById_WhenFound_ReturnsOk()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(7, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ModelAuthor { Id = 7, Name = "Meta", WebsiteUrl = "https://ai.meta.com" });
+
+            var response = await _client.GetAsync("/api/ModelAuthor/7");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var author = await response.Content.ReadFromJsonAsync<ModelAuthorDto>(Json);
+            author!.Id.Should().Be(7);
+            author.Name.Should().Be("Meta");
+        }
+
+        [Fact]
+        public async Task GetById_WhenMissing_Returns404_NotFoundCode()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelAuthor?)null);
+
+            var response = await _client.GetAsync("/api/ModelAuthor/999");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await ReadCodeAsync(response)).Should().Be("not_found");
+        }
+
+        // ---- GetSeriesByAuthor --------------------------------------------------------------
+
+        [Fact]
+        public async Task GetSeriesByAuthor_WhenFound_ReturnsOk_WithSeries()
+        {
+            _repository
+                .Setup(r => r.GetSeriesByAuthorAsync(3, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ModelSeries>
+                {
+                    new() { Id = 10, Name = "GPT", Description = "d", TokenizerType = TokenizerType.None }
+                });
+
+            var response = await _client.GetAsync("/api/ModelAuthor/3/series");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var series = await response.Content.ReadFromJsonAsync<List<SimpleModelSeriesDto>>(Json);
+            series.Should().ContainSingle(s => s.Name == "GPT" && s.Id == 10);
+        }
+
+        [Fact]
+        public async Task GetSeriesByAuthor_WhenAuthorMissing_Returns404()
+        {
+            _repository
+                .Setup(r => r.GetSeriesByAuthorAsync(999, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<ModelSeries>?)null);
+
+            var response = await _client.GetAsync("/api/ModelAuthor/999/series");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await ReadCodeAsync(response)).Should().Be("not_found");
+        }
+
+        // ---- Create -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task Create_WhenNameUnique_Returns201_WithLocationAndBody()
+        {
+            _repository
+                .Setup(r => r.GetByNameAsync("Mistral AI", It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelAuthor?)null);
+            _repository
+                .Setup(r => r.CreateAsync(It.IsAny<ModelAuthor>(), It.IsAny<CancellationToken>()))
+                .Callback<ModelAuthor, CancellationToken>((a, _) => a.Id = 42)
+                .ReturnsAsync(42);
+
+            var response = await _client.PostAsJsonAsync("/api/ModelAuthor",
+                new CreateModelAuthorDto { Name = "Mistral AI", WebsiteUrl = "https://mistral.ai" });
+
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            response.Headers.Location!.ToString().Should().EndWith("/api/ModelAuthor/42");
+            var author = await response.Content.ReadFromJsonAsync<ModelAuthorDto>(Json);
+            author!.Id.Should().Be(42);
+            author.Name.Should().Be("Mistral AI");
+            _repository.Verify(r => r.CreateAsync(It.IsAny<ModelAuthor>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_WhenNameExists_Returns400_InvalidOperation()
+        {
+            _repository
+                .Setup(r => r.GetByNameAsync("OpenAI", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ModelAuthor { Id = 1, Name = "OpenAI" });
+
+            var response = await _client.PostAsJsonAsync("/api/ModelAuthor",
+                new CreateModelAuthorDto { Name = "OpenAI" });
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            (await ReadCodeAsync(response)).Should().Be("invalid_operation");
+            _repository.Verify(r => r.CreateAsync(It.IsAny<ModelAuthor>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // ---- Update -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task Update_WhenIdMismatch_Returns400()
+        {
+            var response = await _client.PutAsJsonAsync("/api/ModelAuthor/1",
+                new UpdateModelAuthorDto { Id = 2, Name = "X" });
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            _repository.Verify(r => r.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Update_WhenMissing_Returns404()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(5, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelAuthor?)null);
+
+            var response = await _client.PutAsJsonAsync("/api/ModelAuthor/5",
+                new UpdateModelAuthorDto { Id = 5, Name = "X" });
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await ReadCodeAsync(response)).Should().Be("not_found");
+        }
+
+        [Fact]
+        public async Task Update_WhenValid_Returns204_AndPersists()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(8, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ModelAuthor { Id = 8, Name = "Cohere" });
+            _repository
+                .Setup(r => r.UpdateAsync(It.IsAny<ModelAuthor>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            // Same name → skips the name-conflict branch; only Description changes.
+            var response = await _client.PutAsJsonAsync("/api/ModelAuthor/8",
+                new UpdateModelAuthorDto { Id = 8, Name = "Cohere", Description = "Enterprise LLMs" });
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            _repository.Verify(r => r.UpdateAsync(
+                It.Is<ModelAuthor>(a => a.Id == 8 && a.Description == "Enterprise LLMs"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        // ---- Delete -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task Delete_WhenMissing_Returns404()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelAuthor?)null);
+
+            var response = await _client.DeleteAsync("/api/ModelAuthor/404");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            (await ReadCodeAsync(response)).Should().Be("not_found");
+        }
+
+        [Fact]
+        public async Task Delete_WhenAuthorHasSeries_Returns400_InvalidOperation()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(6, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ModelAuthor { Id = 6, Name = "Meta" });
+            _repository
+                .Setup(r => r.GetSeriesByAuthorAsync(6, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ModelSeries> { new() { Id = 1, Name = "Llama" } });
+
+            var response = await _client.DeleteAsync("/api/ModelAuthor/6");
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            (await ReadCodeAsync(response)).Should().Be("invalid_operation");
+            _repository.Verify(r => r.DeleteAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_WhenValid_Returns204()
+        {
+            _repository
+                .Setup(r => r.GetByIdAsync(9, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ModelAuthor { Id = 9, Name = "Stability AI" });
+            _repository
+                .Setup(r => r.GetSeriesByAuthorAsync(9, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ModelSeries>());
+            _repository
+                .Setup(r => r.DeleteAsync(9, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var response = await _client.DeleteAsync("/api/ModelAuthor/9");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            _repository.Verify(r => r.DeleteAsync(9, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        /// <summary>Reads the <c>code</c> field from an <c>ErrorResponseDto</c> body, tolerant of casing.</summary>
+        private static async Task<string?> ReadCodeAsync(HttpResponseMessage response)
+        {
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            foreach (var name in new[] { "code", "Code" })
+            {
+                if (doc.RootElement.TryGetProperty(name, out var value))
+                {
+                    return value.GetString();
+                }
+            }
+
+            return null;
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            _server.Dispose();
+        }
+    }
+
+    /// <summary>Test authentication handler that always succeeds, satisfying the MasterKeyPolicy.</summary>
+    internal sealed class AlwaysAuthenticatedHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public AlwaysAuthenticatedHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "TestAdmin") }, Scheme.Name);
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/OpenApi/DefaultErrorResponsesOperationTransformerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/OpenApi/DefaultErrorResponsesOperationTransformerTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Text.Json;
+
+using ConduitLLM.Admin.OpenApi;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Admin.OpenApi
+{
+    /// <summary>
+    /// Unit tests for the Tier 2b (#905) <see cref="DefaultErrorResponsesOperationTransformer"/>, which
+    /// documents the universal 500 once so controllers can drop ~150
+    /// <c>[ProducesResponseType(Status500InternalServerError)]</c> attributes.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "OpenApi")]
+    public class DefaultErrorResponsesOperationTransformerTests
+    {
+        // The transformer ignores the context, so passing null is safe and keeps the test focused.
+        private static async Task TransformAsync(OpenApiOperation operation)
+            => await new DefaultErrorResponsesOperationTransformer()
+                .TransformAsync(operation, null!, CancellationToken.None);
+
+        [Fact]
+        public async Task TransformAsync_AddsA500_WhenAbsent()
+        {
+            var operation = new OpenApiOperation
+            {
+                Responses = new OpenApiResponses
+                {
+                    ["200"] = new OpenApiResponse { Description = "OK" }
+                }
+            };
+
+            await TransformAsync(operation);
+
+            operation.Responses.Should().ContainKey("500");
+            operation.Responses["500"].Description.Should().Contain("ErrorResponseDto");
+        }
+
+        [Fact]
+        public async Task TransformAsync_InitializesResponses_WhenNull()
+        {
+            var operation = new OpenApiOperation { Responses = null };
+
+            await TransformAsync(operation);
+
+            operation.Responses.Should().NotBeNull();
+            operation.Responses.Should().ContainKey("500");
+        }
+
+        [Fact]
+        public async Task TransformAsync_DoesNotOverwrite_ExistingTyped500()
+        {
+            var operation = new OpenApiOperation
+            {
+                Responses = new OpenApiResponses
+                {
+                    ["500"] = new OpenApiResponse { Description = "custom-existing" }
+                }
+            };
+
+            await TransformAsync(operation);
+
+            // A controller that declares its own 500 keeps it — the transformer only fills the gap.
+            operation.Responses["500"].Description.Should().Be("custom-existing");
+        }
+    }
+
+    /// <summary>
+    /// Runtime verification (the "spot-check <c>/openapi/v1.json</c>" gap) that the same transformer
+    /// registered in <c>Program.cs</c> actually injects a documented 500 into every operation of a
+    /// generated OpenAPI document — across both Minimal-API and controller-style operations.
+    /// </summary>
+    [Trait("Category", "Integration")]
+    [Trait("Component", "OpenApi")]
+    public class DefaultErrorResponses500DocumentationTests : IDisposable
+    {
+        private static readonly string[] HttpMethods =
+            { "get", "put", "post", "delete", "options", "head", "patch", "trace" };
+
+        private readonly TestServer _server;
+        private readonly HttpClient _client;
+
+        public DefaultErrorResponses500DocumentationTests()
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webHost =>
+                {
+                    webHost.UseTestServer();
+                    webHost.ConfigureServices(services =>
+                    {
+                        services.AddLogging();
+                        services.AddRouting();
+                        services.AddEndpointsApiExplorer();
+                        services.AddOpenApi("v1", options =>
+                            options.AddOperationTransformer<DefaultErrorResponsesOperationTransformer>());
+                    });
+                    webHost.Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            // Representative operations with varied explicit responses — none declares a 500.
+                            endpoints.MapGet("/things", () => Results.Ok(new[] { "a" }));
+                            endpoints.MapGet("/things/{id:int}", (int id) => Results.Ok(id));
+                            endpoints.MapPost("/things", (SampleDto dto) => Results.Created("/things/1", dto));
+                            endpoints.MapDelete("/things/{id:int}", (int id) => Results.NoContent());
+
+                            endpoints.MapOpenApi();
+                        });
+                    });
+                })
+                .Start();
+
+            _server = host.GetTestServer();
+            _client = _server.CreateClient();
+        }
+
+        [Fact]
+        public async Task GeneratedDocument_DocumentsA500_OnEveryOperation()
+        {
+            var response = await _client.GetAsync("/openapi/v1.json");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            var paths = doc.RootElement.GetProperty("paths");
+
+            var operationCount = 0;
+            foreach (var path in paths.EnumerateObject())
+            {
+                foreach (var member in path.Value.EnumerateObject())
+                {
+                    if (!HttpMethods.Contains(member.Name))
+                    {
+                        continue;
+                    }
+
+                    operationCount++;
+                    member.Value.TryGetProperty("responses", out var responses).Should().BeTrue(
+                        $"operation {member.Name.ToUpperInvariant()} {path.Name} should have responses");
+                    responses.TryGetProperty("500", out _).Should().BeTrue(
+                        $"operation {member.Name.ToUpperInvariant()} {path.Name} should document a 500");
+                }
+            }
+
+            operationCount.Should().BeGreaterThan(0, "the document should contain operations to verify");
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+            _server.Dispose();
+        }
+
+        private sealed class SampleDto
+        {
+            public string Name { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj
+++ b/Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>xUnit2013;CS8632</NoWarn>
+    <!-- Enable interceptors emitted by the Microsoft.AspNetCore.OpenApi source generator, which
+         runs because the OpenAPI runtime tests call AddOpenApi() in this assembly. -->
+    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Closes the two **verification gaps** flagged when Epic #901 landed — the implementation was already merged to `dev`, but two acceptance items were unverified. Adds 17 tests; no production code changes.

### Tier 2b (#905) — OpenAPI 500 documentation
- Unit tests for `DefaultErrorResponsesOperationTransformer`: adds a 500 when absent, initializes a null `Responses`, and **never overwrites** an existing 500.
- **Runtime test** that boots the OpenAPI pipeline and asserts the generated `/openapi/v1.json` documents a 500 on **every** operation — the "spot-check the doc" item that couldn't be done at merge time.

### Tier 3 (#906) — ModelAuthor Minimal-API endpoints
- 13 **HTTP-level integration tests** for `ModelAuthorEndpoints` (which replaced `ModelAuthorController` and previously had **no** behavior tests).
- Covers every branch incl. the throw → `AdminExceptionMiddleware` → `ErrorResponseDto` mapping: dup-name → 400 `invalid_operation`, missing → 404 `not_found`, id-mismatch → 400, create → 201, update/delete → 204.

## How

Uses the existing in-process `TestServer` harness pattern (same as `EphemeralMasterKeyIntegrationTests`) with the **real** `AdminExceptionMiddleware` and `OperationLoggingEndpointFilter`, an always-authenticated test scheme, and a mocked `IModelAuthorRepository`. No `WebApplicationFactory<Program>` — `Program` runs Postgres migrations + seeding inline at startup, so a full-app factory is impractical.

The test `.csproj` gains `<InterceptorsNamespaces>...Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>` — required once `AddOpenApi()` is called inside the test assembly (the OpenAPI source generator emits interceptors).

## Verification

- `dotnet build Tests/ConduitLLM.Tests` → 0 errors
- 17 new tests pass; **Admin slice 551/551** green (534 prior + 17), no regressions.

## Notes

- Behavior-only test PR — touches no `Services/` code.
- Deferred (not in this PR): a written Minimal-API convention doc under `docs/development/` (see #906).