### PR TITLE
feat(messaging): IEventBus + handler host on Wolverine — flag becomes the backend switch (#925)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -9,28 +9,38 @@ namespace ConduitLLM.Admin;
 public partial class Program
 {
     /// <summary>
-    /// Configures MassTransit event bus with RabbitMQ or in-memory transport.
+    /// Configures the event bus: MassTransit (RabbitMQ or in-memory) by default, or
+    /// Wolverine on the PostgreSQL transport when selected by
+    /// <c>ConduitLLM:Messaging:Backend</c> (epic #909 Phase 2).
     /// </summary>
     private static void ConfigureMessagingServices(WebApplicationBuilder builder, ILogger startupLogger)
     {
-        // Phase 2 backend flag (#924): when ConduitLLM:Messaging:Backend=Wolverine, boot
-        // the Wolverine host (PostgreSQL transport + durable persistence) alongside
-        // MassTransit. MassTransit below stays the active IEventBus backend until the
-        // Wolverine IEventBus/handler host lands (#925); this stage proves boot and
-        // durability provisioning only.
+        // Backend-neutral: the shared cache-invalidation IEventHandler<T> implementations (#919).
+        ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationHandlers(builder.Services);
+
+        // Phase 2 backend switch (#924/#925): ConduitLLM:Messaging:Backend selects the
+        // host for the abstraction. Wolverine runs on the PostgreSQL transport with
+        // durable persistence; MassTransit (default) keeps the Phase 1 wiring unchanged.
         if (MessagingBackendResolver.Resolve(builder.Configuration) == MessagingBackend.Wolverine)
         {
+            builder.Services.AddWolverineEventBus();
+
             var (_, wolverineConnectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
                 .GetProviderAndConnectionString("AdminAPI", msg => startupLogger.LogInformation("{Message}", msg));
-            builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin");
-            startupLogger.LogInformation("Wolverine host enabled (PostgreSQL transport) behind Messaging:Backend flag (#924); MassTransit remains the active IEventBus backend until #925");
+
+            builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin", opts =>
+            {
+                ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
+            });
+
+            startupLogger.LogInformation(
+                "Event bus configured with the Wolverine backend (PostgreSQL transport, durable persistence). " +
+                "Cross-service queue topology follows in #926");
+            return;
         }
 
         // Register the Conduit-owned IEventBus abstraction over MassTransit (epic #909).
         builder.Services.AddMassTransitEventBus();
-
-        // Register the shared cache-invalidation IEventHandler<T> implementations (#919).
-        ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationHandlers(builder.Services);
 
         // Configure RabbitMQ settings
         var rabbitMqConfig = builder.Configuration.GetSection("ConduitLLM:RabbitMQ").Get<ConduitLLM.Configuration.RabbitMqConfiguration>()

--- a/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
@@ -1,9 +1,12 @@
 using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Events;
 
 using MassTransit;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
 
 namespace ConduitLLM.Gateway.Extensions
 {
@@ -65,32 +68,56 @@ namespace ConduitLLM.Gateway.Extensions
         }
 
         /// <summary>
+        /// The event types bridged to the Gateway-hosted cache-invalidation/notification
+        /// handlers. One list drives both backends' bridge registration so they cannot
+        /// drift (epic #909 Phase 2, #925).
+        /// </summary>
+        public static readonly IReadOnlyList<Type> BridgedEventTypes = new[]
+        {
+            typeof(VirtualKeyUpdated),
+            typeof(VirtualKeyCreated),
+            typeof(VirtualKeyDeleted),
+            typeof(SpendUpdated),
+            typeof(ProviderCreated),
+            typeof(ProviderUpdated),
+            typeof(ProviderDeleted),
+            typeof(ModelUpdated),
+            typeof(DiscoveryCacheInvalidationRequested),
+            typeof(AsyncTaskCreated),
+            typeof(AsyncTaskUpdated),
+            typeof(AsyncTaskDeleted),
+            typeof(MediaGenerationCompleted),
+            typeof(VideoGenerationStarted),
+            typeof(ModelMappingChanged),
+            typeof(ModelCostChanged),
+            typeof(IpFilterChanged),
+            typeof(ProviderToolChanged),
+            typeof(Configuration.Events.ProviderKeyCredentialCreated),
+            typeof(Configuration.Events.ProviderKeyCredentialUpdated),
+            typeof(Configuration.Events.ProviderKeyCredentialDeleted),
+            typeof(Configuration.Events.ProviderKeyCredentialPrimaryChanged),
+        };
+
+        /// <summary>
         /// Registers the MassTransit bridge consumers for the Gateway-hosted cache events.
         /// </summary>
         public static void AddGatewayCacheInvalidationBridges(this IRegistrationConfigurator x)
         {
-            x.AddEventBridge<VirtualKeyUpdated>();
-            x.AddEventBridge<VirtualKeyCreated>();
-            x.AddEventBridge<VirtualKeyDeleted>();
-            x.AddEventBridge<SpendUpdated>();
-            x.AddEventBridge<ProviderCreated>();
-            x.AddEventBridge<ProviderUpdated>();
-            x.AddEventBridge<ProviderDeleted>();
-            x.AddEventBridge<ModelUpdated>();
-            x.AddEventBridge<DiscoveryCacheInvalidationRequested>();
-            x.AddEventBridge<AsyncTaskCreated>();
-            x.AddEventBridge<AsyncTaskUpdated>();
-            x.AddEventBridge<AsyncTaskDeleted>();
-            x.AddEventBridge<MediaGenerationCompleted>();
-            x.AddEventBridge<VideoGenerationStarted>();
-            x.AddEventBridge<ModelMappingChanged>();
-            x.AddEventBridge<ModelCostChanged>();
-            x.AddEventBridge<IpFilterChanged>();
-            x.AddEventBridge<ProviderToolChanged>();
-            x.AddEventBridge<Configuration.Events.ProviderKeyCredentialCreated>();
-            x.AddEventBridge<Configuration.Events.ProviderKeyCredentialUpdated>();
-            x.AddEventBridge<Configuration.Events.ProviderKeyCredentialDeleted>();
-            x.AddEventBridge<Configuration.Events.ProviderKeyCredentialPrimaryChanged>();
+            foreach (var eventType in BridgedEventTypes)
+            {
+                x.AddEventBridge(eventType);
+            }
+        }
+
+        /// <summary>
+        /// Registers the Wolverine bridge handlers for the Gateway-hosted cache events (#925).
+        /// </summary>
+        public static void AddGatewayCacheInvalidationBridges(this WolverineOptions options)
+        {
+            foreach (var eventType in BridgedEventTypes)
+            {
+                options.AddEventBridge(eventType);
+            }
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Extensions/MediaGenerationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/MediaGenerationMessagingExtensions.cs
@@ -1,9 +1,12 @@
 using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Events;
 
 using MassTransit;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
 
 namespace ConduitLLM.Gateway.Extensions
 {
@@ -45,21 +48,44 @@ namespace ConduitLLM.Gateway.Extensions
         }
 
         /// <summary>
+        /// The media-generation event types bridged to handlers. One list drives both
+        /// backends' bridge registration so they cannot drift (epic #909 Phase 2, #925).
+        /// </summary>
+        public static readonly IReadOnlyList<Type> BridgedEventTypes = new[]
+        {
+            typeof(ImageGenerationRequested),
+            typeof(ImageGenerationCancelled),
+            typeof(VideoGenerationRequested),
+            typeof(VideoGenerationCancelled),
+            typeof(VideoProgressCheckRequested),
+            typeof(ImageGenerationProgress),
+            typeof(ImageGenerationCompleted),
+            typeof(ImageGenerationFailed),
+            typeof(VideoGenerationProgress),
+            typeof(VideoGenerationCompleted),
+            typeof(VideoGenerationFailed),
+        };
+
+        /// <summary>
         /// Registers the MassTransit bridge consumers for the media-generation events.
         /// </summary>
         public static void AddMediaGenerationBridges(this IRegistrationConfigurator x)
         {
-            x.AddEventBridge<ImageGenerationRequested>();
-            x.AddEventBridge<ImageGenerationCancelled>();
-            x.AddEventBridge<VideoGenerationRequested>();
-            x.AddEventBridge<VideoGenerationCancelled>();
-            x.AddEventBridge<VideoProgressCheckRequested>();
-            x.AddEventBridge<ImageGenerationProgress>();
-            x.AddEventBridge<ImageGenerationCompleted>();
-            x.AddEventBridge<ImageGenerationFailed>();
-            x.AddEventBridge<VideoGenerationProgress>();
-            x.AddEventBridge<VideoGenerationCompleted>();
-            x.AddEventBridge<VideoGenerationFailed>();
+            foreach (var eventType in BridgedEventTypes)
+            {
+                x.AddEventBridge(eventType);
+            }
+        }
+
+        /// <summary>
+        /// Registers the Wolverine bridge handlers for the media-generation events (#925).
+        /// </summary>
+        public static void AddMediaGenerationBridges(this WolverineOptions options)
+        {
+            foreach (var eventType in BridgedEventTypes)
+            {
+                options.AddEventBridge(eventType);
+            }
         }
     }
 }

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -10,32 +10,15 @@ public partial class Program
 {
     public static void ConfigureMessagingServices(WebApplicationBuilder builder)
     {
-        // Phase 2 backend flag (#924): when ConduitLLM:Messaging:Backend=Wolverine, boot
-        // the Wolverine host (PostgreSQL transport + durable persistence) alongside
-        // MassTransit. MassTransit below stays the active IEventBus backend until the
-        // Wolverine IEventBus/handler host lands (#925); this stage proves boot and
-        // durability provisioning only.
-        if (MessagingBackendResolver.Resolve(builder.Configuration) == MessagingBackend.Wolverine)
-        {
-            var (_, wolverineConnectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
-                .GetProviderAndConnectionString("CoreAPI");
-            builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-gateway");
-        }
-
-        // Register the Conduit-owned IEventBus abstraction over MassTransit (epic #909).
-        // Scoped so follow-on publishes inside a consume scope stay correlation-aware,
-        // exactly as injecting IPublishEndpoint behaved before.
-        builder.Services.AddMassTransitEventBus();
-
-        // Register the cache-invalidation / notification IEventHandler<T> implementations (#919).
-        // Their MassTransit bridges are registered inside AddMassTransit below.
+        // Backend-neutral handler registrations — identical for both backends.
+        //
+        // Cache-invalidation / notification IEventHandler<T> implementations (#919):
         ConduitLLM.Gateway.Extensions.CacheInvalidationMessagingExtensions.AddGatewayCacheInvalidationHandlers(builder.Services);
         ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationHandlers(builder.Services);
 
-        // Register the media-generation orchestrator / notification IEventHandler<T>
-        // implementations (#920). Their MassTransit bridges are registered inside
-        // AddMassTransit below; the orchestrator bridges are bound to the tuned
-        // image-/video-generation endpoints.
+        // Media-generation orchestrator / notification IEventHandler<T> implementations
+        // (#920). On MassTransit the orchestrator bridges are bound to the tuned
+        // image-/video-generation endpoints below.
         ConduitLLM.Gateway.Extensions.MediaGenerationMessagingExtensions.AddMediaGenerationHandlers(builder.Services);
 
         // High-risk handlers (#921): ordered spend processing (spend-update-events),
@@ -43,6 +26,20 @@ public partial class Program
         builder.Services.AddEventHandler<ConduitLLM.Core.Events.SpendUpdateRequested, ConduitLLM.Gateway.EventHandlers.SpendUpdateProcessor>();
         builder.Services.AddEventHandler<ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent, ConduitLLM.Gateway.EventHandlers.BatchSpendFlushRequestedHandler>();
         builder.Services.AddEventHandler<ConduitLLM.Core.Events.WebhookDeliveryRequested, ConduitLLM.Gateway.Consumers.WebhookDeliveryConsumer>();
+
+        // Phase 2 backend switch (#924/#925): ConduitLLM:Messaging:Backend selects the
+        // host for the abstraction. Wolverine runs on the PostgreSQL transport with
+        // durable persistence; MassTransit (default) keeps the Phase 1 wiring unchanged.
+        if (MessagingBackendResolver.Resolve(builder.Configuration) == MessagingBackend.Wolverine)
+        {
+            ConfigureWolverineMessaging(builder);
+            return;
+        }
+
+        // Register the Conduit-owned IEventBus abstraction over MassTransit (epic #909).
+        // Scoped so follow-on publishes inside a consume scope stay correlation-aware,
+        // exactly as injecting IPublishEndpoint behaved before.
+        builder.Services.AddMassTransitEventBus();
 
         // Configure RabbitMQ settings
         var rabbitMqConfig = builder.Configuration.GetSection("ConduitLLM:RabbitMQ").Get<ConduitLLM.Configuration.RabbitMqConfiguration>() 
@@ -209,6 +206,43 @@ public partial class Program
                 options.ConcurrentPublishers = 3;
             });
         }
+    }
+
+    /// <summary>
+    /// Wolverine backend wiring (#925): IEventBus adapter + one bridge handler per
+    /// bridged event type, on the PostgreSQL transport with durable persistence.
+    /// Publishes route to the local durable queues of this process's bridges; the
+    /// tuned endpoint policies (ordering, deferral, concurrency — the analogue of the
+    /// RabbitMQ endpoints below) and cross-service queue topology land in I2.3/#926.
+    /// </summary>
+    private static void ConfigureWolverineMessaging(WebApplicationBuilder builder)
+    {
+        builder.Services.AddWolverineEventBus();
+
+        var (_, connectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
+            .GetProviderAndConnectionString("CoreAPI");
+
+        builder.Host.AddConduitWolverine(builder.Configuration, connectionString, "conduit-gateway", opts =>
+        {
+            ConduitLLM.Gateway.Extensions.CacheInvalidationMessagingExtensions.AddGatewayCacheInvalidationBridges(opts);
+            ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
+            ConduitLLM.Gateway.Extensions.MediaGenerationMessagingExtensions.AddMediaGenerationBridges(opts);
+
+            // High-risk bridges (#921): endpoint tuning for these (single/sequential
+            // listener for spend ordering, webhook deferral/concurrency) follows in #926.
+            opts.AddEventBridge<SpendUpdateRequested>();
+            opts.AddEventBridge<WebhookDeliveryRequested>();
+            opts.AddEventBridge<ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent>();
+        });
+
+        // Batch webhook publisher: publishes via IEventBus, so it is backend-agnostic.
+        // Registered unconditionally on Wolverine (there is no RabbitMQ to gate on).
+        builder.Services.AddBatchWebhookPublisher(options =>
+        {
+            options.MaxBatchSize = 100;
+            options.MaxBatchDelay = TimeSpan.FromMilliseconds(100);
+            options.ConcurrentPublishers = 3;
+        });
     }
 
     /// <summary>

--- a/Services/ConduitLLM.Gateway/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Gateway/Program.Monitoring.cs
@@ -42,8 +42,13 @@ public partial class Program
             // Add basic health checks
             var healthChecksBuilder = builder.Services.AddHealthChecks();
 
-            // Add comprehensive RabbitMQ health check if RabbitMQ is configured
-            if (useRabbitMq)
+            // Add comprehensive RabbitMQ health check if RabbitMQ is configured AND the
+            // MassTransit backend is active — the check injects MassTransit's IBus, which
+            // is not registered on the Wolverine backend (#925; Wolverine-native health
+            // checks land in #931).
+            if (useRabbitMq
+                && ConduitLLM.Configuration.Messaging.MessagingBackendResolver.Resolve(builder.Configuration)
+                    == ConduitLLM.Configuration.Messaging.MessagingBackend.MassTransit)
             {
                 healthChecksBuilder.AddCheck<ConduitLLM.Core.HealthChecks.RabbitMQHealthCheck>(
                     "rabbitmq_comprehensive",

--- a/Shared/ConduitLLM.Configuration/ConduitLLM.Configuration.csproj
+++ b/Shared/ConduitLLM.Configuration/ConduitLLM.Configuration.csproj
@@ -45,6 +45,10 @@
          Spike-verified on this toolchain: docs/architecture/messaging-migration/spike-wolverine-postgres.md -->
     <PackageReference Include="WolverineFx" Version="6.14.0" />
     <PackageReference Include="WolverineFx.Postgresql" Version="6.14.0" />
+    <!-- Wolverine 6 no longer ships the runtime (Roslyn) compiler in the core package;
+         without this, hosts fail at startup in the default TypeLoadMode.Dynamic.
+         Pre-generated static codegen is a cutover-time optimization (#930). -->
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shared/ConduitLLM.Configuration/Messaging/MassTransit/MassTransitMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/MassTransit/MassTransitMessagingExtensions.cs
@@ -46,5 +46,15 @@ namespace ConduitLLM.Configuration.Messaging.MassTransit
         {
             configurator.AddConsumer<MassTransitConsumerBridge<TEvent>>();
         }
+
+        /// <summary>
+        /// Non-generic overload of <see cref="AddEventBridge{TEvent}(IRegistrationConfigurator)"/>
+        /// for registering bridges from a shared event-type list (the same list drives the
+        /// Wolverine backend's bridge registration, keeping the two backends in sync).
+        /// </summary>
+        public static void AddEventBridge(this IRegistrationConfigurator configurator, Type eventType)
+        {
+            configurator.AddConsumer(typeof(MassTransitConsumerBridge<>).MakeGenericType(eventType));
+        }
     }
 }

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventBus.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventBus.cs
@@ -1,0 +1,58 @@
+using Wolverine;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// <see cref="IEventBus"/> implementation that delegates to Wolverine's
+    /// <see cref="IMessageBus"/>. This is the Phase 2 backend of the messaging
+    /// abstraction (epic #909, I2.2/#925): call sites are identical to the
+    /// MassTransit backend — routing is by the closed generic event type.
+    /// </summary>
+    /// <remarks>
+    /// Registered scoped, like <c>MassTransitEventBus</c>: Wolverine's
+    /// <see cref="IMessageBus"/> is itself scoped, and inside a handler scope it is the
+    /// active <see cref="IMessageContext"/>, so follow-on publishes from handlers flow
+    /// through the current envelope (correlation-aware) and participate in the
+    /// transactional outbox once a transaction is applied (#927).
+    /// <para>
+    /// Wolverine's publish APIs carry no <see cref="CancellationToken"/>; the token is
+    /// honored by checking it before handing each event to the transport.
+    /// </para>
+    /// </remarks>
+    public sealed class WolverineEventBus : IEventBus
+    {
+        private readonly IMessageBus _bus;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WolverineEventBus"/> class.
+        /// </summary>
+        /// <param name="bus">The Wolverine message bus to delegate to.</param>
+        public WolverineEventBus(IMessageBus bus)
+        {
+            _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        }
+
+        /// <inheritdoc />
+        public Task PublishAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            ArgumentNullException.ThrowIfNull(@event);
+            cancellationToken.ThrowIfCancellationRequested();
+            return _bus.PublishAsync(@event).AsTask();
+        }
+
+        /// <inheritdoc />
+        // Wolverine has no batch-publish API; sequential publishes preserve the
+        // IEventBus contract (the batch is an optimization, not a semantic guarantee).
+        public async Task PublishBatchAsync<TEvent>(IEnumerable<TEvent> events, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            ArgumentNullException.ThrowIfNull(events);
+            foreach (var @event in events)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await _bus.PublishAsync(@event);
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventContext.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventContext.cs
@@ -1,0 +1,82 @@
+using Wolverine;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// Adapts a Wolverine <see cref="IMessageContext"/> to the transport-agnostic
+    /// <see cref="IEventContext"/> handed to <see cref="IEventHandler{TEvent}"/> —
+    /// the mirror of <c>MassTransitEventContext</c>.
+    /// </summary>
+    internal sealed class WolverineEventContext : IEventContext
+    {
+        private readonly IMessageContext _context;
+        private readonly CancellationToken _cancellationToken;
+
+        /// <param name="context">The Wolverine message context for the current delivery.</param>
+        /// <param name="cancellationToken">
+        /// The delivery-lifetime token (Wolverine injects it as a handler method
+        /// parameter rather than exposing it on the context).
+        /// </param>
+        public WolverineEventContext(IMessageContext context, CancellationToken cancellationToken)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _cancellationToken = cancellationToken;
+        }
+
+        /// <inheritdoc />
+        public CancellationToken CancellationToken => _cancellationToken;
+
+        /// <inheritdoc />
+        public Guid? MessageId => _context.Envelope?.Id;
+
+        /// <inheritdoc />
+        public string? CorrelationId => _context.Envelope?.CorrelationId;
+
+        /// <inheritdoc />
+        public bool TryGetHeader(string key, out object? value)
+        {
+            if (_context.Envelope?.Headers is { } headers && headers.TryGetValue(key, out var headerValue))
+            {
+                value = headerValue;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        // Routed through the message context so Wolverine treats it as a cascading
+        // publish from the current envelope (correlation propagated, outbox-aware) —
+        // the equivalent of MassTransit's ConsumeContext.Publish.
+        public Task PublishAsync<TEvent>(TEvent @event, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            ArgumentNullException.ThrowIfNull(@event);
+            cancellationToken.ThrowIfCancellationRequested();
+            return _context.PublishAsync(@event).AsTask();
+        }
+
+        /// <inheritdoc />
+        // Wolverine-native durable scheduling (survives restarts, unlike the
+        // unconfigured MassTransit scheduler this replaces). The scheduled event is
+        // routed by type, which lands it back on the same subscription the current
+        // delivery came from — the ScheduleSend semantics WebhookDeliveryConsumer needs.
+        public Task SchedulePublishAsync<TEvent>(DateTime deliveryTime, TEvent @event, CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            ArgumentNullException.ThrowIfNull(@event);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Callers pass UTC (DateTime.UtcNow + delay); treat an unspecified kind as
+            // UTC rather than letting DateTimeOffset assume server-local time.
+            var deliverAt = deliveryTime.Kind == DateTimeKind.Unspecified
+                ? new DateTimeOffset(deliveryTime, TimeSpan.Zero)
+                : new DateTimeOffset(deliveryTime.ToUniversalTime());
+
+            // Equivalent to the ScheduleAsync extension, but via the interface method so
+            // the scheduling intent is explicit (and testable).
+            return _context.PublishAsync(@event, new DeliveryOptions { ScheduledTime = deliverAt }).AsTask();
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineHandlerBridge.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineHandlerBridge.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+
+using Wolverine;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// Generic Wolverine handler that bridges a delivered <typeparamref name="TEvent"/>
+    /// to every registered <see cref="IEventHandler{TEvent}"/> — the consume half of the
+    /// Wolverine backend (epic #909, I2.2/#925) and the exact mirror of
+    /// <c>MassTransitConsumerBridge&lt;TEvent&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Conventional discovery is disabled (see <c>WolverineMessagingExtensions</c>);
+    /// closed bridge types are registered explicitly per event type via
+    /// <c>AddEventBridge</c>. Wolverine constructs the bridge (and resolves its
+    /// <see cref="IEventHandler{TEvent}"/> dependencies) from the per-message scope, so a
+    /// handler that injects <see cref="IEventBus"/> for follow-on publishes gets the
+    /// scoped, correlation-aware message context.
+    /// <para>
+    /// Handlers are invoked sequentially. An exception from any handler propagates to
+    /// Wolverine, triggering the endpoint's retry / redelivery policy — identical to the
+    /// MassTransit bridge's behavior. Event types delivered to more than one handler are
+    /// all idempotent cache/notification handlers; the ordered/financial/deferred
+    /// endpoints each have exactly one handler.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TEvent">The event type this bridge handles.</typeparam>
+    public sealed class WolverineHandlerBridge<TEvent>
+        where TEvent : class
+    {
+        private readonly IEnumerable<IEventHandler<TEvent>> _handlers;
+        private readonly ILogger<WolverineHandlerBridge<TEvent>> _logger;
+
+        public WolverineHandlerBridge(
+            IEnumerable<IEventHandler<TEvent>> handlers,
+            ILogger<WolverineHandlerBridge<TEvent>> logger)
+        {
+            _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Wolverine handler entry point: dispatches the event to every registered
+        /// <see cref="IEventHandler{TEvent}"/> with a Wolverine-backed
+        /// <see cref="IEventContext"/>.
+        /// </summary>
+        public async Task Handle(TEvent message, IMessageContext context, CancellationToken cancellationToken)
+        {
+            var eventContext = new WolverineEventContext(context, cancellationToken);
+
+            foreach (var handler in _handlers)
+            {
+                // Let exceptions propagate so Wolverine applies the endpoint retry /
+                // redelivery policy, exactly as the MassTransit bridge does.
+                await handler.HandleAsync(message, eventContext);
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using Wolverine;
@@ -46,11 +47,17 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         /// Wolverine service identity (e.g. <c>conduit-gateway</c>); distinguishes each
         /// service's durability agent and node records in the shared database.
         /// </param>
+        /// <param name="configure">
+        /// Per-service Wolverine configuration applied after the Conduit defaults —
+        /// bridge registrations (<see cref="AddEventBridge{TEvent}"/>) and, from
+        /// I2.3/#926, the tuned endpoint policies.
+        /// </param>
         public static IHostBuilder AddConduitWolverine(
             this IHostBuilder host,
             IConfiguration configuration,
             string connectionString,
-            string serviceName)
+            string serviceName,
+            Action<WolverineOptions>? configure = null)
         {
             var schemaName = configuration[SchemaNameKey] ?? "wolverine";
             var autoProvision = configuration.GetValue(AutoProvisionKey, true);
@@ -59,6 +66,13 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
             {
                 opts.ServiceName = serviceName;
 
+                // Wolverine 6 split the Roslyn runtime compiler out of the core package;
+                // the default TypeLoadMode.Dynamic fails at startup without it. Explicit
+                // (rather than relying on referenced-assembly auto-registration) so boot
+                // does not depend on assembly load order. Pre-generated static codegen
+                // ('codegen write' + TypeLoadMode.Static) is a cutover optimization (#930).
+                opts.UseRuntimeCompilation();
+
                 // Persistence (inbox/outbox/scheduled messages) AND the message transport
                 // share the existing Postgres database, in an isolated schema.
                 opts.UsePostgresqlPersistenceAndTransport(connectionString, schemaName);
@@ -66,6 +80,12 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                 // Wraps handlers in a database transaction where one applies — the
                 // foundation for the transactional outbox work in I2.4/#927.
                 opts.Policies.AutoApplyTransactions();
+
+                // Local queues (where in-process bridge handlers receive publishes) are
+                // backed by the Postgres durability tables, so buffered messages survive
+                // a crash — already an improvement on MassTransit's in-memory transport.
+                // Full outbox semantics for the financial paths land in I2.4/#927.
+                opts.Policies.UseDurableLocalQueues();
 
                 // Conduit's IEventHandler<T> implementations are named *Handler/*Consumer
                 // with HandleAsync methods, which Wolverine's conventional discovery would
@@ -77,7 +97,43 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                 opts.AutoBuildMessageStorageOnStartup = autoProvision
                     ? AutoCreate.CreateOrUpdate
                     : AutoCreate.None;
+
+                configure?.Invoke(opts);
             });
+        }
+
+        /// <summary>
+        /// Registers the <see cref="IEventBus"/> adapter over Wolverine's
+        /// <see cref="IMessageBus"/>. Scoped for the same reason as
+        /// <c>AddMassTransitEventBus</c>: inside a handler scope the bus is the active
+        /// message context, so follow-on publishes stay correlation-aware.
+        /// </summary>
+        public static IServiceCollection AddWolverineEventBus(this IServiceCollection services)
+        {
+            services.AddScoped<IEventBus, WolverineEventBus>();
+            return services;
+        }
+
+        /// <summary>
+        /// Registers the generic Wolverine bridge handler for an event type — the
+        /// Wolverine analogue of the MassTransit <c>AddEventBridge</c>. Causes the event
+        /// type to be consumed and dispatched to every registered
+        /// <see cref="IEventHandler{TEvent}"/>. Required because conventional discovery
+        /// is disabled.
+        /// </summary>
+        public static void AddEventBridge<TEvent>(this WolverineOptions options)
+            where TEvent : class
+        {
+            options.AddEventBridge(typeof(TEvent));
+        }
+
+        /// <summary>
+        /// Non-generic overload of <see cref="AddEventBridge{TEvent}(WolverineOptions)"/>
+        /// for registering bridges from a shared event-type list.
+        /// </summary>
+        public static void AddEventBridge(this WolverineOptions options, Type eventType)
+        {
+            options.Discovery.IncludeType(typeof(WolverineHandlerBridge<>).MakeGenericType(eventType));
         }
     }
 }

--- a/Shared/ConduitLLM.Core/Extensions/SharedCacheInvalidationMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Core/Extensions/SharedCacheInvalidationMessagingExtensions.cs
@@ -1,10 +1,13 @@
 using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Consumers;
 using ConduitLLM.Core.Events;
 
 using MassTransit;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
 
 namespace ConduitLLM.Core.Extensions
 {
@@ -25,12 +28,33 @@ namespace ConduitLLM.Core.Extensions
             return services;
         }
 
+        /// <summary>
+        /// The shared Core cache event types bridged to handlers. One list drives both
+        /// backends' bridge registration so they cannot drift (epic #909 Phase 2, #925).
+        /// </summary>
+        public static readonly IReadOnlyList<Type> BridgedEventTypes = new[]
+        {
+            typeof(GlobalSettingChanged),
+            typeof(FunctionConfigurationChanged),
+            typeof(FunctionDiscoveryCacheInvalidationRequested),
+        };
+
         /// <summary>Registers the MassTransit bridge consumers for the shared Core cache events.</summary>
         public static void AddSharedCacheInvalidationBridges(this IRegistrationConfigurator x)
         {
-            x.AddEventBridge<GlobalSettingChanged>();
-            x.AddEventBridge<FunctionConfigurationChanged>();
-            x.AddEventBridge<FunctionDiscoveryCacheInvalidationRequested>();
+            foreach (var eventType in BridgedEventTypes)
+            {
+                x.AddEventBridge(eventType);
+            }
+        }
+
+        /// <summary>Registers the Wolverine bridge handlers for the shared Core cache events (#925).</summary>
+        public static void AddSharedCacheInvalidationBridges(this WolverineOptions options)
+        {
+            foreach (var eventType in BridgedEventTypes)
+            {
+                options.AddEventBridge(eventType);
+            }
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineBridgePilotTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineBridgePilotTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Wolverine;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Pilot end-to-end test for the Wolverine backend (#925) — the mirror of
+    /// <see cref="MassTransitConsumerBridgeTests"/>: a handler written purely against
+    /// <see cref="IEventHandler{TEvent}"/> / <see cref="IEventContext"/> runs when its
+    /// event is published through the Wolverine-backed <see cref="IEventBus"/>, dispatched
+    /// via <see cref="WolverineHandlerBridge{TEvent}"/> on in-memory local queues (no
+    /// Postgres required; conventional discovery disabled, exactly as in production).
+    /// </summary>
+    public class WolverineBridgePilotTests
+    {
+        public record PilotEvent(string Payload);
+
+        public sealed class PilotSink
+        {
+            public List<PilotEvent> Received { get; } = new();
+            public Guid? LastMessageId { get; set; }
+            public string? LastCorrelationId { get; set; }
+            public TaskCompletionSource<PilotEvent> Signal { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public sealed class RecordingPilotHandler : IEventHandler<PilotEvent>
+        {
+            private readonly PilotSink _sink;
+            public RecordingPilotHandler(PilotSink sink) => _sink = sink;
+
+            public Task HandleAsync(PilotEvent @event, IEventContext context)
+            {
+                _sink.Received.Add(@event);
+                _sink.LastMessageId = context.MessageId;
+                _sink.LastCorrelationId = context.CorrelationId;
+                _sink.Signal.TrySetResult(@event);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task PilotHandler_RunsEndToEnd_ViaWolverineBridge()
+        {
+            var sink = new PilotSink();
+
+            using var host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    // Production parity: no conventional discovery; the bridge is the
+                    // only handler registration (WolverineMessagingExtensions does the
+                    // same, minus the Postgres transport this test does not need).
+                    opts.Discovery.DisableConventionalDiscovery();
+                    opts.UseRuntimeCompilation();
+                    opts.AddEventBridge<PilotEvent>();
+
+                    opts.Services.AddSingleton(sink);
+                    opts.Services.AddScoped<IEventHandler<PilotEvent>, RecordingPilotHandler>();
+                    opts.Services.AddWolverineEventBus();
+                })
+                .StartAsync();
+
+            try
+            {
+                using (var scope = host.Services.CreateScope())
+                {
+                    var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                    eventBus.Should().BeOfType<WolverineEventBus>();
+
+                    await eventBus.PublishAsync(new PilotEvent("hello"));
+                }
+
+                // The bridge dispatched the event to the IEventHandler with a usable context.
+                var received = await sink.Signal.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                received.Payload.Should().Be("hello");
+                sink.Received.Should().ContainSingle();
+                sink.LastMessageId.Should().NotBeNull();
+                sink.LastCorrelationId.Should().NotBeNullOrEmpty();
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineEventBusTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineEventBusTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using Moq;
+
+using Wolverine;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Unit tests for the Wolverine <c>IEventBus</c> adapter (#925) — the mirror of
+    /// <see cref="MassTransitEventBusTests"/>.
+    /// </summary>
+    public class WolverineEventBusTests
+    {
+        public record TestEvent(string Payload);
+
+        private readonly Mock<IMessageBus> _busMock = new();
+
+        [Fact]
+        public void Constructor_NullBus_Throws()
+        {
+            var act = () => new WolverineEventBus(null!);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task PublishAsync_DelegatesToWolverineBus()
+        {
+            var bus = new WolverineEventBus(_busMock.Object);
+            var @event = new TestEvent("hello");
+
+            await bus.PublishAsync(@event);
+
+            _busMock.Verify(b => b.PublishAsync(@event, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task PublishAsync_NullEvent_Throws()
+        {
+            var bus = new WolverineEventBus(_busMock.Object);
+
+            var act = () => bus.PublishAsync<TestEvent>(null!);
+
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task PublishAsync_CanceledToken_Throws()
+        {
+            var bus = new WolverineEventBus(_busMock.Object);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var act = () => bus.PublishAsync(new TestEvent("hello"), cts.Token);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+            _busMock.Verify(b => b.PublishAsync(It.IsAny<TestEvent>(), null), Times.Never);
+        }
+
+        [Fact]
+        public async Task PublishBatchAsync_PublishesEachEvent()
+        {
+            var bus = new WolverineEventBus(_busMock.Object);
+            var events = new List<TestEvent> { new("one"), new("two"), new("three") };
+
+            await bus.PublishBatchAsync(events);
+
+            foreach (var @event in events)
+            {
+                _busMock.Verify(b => b.PublishAsync(@event, null), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task PublishBatchAsync_NullEvents_Throws()
+        {
+            var bus = new WolverineEventBus(_busMock.Object);
+
+            var act = () => bus.PublishBatchAsync<TestEvent>(null!);
+
+            await act.Should().ThrowAsync<ArgumentNullException>();
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineHandlerBridgeTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineHandlerBridgeTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Wolverine;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Unit tests for <see cref="WolverineHandlerBridge{TEvent}"/> and the Wolverine-backed
+    /// <c>IEventContext</c> it hands to handlers (#925) — the mirror of the MassTransit
+    /// bridge's behavior: sequential dispatch to every handler, exception propagation, and
+    /// a context that surfaces envelope metadata and cascading/scheduled publishes.
+    /// </summary>
+    public class WolverineHandlerBridgeTests
+    {
+        public record TestEvent(string Payload);
+        public record FollowOnEvent(string Payload);
+
+        private sealed class RecordingHandler : IEventHandler<TestEvent>
+        {
+            public List<TestEvent> Received { get; } = new();
+            public IEventContext? LastContext { get; private set; }
+
+            public Task HandleAsync(TestEvent @event, IEventContext context)
+            {
+                Received.Add(@event);
+                LastContext = context;
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class ThrowingHandler : IEventHandler<TestEvent>
+        {
+            public Task HandleAsync(TestEvent @event, IEventContext context)
+                => throw new InvalidOperationException("handler failed");
+        }
+
+        private static WolverineHandlerBridge<TestEvent> CreateBridge(params IEventHandler<TestEvent>[] handlers)
+            => new(handlers, NullLogger<WolverineHandlerBridge<TestEvent>>.Instance);
+
+        [Fact]
+        public async Task Handle_DispatchesToAllHandlers()
+        {
+            var first = new RecordingHandler();
+            var second = new RecordingHandler();
+            var bridge = CreateBridge(first, second);
+            var @event = new TestEvent("hello");
+
+            await bridge.Handle(@event, Mock.Of<IMessageContext>(), CancellationToken.None);
+
+            first.Received.Should().ContainSingle().Which.Should().Be(@event);
+            second.Received.Should().ContainSingle().Which.Should().Be(@event);
+        }
+
+        [Fact]
+        public async Task Handle_HandlerException_PropagatesToWolverine()
+        {
+            var bridge = CreateBridge(new ThrowingHandler());
+
+            var act = () => bridge.Handle(new TestEvent("boom"), Mock.Of<IMessageContext>(), CancellationToken.None);
+
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("handler failed");
+        }
+
+        [Fact]
+        public async Task Context_SurfacesEnvelopeMetadataAndToken()
+        {
+            var envelope = new Envelope { CorrelationId = "corr-1" };
+            envelope.Headers["x-conduit-test"] = "header-value";
+            var contextMock = new Mock<IMessageContext>();
+            contextMock.SetupGet(c => c.Envelope).Returns(envelope);
+            var handler = new RecordingHandler();
+            var bridge = CreateBridge(handler);
+            using var cts = new CancellationTokenSource();
+
+            await bridge.Handle(new TestEvent("hello"), contextMock.Object, cts.Token);
+
+            var context = handler.LastContext!;
+            context.MessageId.Should().Be(envelope.Id);
+            context.CorrelationId.Should().Be("corr-1");
+            context.CancellationToken.Should().Be(cts.Token);
+            context.TryGetHeader("x-conduit-test", out var value).Should().BeTrue();
+            value.Should().Be("header-value");
+            context.TryGetHeader("missing", out var missing).Should().BeFalse();
+            missing.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Context_PublishAsync_CascadesThroughMessageContext()
+        {
+            var contextMock = new Mock<IMessageContext>();
+            var handler = new RecordingHandler();
+            var bridge = CreateBridge(handler);
+
+            await bridge.Handle(new TestEvent("hello"), contextMock.Object, CancellationToken.None);
+            var followOn = new FollowOnEvent("next");
+            await handler.LastContext!.PublishAsync(followOn);
+
+            contextMock.Verify(c => c.PublishAsync(followOn, null), Times.Once);
+        }
+
+        [Fact]
+        public async Task Context_SchedulePublishAsync_UsesWolverineScheduling()
+        {
+            var contextMock = new Mock<IMessageContext>();
+            var handler = new RecordingHandler();
+            var bridge = CreateBridge(handler);
+            var deliveryTime = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+
+            await bridge.Handle(new TestEvent("hello"), contextMock.Object, CancellationToken.None);
+            var retry = new FollowOnEvent("retry");
+            await handler.LastContext!.SchedulePublishAsync(deliveryTime, retry);
+
+            contextMock.Verify(
+                c => c.PublishAsync(retry, It.Is<DeliveryOptions>(o => o.ScheduledTime == new DateTimeOffset(deliveryTime))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Context_SchedulePublishAsync_TreatsUnspecifiedKindAsUtc()
+        {
+            var contextMock = new Mock<IMessageContext>();
+            var handler = new RecordingHandler();
+            var bridge = CreateBridge(handler);
+            var unspecified = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Unspecified);
+
+            await bridge.Handle(new TestEvent("hello"), contextMock.Object, CancellationToken.None);
+            var retry = new FollowOnEvent("retry");
+            await handler.LastContext!.SchedulePublishAsync(unspecified, retry);
+
+            contextMock.Verify(
+                c => c.PublishAsync(retry, It.Is<DeliveryOptions>(o => o.ScheduledTime == new DateTimeOffset(unspecified, TimeSpan.Zero))),
+                Times.Once);
+        }
+    }
+}

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -48,18 +48,40 @@ sites are untouched.
   either/or composition-root switch shown above.
 - Acceptance: app boots with Wolverine configured but **inactive** (flag still `MassTransit`).
 
-## I2.2 — IEventBus / handler host on Wolverine (#925)
+## I2.2 — IEventBus / handler host on Wolverine (#925) — ✅ implemented
 
-- `WolverineEventBus : IEventBus` → `PublishAsync<T>` delegates to Wolverine `IMessageBus.PublishAsync`.
-- `WolverineEventContext : IEventContext` → wraps Wolverine's message context:
-  `CancellationToken`, `Envelope.Id` → `MessageId`, `Envelope.CorrelationId`, header
-  lookup, `PublishAsync` (cascading), and `SchedulePublishAsync` → `bus.ScheduleAsync(evt, deliveryTime)`.
-- Handler host: a generic Wolverine handler `WolverineHandlerBridge<TEvent>` (or a
-  conventional handler discovered by Wolverine) resolves all `IEventHandler<TEvent>` and
-  invokes each — the mirror of `MassTransitConsumerBridge<TEvent>`. Throwing propagates to
-  Wolverine's retry/redelivery (configured from the descriptors in #926).
-- Acceptance: every event type publishes/consumes via Wolverine in a dev run; the existing
-  abstraction unit tests + the in-memory pilot pass against the Wolverine backend.
+- `WolverineEventBus : IEventBus` (scoped, like the MassTransit adapter — inside a handler
+  scope Wolverine's `IMessageBus` is the active message context, so follow-on publishes are
+  correlation-aware and outbox-eligible). `PublishBatchAsync` = sequential publishes
+  (Wolverine has no batch API; the batch is an optimization, not a semantic guarantee).
+- `WolverineEventContext : IEventContext` → `Envelope.Id`/`CorrelationId`/`Headers`,
+  cascading `PublishAsync`, and `SchedulePublishAsync` →
+  `PublishAsync(evt, new DeliveryOptions { ScheduledTime = … })` (the interface form of
+  `ScheduleAsync`, which is an extension method; unspecified `DateTime.Kind` treated as UTC).
+  The `CancellationToken` is captured from the handler-method parameter (Wolverine does not
+  expose it on the context).
+- `WolverineHandlerBridge<TEvent>.Handle(TEvent, IMessageContext, CancellationToken)` —
+  sequential dispatch to all `IEventHandler<TEvent>`, exceptions propagate to Wolverine's
+  retry. Closed bridge types registered per event type via `AddEventBridge` /
+  `Discovery.IncludeType` (conventional discovery stays off). One shared
+  `BridgedEventTypes` list per extension class drives BOTH backends' registration
+  (`CacheInvalidationMessagingExtensions`, `SharedCacheInvalidationMessagingExtensions`,
+  `MediaGenerationMessagingExtensions`).
+- Composition roots are now the either/or switch from the plan; handler registrations are
+  backend-neutral and shared. `RabbitMQHealthCheck` (injects MassTransit `IBus`) is gated
+  to the MassTransit backend (#931 replaces it). `BatchWebhookPublisher` registers
+  unconditionally on Wolverine (it publishes via `IEventBus`).
+- **Gotcha:** Wolverine 6 split the Roslyn runtime compiler out of the core package —
+  without `WolverineFx.RuntimeCompilation` + `opts.UseRuntimeCompilation()`, hosts throw at
+  startup in the default `TypeLoadMode.Dynamic`. Pre-generated static codegen
+  (`codegen write` + `TypeLoadMode.Static`) is a cutover-time optimization (#930).
+- Local queues are durable (`UseDurableLocalQueues`, Postgres-backed). Publishes route to
+  this process's bridge handlers; **cross-service queue topology is #926 scope** — parity
+  with today's in-memory MassTransit mode, where cross-service invalidation likewise rides
+  the (separate, retained) Redis pub/sub cache bus.
+- Acceptance met: in-memory pilot (`WolverineBridgePilotTests`) publishes via `IEventBus`
+  through the bridge to an `IEventHandler` with envelope metadata; adapter/bridge/context
+  unit tests mirror the MassTransit set.
 
 ## I2.3 — Map the 4 tuned endpoints (#926)
 


### PR DESCRIPTION
## Summary

**Stacked on #944** (retarget to `dev` after it merges). Lands **I2.2 (#925)**: the Wolverine backend of the messaging abstraction. `ConduitLLM:Messaging:Backend=Wolverine` now runs the full `IEventBus`/`IEventHandler<T>` stack on Wolverine and skips MassTransit entirely; the default remains MassTransit with Phase 1 wiring untouched.

- **`WolverineEventBus : IEventBus`** — scoped over `IMessageBus` (inside a handler scope it's the active message context: correlation-aware, outbox-eligible). `PublishBatchAsync` = sequential publishes.
- **`WolverineEventContext : IEventContext`** — `Envelope.Id`/`CorrelationId`/headers, cascading publish, `SchedulePublishAsync` via `DeliveryOptions.ScheduledTime` (durable scheduling; unspecified `DateTime.Kind` treated as UTC).
- **`WolverineHandlerBridge<TEvent>`** — mirror of `MassTransitConsumerBridge<TEvent>`: sequential dispatch to all registered handlers, exceptions propagate to Wolverine's retry. Registered per event type via `Discovery.IncludeType` (conventional discovery stays off).
- **Anti-drift:** each bridge-extension class now exposes a single `BridgedEventTypes` list that drives *both* backends' registration (MassTransit gained a non-generic `AddEventBridge(Type)`).
- **Composition roots** (Gateway + Admin) are the either/or switch from the plan; handler registrations are backend-neutral and shared. `RabbitMQHealthCheck` (injects MassTransit `IBus`) gated to the MassTransit backend (#931 replaces it); `BatchWebhookPublisher` registers on Wolverine unconditionally (it publishes via `IEventBus`).
- **Gotcha found by the pilot test:** Wolverine 6 split the Roslyn compiler out of core — hosts throw at startup in the default `TypeLoadMode.Dynamic` without `WolverineFx.RuntimeCompilation` + `UseRuntimeCompilation()`. Now explicit in the bootstrap; static pre-generated codegen is a #930 optimization.
- Local queues are durable (Postgres-backed). Publishes reach this process's bridges; **cross-service queue topology is #926 scope** — parity with today's in-memory MassTransit mode (cross-service invalidation rides the retained Redis pub/sub cache bus).

## Verification

- `dotnet build` — full solution, 0 errors.
- Messaging suite 32/32, including an **in-memory end-to-end pilot**: `IEventBus` publish → Wolverine local queue → `WolverineHandlerBridge` → `IEventHandler`, envelope metadata asserted (the Wolverine mirror of `MassTransitConsumerBridgeTests`).
- Full unit suite: 2784 pass / 44 fail — failure set **name-identical to the dev baseline** (Redis-environment + pre-existing controller exception-500 tests).
- Not verifiable here: flag-on boot against live Postgres (durability tables + runtime codegen on the real host graph) — dev-container/staging item, same as #944.

Refs #925 (epic #909)