### PR TITLE
feat(messaging): Wolverine bootstrap on PostgreSQL transport behind Messaging:Backend flag (#924)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -1,4 +1,6 @@
+using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
 
 using MassTransit;
 
@@ -11,6 +13,19 @@ public partial class Program
     /// </summary>
     private static void ConfigureMessagingServices(WebApplicationBuilder builder, ILogger startupLogger)
     {
+        // Phase 2 backend flag (#924): when ConduitLLM:Messaging:Backend=Wolverine, boot
+        // the Wolverine host (PostgreSQL transport + durable persistence) alongside
+        // MassTransit. MassTransit below stays the active IEventBus backend until the
+        // Wolverine IEventBus/handler host lands (#925); this stage proves boot and
+        // durability provisioning only.
+        if (MessagingBackendResolver.Resolve(builder.Configuration) == MessagingBackend.Wolverine)
+        {
+            var (_, wolverineConnectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
+                .GetProviderAndConnectionString("AdminAPI", msg => startupLogger.LogInformation("{Message}", msg));
+            builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin");
+            startupLogger.LogInformation("Wolverine host enabled (PostgreSQL transport) behind Messaging:Backend flag (#924); MassTransit remains the active IEventBus backend until #925");
+        }
+
         // Register the Conduit-owned IEventBus abstraction over MassTransit (epic #909).
         builder.Services.AddMassTransitEventBus();
 

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Events;
 using ConduitLLM.Core.Services;
 
@@ -9,6 +10,18 @@ public partial class Program
 {
     public static void ConfigureMessagingServices(WebApplicationBuilder builder)
     {
+        // Phase 2 backend flag (#924): when ConduitLLM:Messaging:Backend=Wolverine, boot
+        // the Wolverine host (PostgreSQL transport + durable persistence) alongside
+        // MassTransit. MassTransit below stays the active IEventBus backend until the
+        // Wolverine IEventBus/handler host lands (#925); this stage proves boot and
+        // durability provisioning only.
+        if (MessagingBackendResolver.Resolve(builder.Configuration) == MessagingBackend.Wolverine)
+        {
+            var (_, wolverineConnectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
+                .GetProviderAndConnectionString("CoreAPI");
+            builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-gateway");
+        }
+
         // Register the Conduit-owned IEventBus abstraction over MassTransit (epic #909).
         // Scoped so follow-on publishes inside a consume scope stay correlation-aware,
         // exactly as injecting IPublishEndpoint behaved before.

--- a/Shared/ConduitLLM.Configuration/ConduitLLM.Configuration.csproj
+++ b/Shared/ConduitLLM.Configuration/ConduitLLM.Configuration.csproj
@@ -41,6 +41,10 @@
 
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.5.7" />
+    <!-- Wolverine backend of the messaging abstraction (epic #909 Phase 2, #924).
+         Spike-verified on this toolchain: docs/architecture/messaging-migration/spike-wolverine-postgres.md -->
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.Postgresql" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared/ConduitLLM.Configuration/Messaging/MessagingBackend.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/MessagingBackend.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Configuration;
+
+namespace ConduitLLM.Configuration.Messaging
+{
+    /// <summary>
+    /// The messaging backend hosting the <see cref="IEventBus"/> / <see cref="IEventHandler{TEvent}"/>
+    /// abstraction (epic #909). Selected at startup by <c>ConduitLLM:Messaging:Backend</c>;
+    /// both backends bind the same contracts and consume the same
+    /// <see cref="EndpointPolicy"/> descriptors, so domain code is backend-agnostic.
+    /// </summary>
+    public enum MessagingBackend
+    {
+        /// <summary>MassTransit over RabbitMQ (multi-instance) or in-memory (single-instance). The Phase 1 default.</summary>
+        MassTransit,
+
+        /// <summary>Wolverine on the PostgreSQL transport with transactional durability (Phase 2).</summary>
+        Wolverine
+    }
+
+    /// <summary>
+    /// Resolves the active <see cref="MessagingBackend"/> from configuration.
+    /// </summary>
+    public static class MessagingBackendResolver
+    {
+        /// <summary>Configuration key selecting the backend. Absent/empty means <see cref="MessagingBackend.MassTransit"/>.</summary>
+        public const string ConfigurationKey = "ConduitLLM:Messaging:Backend";
+
+        /// <summary>
+        /// Reads <see cref="ConfigurationKey"/> and returns the selected backend.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The value is present but not a recognized backend name — misconfiguring the
+        /// cutover flag must fail the boot loudly rather than silently fall back.
+        /// </exception>
+        public static MessagingBackend Resolve(IConfiguration configuration)
+        {
+            var value = configuration[ConfigurationKey];
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return MessagingBackend.MassTransit;
+            }
+
+            if (Enum.TryParse<MessagingBackend>(value.Trim(), ignoreCase: true, out var backend))
+            {
+                return backend;
+            }
+
+            throw new InvalidOperationException(
+                $"Unrecognized messaging backend '{value}' in '{ConfigurationKey}'. " +
+                $"Valid values: {string.Join(", ", Enum.GetNames<MessagingBackend>())}.");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -1,0 +1,83 @@
+using JasperFx;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+using Wolverine;
+using Wolverine.Postgresql;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// Bootstrap for the Wolverine backend of the messaging abstraction (Phase 2 of
+    /// epic #909, I2.1/#924). Configures the Wolverine host on the PostgreSQL
+    /// transport with durable message persistence, reusing the service's existing
+    /// Npgsql database — no new broker.
+    /// </summary>
+    /// <remarks>
+    /// This registers the Wolverine host only. The <see cref="IEventBus"/> adapter and
+    /// the <see cref="IEventHandler{TEvent}"/> handler host land in I2.2/#925; until
+    /// then MassTransit remains the active backend and Wolverine boots idle behind the
+    /// <c>ConduitLLM:Messaging:Backend</c> flag.
+    /// </remarks>
+    public static class WolverineMessagingExtensions
+    {
+        /// <summary>Configuration key for the durability/queue schema name (default <c>wolverine</c>).</summary>
+        public const string SchemaNameKey = "ConduitLLM:Messaging:Wolverine:SchemaName";
+
+        /// <summary>
+        /// Configuration key controlling automatic provisioning of Wolverine's durability
+        /// and queue tables at startup (default <c>true</c>). Production deployments that
+        /// manage schema explicitly set this to <c>false</c> and provision via script —
+        /// see the Phase 2 plan (#924).
+        /// </summary>
+        public const string AutoProvisionKey = "ConduitLLM:Messaging:Wolverine:AutoProvision";
+
+        /// <summary>
+        /// Adds the Wolverine host on the PostgreSQL transport with durable persistence.
+        /// </summary>
+        /// <param name="host">The host builder.</param>
+        /// <param name="configuration">App configuration (schema/provisioning knobs).</param>
+        /// <param name="connectionString">
+        /// The service's PostgreSQL connection string (the same database EF Core uses,
+        /// resolved per-service, e.g. "CoreAPI" / "AdminAPI").
+        /// </param>
+        /// <param name="serviceName">
+        /// Wolverine service identity (e.g. <c>conduit-gateway</c>); distinguishes each
+        /// service's durability agent and node records in the shared database.
+        /// </param>
+        public static IHostBuilder AddConduitWolverine(
+            this IHostBuilder host,
+            IConfiguration configuration,
+            string connectionString,
+            string serviceName)
+        {
+            var schemaName = configuration[SchemaNameKey] ?? "wolverine";
+            var autoProvision = configuration.GetValue(AutoProvisionKey, true);
+
+            return host.UseWolverine(opts =>
+            {
+                opts.ServiceName = serviceName;
+
+                // Persistence (inbox/outbox/scheduled messages) AND the message transport
+                // share the existing Postgres database, in an isolated schema.
+                opts.UsePostgresqlPersistenceAndTransport(connectionString, schemaName);
+
+                // Wraps handlers in a database transaction where one applies — the
+                // foundation for the transactional outbox work in I2.4/#927.
+                opts.Policies.AutoApplyTransactions();
+
+                // Conduit's IEventHandler<T> implementations are named *Handler/*Consumer
+                // with HandleAsync methods, which Wolverine's conventional discovery would
+                // otherwise pick up as native handlers (with IEventContext unresolvable).
+                // Dispatch goes exclusively through the explicit bridge registrations
+                // added in I2.2/#925.
+                opts.Discovery.DisableConventionalDiscovery();
+
+                opts.AutoBuildMessageStorageOnStartup = autoProvision
+                    ? AutoCreate.CreateOrUpdate
+                    : AutoCreate.None;
+            });
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Messaging/MessagingBackendResolverTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/MessagingBackendResolverTests.cs
@@ -1,0 +1,74 @@
+using ConduitLLM.Configuration.Messaging;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    public class MessagingBackendResolverTests
+    {
+        private static IConfiguration BuildConfiguration(string? backendValue)
+        {
+            var values = new Dictionary<string, string?>();
+            if (backendValue != null)
+            {
+                values[MessagingBackendResolver.ConfigurationKey] = backendValue;
+            }
+
+            return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        }
+
+        [Fact]
+        public void Resolve_KeyAbsent_DefaultsToMassTransit()
+        {
+            var result = MessagingBackendResolver.Resolve(BuildConfiguration(null));
+
+            result.Should().Be(MessagingBackend.MassTransit);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Resolve_KeyEmpty_DefaultsToMassTransit(string value)
+        {
+            var result = MessagingBackendResolver.Resolve(BuildConfiguration(value));
+
+            result.Should().Be(MessagingBackend.MassTransit);
+        }
+
+        [Theory]
+        [InlineData("Wolverine")]
+        [InlineData("wolverine")]
+        [InlineData("WOLVERINE")]
+        [InlineData(" Wolverine ")]
+        public void Resolve_WolverineAnyCase_ReturnsWolverine(string value)
+        {
+            var result = MessagingBackendResolver.Resolve(BuildConfiguration(value));
+
+            result.Should().Be(MessagingBackend.Wolverine);
+        }
+
+        [Theory]
+        [InlineData("MassTransit")]
+        [InlineData("masstransit")]
+        public void Resolve_MassTransitAnyCase_ReturnsMassTransit(string value)
+        {
+            var result = MessagingBackendResolver.Resolve(BuildConfiguration(value));
+
+            result.Should().Be(MessagingBackend.MassTransit);
+        }
+
+        [Fact]
+        public void Resolve_UnrecognizedValue_Throws()
+        {
+            var act = () => MessagingBackendResolver.Resolve(BuildConfiguration("Rebus"));
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*Rebus*")
+                .WithMessage("*MassTransit, Wolverine*");
+        }
+    }
+}

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -27,11 +27,25 @@ Both backends bind the **same** `IEventBus`/`IEventHandler<T>` contracts and con
 **same** `EndpointPolicy` descriptors (`ConduitEndpointPolicies`), so handlers and call
 sites are untouched.
 
-## I2.1 — Bootstrap (#924)
+## I2.1 — Bootstrap (#924) — ✅ implemented
 
-- Add `WolverineFx` + `WolverineFx.PostgreSQL` to Gateway and Admin.
-- `builder.Host.UseWolverine(opts => { opts.PersistMessagesWithPostgresql(connString); opts.Policies.AutoApplyTransactions(); })`.
-- Provision durability tables via `opts.Services.AddResourceSetupOnStartup()` / `.AutoProvision()` in dev, or an EF migration for prod (reuse the existing Npgsql connection — no new broker).
+- `WolverineFx` + `WolverineFx.Postgresql` 6.14.0 referenced from `ConduitLLM.Configuration`
+  (same placement as the MassTransit adapter; flows transitively to Gateway/Admin).
+- `AddConduitWolverine(configuration, connectionString, serviceName)`
+  (`ConduitLLM.Configuration.Messaging.Wolverine`) wraps `UseWolverine`:
+  `UsePostgresqlPersistenceAndTransport` on the service's existing EF connection
+  ("CoreAPI"/"AdminAPI"), `Policies.AutoApplyTransactions()`, and
+  **`Discovery.DisableConventionalDiscovery()`** — without it Wolverine's conventions
+  would pick up Conduit's `*Handler`/`*Consumer` classes (whose `HandleAsync` takes an
+  `IEventContext` Wolverine can't resolve). Dispatch is exclusively via the explicit
+  bridges added in #925.
+- Config keys: `ConduitLLM:Messaging:Backend` (`MassTransit` default; unrecognized values
+  **throw at boot**), `…:Wolverine:SchemaName` (default `wolverine`),
+  `…:Wolverine:AutoProvision` (default `true` → `AutoCreate.CreateOrUpdate`; prod sets
+  `false` and provisions by script).
+- Staging note (#924 as landed): with the flag set, the Wolverine host boots **alongside**
+  MassTransit, which remains the active `IEventBus` backend; #925 turns the flag into the
+  either/or composition-root switch shown above.
 - Acceptance: app boots with Wolverine configured but **inactive** (flag still `MassTransit`).
 
 ## I2.2 — IEventBus / handler host on Wolverine (#925)


### PR DESCRIPTION
## Summary

Phase 2 of epic #909 begins: this lands **I2.1 (#924)** — the Wolverine host bootstrap behind a default-off config flag. Zero runtime change with default configuration.

- **Packages:** `WolverineFx` + `WolverineFx.Postgresql` **6.14.0** (spike-verified on the .NET 10 toolchain, see `docs/architecture/messaging-migration/spike-wolverine-postgres.md`), referenced from `ConduitLLM.Configuration` — same placement as the MassTransit adapter.
- **`AddConduitWolverine(configuration, connectionString, serviceName)`** (`ConduitLLM.Configuration.Messaging.Wolverine`): `UsePostgresqlPersistenceAndTransport` on the service's existing EF Postgres connection (no new broker), `Policies.AutoApplyTransactions()` (foundation for the #927 outbox), and `Discovery.DisableConventionalDiscovery()` — Wolverine's conventions would otherwise mis-discover Conduit's `*Handler`/`*Consumer` classes whose `HandleAsync(TEvent, IEventContext, …)` signature it can't resolve. Dispatch will go exclusively through the explicit bridge registrations added in #925.
- **Flag:** `ConduitLLM:Messaging:Backend` = `MassTransit` (default) | `Wolverine`. Unrecognized values **fail the boot loudly** rather than silently falling back — it's a cutover flag. Knobs: `…:Wolverine:SchemaName` (default `wolverine`), `…:Wolverine:AutoProvision` (default `true` → `AutoCreate.CreateOrUpdate`; prod sets `false` and provisions by script).
- **Composition roots (Gateway + Admin):** when the flag is `Wolverine`, the Wolverine host boots **idle alongside** MassTransit, which remains the active `IEventBus` backend until the Wolverine `IEventBus`/handler host lands in #925 (which turns the flag into the either/or switch from the plan).

## Verification

- `dotnet build` — full solution, 0 errors; forced rebuild of `ConduitLLM.Configuration` shows 0 warnings (no Npgsql/package-version conflicts from the new packages).
- `dotnet test --filter FullyQualifiedName~ConduitLLM.Tests.Messaging` — 19/19 pass (10 new `MessagingBackendResolver` tests + existing Phase 1 messaging tests).
- Boot with the flag **set** requires a live Postgres (provisions `wolverine.*` durability tables at startup) — to be exercised in the dev container/staging; with the flag unset the new code path is never entered.

Refs #924 (epic #909)