### PR TITLE
feat(messaging): map tuned endpoints + event→queue topology to Wolverine (#926)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -31,11 +31,17 @@ public partial class Program
             builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin", opts =>
             {
                 ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
+
+                // Event→queue topology (#926): the same publish routing as the Gateway
+                // (so Admin publishes land on the Gateway's queues), listening only on
+                // admin-events (the shared cache events).
+                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
+                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitAdmin(opts);
             });
 
             startupLogger.LogInformation(
-                "Event bus configured with the Wolverine backend (PostgreSQL transport, durable persistence). " +
-                "Cross-service queue topology follows in #926");
+                "Event bus configured with the Wolverine backend (PostgreSQL transport, durable persistence, " +
+                "shared event->queue topology). Admin publishes route to the Gateway's tuned queues");
             return;
         }
 

--- a/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
@@ -70,33 +70,12 @@ namespace ConduitLLM.Gateway.Extensions
         /// <summary>
         /// The event types bridged to the Gateway-hosted cache-invalidation/notification
         /// handlers. One list drives both backends' bridge registration so they cannot
-        /// drift (epic #909 Phase 2, #925).
+        /// drift (epic #909 Phase 2, #925); the canonical list lives in
+        /// <see cref="ConduitLLM.Core.Messaging.ConduitMessagingTopology"/> because the
+        /// Wolverine queue routing (#926) needs it from both hosts.
         /// </summary>
-        public static readonly IReadOnlyList<Type> BridgedEventTypes = new[]
-        {
-            typeof(VirtualKeyUpdated),
-            typeof(VirtualKeyCreated),
-            typeof(VirtualKeyDeleted),
-            typeof(SpendUpdated),
-            typeof(ProviderCreated),
-            typeof(ProviderUpdated),
-            typeof(ProviderDeleted),
-            typeof(ModelUpdated),
-            typeof(DiscoveryCacheInvalidationRequested),
-            typeof(AsyncTaskCreated),
-            typeof(AsyncTaskUpdated),
-            typeof(AsyncTaskDeleted),
-            typeof(MediaGenerationCompleted),
-            typeof(VideoGenerationStarted),
-            typeof(ModelMappingChanged),
-            typeof(ModelCostChanged),
-            typeof(IpFilterChanged),
-            typeof(ProviderToolChanged),
-            typeof(Configuration.Events.ProviderKeyCredentialCreated),
-            typeof(Configuration.Events.ProviderKeyCredentialUpdated),
-            typeof(Configuration.Events.ProviderKeyCredentialDeleted),
-            typeof(Configuration.Events.ProviderKeyCredentialPrimaryChanged),
-        };
+        public static IReadOnlyList<Type> BridgedEventTypes =>
+            ConduitLLM.Core.Messaging.ConduitMessagingTopology.GatewayCacheInvalidationEvents;
 
         /// <summary>
         /// Registers the MassTransit bridge consumers for the Gateway-hosted cache events.

--- a/Services/ConduitLLM.Gateway/Extensions/MediaGenerationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/MediaGenerationMessagingExtensions.cs
@@ -49,22 +49,16 @@ namespace ConduitLLM.Gateway.Extensions
 
         /// <summary>
         /// The media-generation event types bridged to handlers. One list drives both
-        /// backends' bridge registration so they cannot drift (epic #909 Phase 2, #925).
+        /// backends' bridge registration so they cannot drift (epic #909 Phase 2, #925);
+        /// the canonical per-queue lists live in
+        /// <see cref="ConduitLLM.Core.Messaging.ConduitMessagingTopology"/> because the
+        /// Wolverine queue routing (#926) needs them from both hosts.
         /// </summary>
-        public static readonly IReadOnlyList<Type> BridgedEventTypes = new[]
-        {
-            typeof(ImageGenerationRequested),
-            typeof(ImageGenerationCancelled),
-            typeof(VideoGenerationRequested),
-            typeof(VideoGenerationCancelled),
-            typeof(VideoProgressCheckRequested),
-            typeof(ImageGenerationProgress),
-            typeof(ImageGenerationCompleted),
-            typeof(ImageGenerationFailed),
-            typeof(VideoGenerationProgress),
-            typeof(VideoGenerationCompleted),
-            typeof(VideoGenerationFailed),
-        };
+        public static readonly IReadOnlyList<Type> BridgedEventTypes =
+            ConduitLLM.Core.Messaging.ConduitMessagingTopology.ImageGenerationEvents
+                .Concat(ConduitLLM.Core.Messaging.ConduitMessagingTopology.VideoGenerationEvents)
+                .Concat(ConduitLLM.Core.Messaging.ConduitMessagingTopology.MediaGenerationDefaultEvents)
+                .ToArray();
 
         /// <summary>
         /// Registers the MassTransit bridge consumers for the media-generation events.

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -209,11 +209,14 @@ public partial class Program
     }
 
     /// <summary>
-    /// Wolverine backend wiring (#925): IEventBus adapter + one bridge handler per
-    /// bridged event type, on the PostgreSQL transport with durable persistence.
-    /// Publishes route to the local durable queues of this process's bridges; the
-    /// tuned endpoint policies (ordering, deferral, concurrency — the analogue of the
-    /// RabbitMQ endpoints below) and cross-service queue topology land in I2.3/#926.
+    /// Wolverine backend wiring (#925/#926): IEventBus adapter + one bridge handler per
+    /// bridged event type, on the PostgreSQL transport with durable persistence. Events
+    /// route through the shared queue topology (<c>ConduitMessagingTopology</c>): the four
+    /// tuned queues carry the <c>ConduitEndpointPolicies</c> descriptors translated by
+    /// <c>WolverineEndpointPolicy</c> (strict ordering for spend/image, concurrency cap +
+    /// circuit breaker for webhooks, per-type retry rules), everything else rides
+    /// <c>gateway-events</c>. Cross-service delivery (Admin→Gateway) flows over the same
+    /// queues.
     /// </summary>
     private static void ConfigureWolverineMessaging(WebApplicationBuilder builder)
     {
@@ -228,11 +231,16 @@ public partial class Program
             ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
             ConduitLLM.Gateway.Extensions.MediaGenerationMessagingExtensions.AddMediaGenerationBridges(opts);
 
-            // High-risk bridges (#921): endpoint tuning for these (single/sequential
-            // listener for spend ordering, webhook deferral/concurrency) follows in #926.
+            // High-risk bridges (#921); their endpoint tuning is applied by
+            // ListenAsConduitGateway below (#926).
             opts.AddEventBridge<SpendUpdateRequested>();
             opts.AddEventBridge<WebhookDeliveryRequested>();
             opts.AddEventBridge<ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent>();
+
+            // Event→queue topology (#926): publish routing identical on all hosts;
+            // the Gateway listens on the four tuned queues + gateway-events.
+            ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
+            ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitGateway(opts);
         });
 
         // Batch webhook publisher: publishes via IEventBus, so it is backend-agnostic.

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
@@ -1,0 +1,156 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+
+using Wolverine;
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Postgresql;
+using Wolverine.Runtime.Handlers;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// Translates the transport-agnostic <see cref="EndpointPolicy"/> descriptors
+    /// (<see cref="ConduitEndpointPolicies"/>) into Wolverine primitives — the Wolverine
+    /// analogue of the Gateway's <c>ApplyRabbitMqEndpointPolicy</c> /
+    /// <c>MassTransitEndpointPolicy.ApplyResiliencePolicies</c> (epic #909, I2.3/#926).
+    /// </summary>
+    /// <remarks>
+    /// Mapping notes:
+    /// <list type="bullet">
+    /// <item><c>SingleActiveConsumer</c> → <c>ListenWithStrictOrdering</c>: exactly one
+    /// node listens at a time with sequential handling — the cluster-wide equivalent of
+    /// RabbitMQ's <c>x-single-active-consumer</c> + <c>ConcurrentMessageLimit = 1</c>.</item>
+    /// <item><c>ConcurrentMessageLimit</c> → <c>MaximumParallelMessages</c>; null inherits
+    /// Wolverine's default. <c>PrefetchCount</c> has no Postgres-transport analogue (the
+    /// listener batches its own polling).</item>
+    /// <item><c>Retry</c> → failure rules scoped to the endpoint's message types (see
+    /// <see cref="ComputeRetryCooldowns"/>); <c>DelayedRedeliveryIntervals</c> →
+    /// scheduled retries after the inline attempts. Exhausted messages land in
+    /// Wolverine's Postgres dead-letter storage.</item>
+    /// <item><c>CircuitBreaker</c> → the listener circuit breaker (pauses the listener).</item>
+    /// <item><c>QuorumQueue</c>/<c>QueueArguments</c> are RabbitMQ-native and do not apply;
+    /// <c>RateLimit</c> (webhook 100/s) is intentionally NOT translated — the app-level
+    /// webhook rate limiting/circuit breaking is retained, per the Phase 2 plan.</item>
+    /// </list>
+    /// </remarks>
+    public static class WolverineEndpointPolicy
+    {
+        /// <summary>
+        /// Configures a listener for the policy's queue on this host and registers the
+        /// policy's retry rules for the given event types. Call only on the host that
+        /// consumes the queue; publishers need only the routing rules
+        /// (<c>PublishMessage(...).ToPostgresqlQueue(policy.Name)</c>).
+        /// </summary>
+        /// <param name="options">The Wolverine options under configuration.</param>
+        /// <param name="policy">The tuned endpoint descriptor.</param>
+        /// <param name="eventTypes">The event types consumed on this endpoint.</param>
+        public static void ListenWithPolicy(this WolverineOptions options, EndpointPolicy policy, IReadOnlyList<Type> eventTypes)
+        {
+            var listener = options.ListenToPostgresqlQueue(policy.Name);
+
+            if (policy.SingleActiveConsumer || policy.ConcurrentMessageLimit == 1)
+            {
+                // Cluster-wide single active listener + sequential handling: strict
+                // ordering across all nodes (spend-update-events / image-generation-events).
+                listener.ListenWithStrictOrdering();
+            }
+            else if (policy.ConcurrentMessageLimit is int limit)
+            {
+                listener.MaximumParallelMessages(limit);
+            }
+
+            if (policy.CircuitBreaker is { } breaker)
+            {
+                listener.CircuitBreaker(cb =>
+                {
+                    cb.TrackingPeriod = breaker.TrackingPeriod;
+                    cb.FailurePercentageThreshold = breaker.TripThreshold;
+                    cb.MinimumThreshold = breaker.ActiveThreshold;
+                    cb.PauseTime = breaker.ResetInterval;
+                });
+            }
+
+            if (policy.Retry is not null || policy.DelayedRedeliveryIntervals is not null)
+            {
+                options.Policies.Add(new EndpointRetryHandlerPolicy(
+                    eventTypes,
+                    policy.Retry is { } retry ? ComputeRetryCooldowns(retry) : Array.Empty<TimeSpan>(),
+                    policy.DelayedRedeliveryIntervals?.ToArray()));
+            }
+        }
+
+        /// <summary>
+        /// Expands a <see cref="RetryPolicy"/> descriptor into the per-attempt cooldowns
+        /// Wolverine's <c>RetryWithCooldown</c> expects. Immediate → zero delays;
+        /// Incremental → min + step·attempt; Exponential → min + step·(2ⁿ−1) capped at max
+        /// (the same shape MassTransit's <c>Exponential</c> produces).
+        /// </summary>
+        public static TimeSpan[] ComputeRetryCooldowns(RetryPolicy retry)
+        {
+            var cooldowns = new TimeSpan[retry.RetryCount];
+            for (var attempt = 0; attempt < retry.RetryCount; attempt++)
+            {
+                cooldowns[attempt] = retry.Kind switch
+                {
+                    RetryKind.Immediate => TimeSpan.Zero,
+                    RetryKind.Incremental =>
+                        (retry.MinInterval ?? TimeSpan.Zero) + (retry.IntervalStep ?? TimeSpan.Zero) * attempt,
+                    RetryKind.Exponential => Cap(
+                        (retry.MinInterval ?? TimeSpan.Zero) + (retry.IntervalStep ?? TimeSpan.Zero) * (Math.Pow(2, attempt) - 1),
+                        retry.MaxInterval),
+                    _ => TimeSpan.Zero,
+                };
+            }
+
+            return cooldowns;
+        }
+
+        private static TimeSpan Cap(TimeSpan value, TimeSpan? max)
+            => max is { } m && value > m ? m : value;
+
+        /// <summary>
+        /// Applies an endpoint descriptor's retry shape as failure rules on the handler
+        /// chains of that endpoint's message types only — Wolverine's failure-rule DSL is
+        /// either global or generically typed, and the endpoint policies carry runtime
+        /// <see cref="Type"/> lists, hence this <see cref="IHandlerPolicy"/>.
+        /// </summary>
+        internal sealed class EndpointRetryHandlerPolicy : IHandlerPolicy
+        {
+            private readonly HashSet<Type> _messageTypes;
+            private readonly TimeSpan[] _cooldowns;
+            private readonly TimeSpan[]? _scheduledRetries;
+
+            public EndpointRetryHandlerPolicy(
+                IEnumerable<Type> messageTypes,
+                TimeSpan[] cooldowns,
+                TimeSpan[]? scheduledRetries)
+            {
+                _messageTypes = new HashSet<Type>(messageTypes);
+                _cooldowns = cooldowns;
+                _scheduledRetries = scheduledRetries;
+            }
+
+            public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+            {
+                foreach (var chain in chains)
+                {
+                    if (!_messageTypes.Contains(chain.MessageType))
+                    {
+                        continue;
+                    }
+
+                    if (_cooldowns.Length > 0)
+                    {
+                        chain.OnException<Exception>().RetryWithCooldown(_cooldowns);
+                    }
+
+                    if (_scheduledRetries is { Length: > 0 })
+                    {
+                        chain.OnException<Exception>().ScheduleRetry(_scheduledRetries);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
+++ b/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
@@ -1,0 +1,175 @@
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Extensions;
+
+using Wolverine;
+using Wolverine.Postgresql;
+
+namespace ConduitLLM.Core.Messaging
+{
+    /// <summary>
+    /// The canonical event→queue topology for the Wolverine backend (epic #909,
+    /// I2.3/#926). On MassTransit/RabbitMQ, topology is exchange-based and derived from
+    /// consumer registrations; Postgres queues are point-to-point, so the routing must be
+    /// declared. This class is the single source of truth: publish routing is applied
+    /// identically on every host (rules for types a host never publishes are inert), and
+    /// each host listens only to its own queues.
+    /// </summary>
+    /// <remarks>
+    /// Queue plan (all durable, in the shared Wolverine schema):
+    /// <list type="bullet">
+    /// <item>The four tuned queues from <see cref="ConduitEndpointPolicies"/>
+    /// (webhook-delivery, spend-update-events, video-/image-generation-events) — Gateway
+    /// listens with the translated policies.</item>
+    /// <item><c>gateway-events</c> — every other Gateway-consumed event (cache
+    /// invalidation, media progress/completed/failed, batch spend flush).</item>
+    /// <item><c>admin-events</c> — the shared cache events Admin also consumes. Shared
+    /// event types are routed to BOTH service queues (the fan-out RabbitMQ's exchange
+    /// topology used to provide).</item>
+    /// </list>
+    /// Multiple instances of one service compete on their queue — the same
+    /// one-consumer-per-event semantics as today's per-service RabbitMQ queues (per-instance
+    /// cache fan-out remains the job of the separate Redis pub/sub cache bus).
+    /// </remarks>
+    public static class ConduitMessagingTopology
+    {
+        /// <summary>Default queue for Gateway-consumed events without a tuned policy.</summary>
+        public const string GatewayEventsQueue = "gateway-events";
+
+        /// <summary>Queue for the shared cache events consumed by the Admin host.</summary>
+        public const string AdminEventsQueue = "admin-events";
+
+        /// <summary>webhook-delivery (tuned: <see cref="ConduitEndpointPolicies.WebhookDelivery"/>).</summary>
+        public static readonly IReadOnlyList<Type> WebhookDeliveryEvents = new[]
+        {
+            typeof(WebhookDeliveryRequested),
+        };
+
+        /// <summary>spend-update-events (tuned: <see cref="ConduitEndpointPolicies.SpendUpdate"/>).</summary>
+        public static readonly IReadOnlyList<Type> SpendUpdateEvents = new[]
+        {
+            typeof(SpendUpdateRequested),
+        };
+
+        /// <summary>video-generation-events (tuned: <see cref="ConduitEndpointPolicies.VideoGeneration"/>).</summary>
+        public static readonly IReadOnlyList<Type> VideoGenerationEvents = new[]
+        {
+            typeof(VideoGenerationRequested),
+            typeof(VideoGenerationCancelled),
+            typeof(VideoProgressCheckRequested),
+        };
+
+        /// <summary>image-generation-events (tuned: <see cref="ConduitEndpointPolicies.ImageGeneration"/>).</summary>
+        public static readonly IReadOnlyList<Type> ImageGenerationEvents = new[]
+        {
+            typeof(ImageGenerationRequested),
+            typeof(ImageGenerationCancelled),
+        };
+
+        /// <summary>
+        /// Gateway-hosted cache-invalidation / notification events (the Gateway's
+        /// <c>CacheInvalidationMessagingExtensions</c> derives its bridge list from this).
+        /// </summary>
+        public static readonly IReadOnlyList<Type> GatewayCacheInvalidationEvents = new[]
+        {
+            typeof(VirtualKeyUpdated),
+            typeof(VirtualKeyCreated),
+            typeof(VirtualKeyDeleted),
+            typeof(SpendUpdated),
+            typeof(ProviderCreated),
+            typeof(ProviderUpdated),
+            typeof(ProviderDeleted),
+            typeof(ModelUpdated),
+            typeof(DiscoveryCacheInvalidationRequested),
+            typeof(AsyncTaskCreated),
+            typeof(AsyncTaskUpdated),
+            typeof(AsyncTaskDeleted),
+            typeof(MediaGenerationCompleted),
+            typeof(VideoGenerationStarted),
+            typeof(ModelMappingChanged),
+            typeof(ModelCostChanged),
+            typeof(IpFilterChanged),
+            typeof(ProviderToolChanged),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialCreated),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialUpdated),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialDeleted),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialPrimaryChanged),
+        };
+
+        /// <summary>
+        /// Media-generation notification events consumed on the default endpoint (the
+        /// orchestrator request/cancel/progress-check types ride the tuned queues above).
+        /// </summary>
+        public static readonly IReadOnlyList<Type> MediaGenerationDefaultEvents = new[]
+        {
+            typeof(ImageGenerationProgress),
+            typeof(ImageGenerationCompleted),
+            typeof(ImageGenerationFailed),
+            typeof(VideoGenerationProgress),
+            typeof(VideoGenerationCompleted),
+            typeof(VideoGenerationFailed),
+        };
+
+        /// <summary>
+        /// Everything routed to <see cref="GatewayEventsQueue"/>: cache invalidation,
+        /// media notifications, and the batch spend flush.
+        /// </summary>
+        public static readonly IReadOnlyList<Type> GatewayEvents =
+            GatewayCacheInvalidationEvents
+                .Concat(MediaGenerationDefaultEvents)
+                .Append(typeof(ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent))
+                .ToArray();
+
+        /// <summary>
+        /// Shared cache events consumed by BOTH hosts — routed to both service queues.
+        /// </summary>
+        public static IReadOnlyList<Type> SharedEvents =>
+            SharedCacheInvalidationMessagingExtensions.BridgedEventTypes;
+
+        /// <summary>
+        /// Declares the publish routing rules. Applied identically on every host so an
+        /// event lands on its consumer's queue no matter which service publishes it.
+        /// </summary>
+        public static void ApplyConduitPublishRouting(this WolverineOptions options)
+        {
+            RouteAll(options, WebhookDeliveryEvents, ConduitEndpointPolicies.WebhookDelivery.Name);
+            RouteAll(options, SpendUpdateEvents, ConduitEndpointPolicies.SpendUpdate.Name);
+            RouteAll(options, VideoGenerationEvents, ConduitEndpointPolicies.VideoGeneration.Name);
+            RouteAll(options, ImageGenerationEvents, ConduitEndpointPolicies.ImageGeneration.Name);
+            RouteAll(options, GatewayEvents, GatewayEventsQueue);
+
+            // Fan-out: shared cache events go to both services' queues.
+            RouteAll(options, SharedEvents, GatewayEventsQueue);
+            RouteAll(options, SharedEvents, AdminEventsQueue);
+        }
+
+        /// <summary>
+        /// Gateway-side listeners: the four tuned queues with their translated policies
+        /// plus the default <see cref="GatewayEventsQueue"/>.
+        /// </summary>
+        public static void ListenAsConduitGateway(this WolverineOptions options)
+        {
+            options.ListenWithPolicy(ConduitEndpointPolicies.WebhookDelivery, WebhookDeliveryEvents);
+            options.ListenWithPolicy(ConduitEndpointPolicies.SpendUpdate, SpendUpdateEvents);
+            options.ListenWithPolicy(ConduitEndpointPolicies.VideoGeneration, VideoGenerationEvents);
+            options.ListenWithPolicy(ConduitEndpointPolicies.ImageGeneration, ImageGenerationEvents);
+
+            options.ListenToPostgresqlQueue(GatewayEventsQueue);
+        }
+
+        /// <summary>Admin-side listener: the shared cache events queue.</summary>
+        public static void ListenAsConduitAdmin(this WolverineOptions options)
+        {
+            options.ListenToPostgresqlQueue(AdminEventsQueue);
+        }
+
+        private static void RouteAll(WolverineOptions options, IReadOnlyList<Type> eventTypes, string queueName)
+        {
+            foreach (var eventType in eventTypes)
+            {
+                options.PublishMessage(eventType).ToPostgresqlQueue(queueName);
+            }
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineEndpointPolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineEndpointPolicyTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+using ConduitLLM.Core.Messaging;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Tests for the Wolverine translation of the tuned endpoint descriptors (#926):
+    /// the retry-cooldown expansion and the invariants of the shared event→queue topology.
+    /// </summary>
+    public class WolverineEndpointPolicyTests
+    {
+        [Fact]
+        public void ComputeRetryCooldowns_Immediate_AllZero()
+        {
+            var cooldowns = WolverineEndpointPolicy.ComputeRetryCooldowns(RetryPolicy.Immediate(3));
+
+            cooldowns.Should().Equal(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void ComputeRetryCooldowns_Incremental_LinearBackoff()
+        {
+            // video-generation-events: Incremental(3, 2s, 5s)
+            var cooldowns = WolverineEndpointPolicy.ComputeRetryCooldowns(
+                ConduitEndpointPolicies.VideoGeneration.Retry!);
+
+            cooldowns.Should().Equal(
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(7),
+                TimeSpan.FromSeconds(12));
+        }
+
+        [Fact]
+        public void ComputeRetryCooldowns_Exponential_DoublingCappedAtMax()
+        {
+            // webhook-delivery: Exponential(3, 1s, 30s, 2s) → 1s, 3s, 7s (min + step·(2ⁿ−1))
+            var cooldowns = WolverineEndpointPolicy.ComputeRetryCooldowns(
+                ConduitEndpointPolicies.WebhookDelivery.Retry!);
+
+            cooldowns.Should().Equal(
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(7));
+        }
+
+        [Fact]
+        public void ComputeRetryCooldowns_Exponential_CapsAtMaxInterval()
+        {
+            var cooldowns = WolverineEndpointPolicy.ComputeRetryCooldowns(
+                RetryPolicy.Exponential(5, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2)));
+
+            cooldowns.Should().Equal(
+                TimeSpan.FromSeconds(1),   // 1 + 2·(2⁰·2−2)/... = 1 + 2·1−2 → 1
+                TimeSpan.FromSeconds(3),   // 1 + 2·(2¹−1) = 3
+                TimeSpan.FromSeconds(7),   // 1 + 2·(2²−1) = 7
+                TimeSpan.FromSeconds(10),  // 1 + 2·(2³−1) = 15 → capped 10
+                TimeSpan.FromSeconds(10)); // capped
+        }
+
+        [Fact]
+        public void Topology_TunedAndDefaultQueues_CoverEveryGatewayBridgedEventExactlyOnce()
+        {
+            var routed = ConduitMessagingTopology.WebhookDeliveryEvents
+                .Concat(ConduitMessagingTopology.SpendUpdateEvents)
+                .Concat(ConduitMessagingTopology.VideoGenerationEvents)
+                .Concat(ConduitMessagingTopology.ImageGenerationEvents)
+                .Concat(ConduitMessagingTopology.GatewayEvents)
+                .ToList();
+
+            // No event type is routed to two Gateway queues (shared events fan out to the
+            // admin queue as well, which is intentional and not covered by this list).
+            routed.Should().OnlyHaveUniqueItems();
+
+            // Every event type the Gateway bridges is routed to exactly one Gateway queue.
+            var bridged = ConduitLLM.Gateway.Extensions.CacheInvalidationMessagingExtensions.BridgedEventTypes
+                .Concat(ConduitLLM.Gateway.Extensions.MediaGenerationMessagingExtensions.BridgedEventTypes)
+                .Append(typeof(ConduitLLM.Core.Events.SpendUpdateRequested))
+                .Append(typeof(ConduitLLM.Core.Events.WebhookDeliveryRequested))
+                .Append(typeof(ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent))
+                .Distinct()
+                .ToList();
+
+            routed.Should().BeEquivalentTo(bridged);
+        }
+
+        [Fact]
+        public void Topology_SharedEvents_AreTheSharedBridgeList()
+        {
+            ConduitMessagingTopology.SharedEvents.Should().BeEquivalentTo(
+                ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.BridgedEventTypes);
+
+            // Shared events ride the per-service queues, not the tuned ones.
+            ConduitMessagingTopology.GatewayEvents.Should().NotContain(ConduitMessagingTopology.SharedEvents);
+        }
+
+        [Fact]
+        public void Topology_StrictOrderingEndpoints_MatchTheRabbitMqSemantics()
+        {
+            // The two endpoints that relied on RabbitMQ single-active-consumer must map
+            // to Wolverine strict ordering; webhook/video must not.
+            ConduitEndpointPolicies.SpendUpdate.SingleActiveConsumer.Should().BeTrue();
+            ConduitEndpointPolicies.ImageGeneration.SingleActiveConsumer.Should().BeTrue();
+            ConduitEndpointPolicies.WebhookDelivery.SingleActiveConsumer.Should().BeFalse();
+            ConduitEndpointPolicies.VideoGeneration.SingleActiveConsumer.Should().BeFalse();
+        }
+    }
+}

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -83,23 +83,36 @@ sites are untouched.
   through the bridge to an `IEventHandler` with envelope metadata; adapter/bridge/context
   unit tests mirror the MassTransit set.
 
-## I2.3 — Map the 4 tuned endpoints (#926)
+## I2.3 — Map the 4 tuned endpoints (#926) — ✅ implemented (behavioral parity gate = #929)
 
-Translate `ConduitEndpointPolicies` → Wolverine, the analogue of
-`MassTransitEndpointPolicy.ApplyResiliencePolicies`:
+Implemented as `WolverineEndpointPolicy` (descriptor translation) +
+`ConduitMessagingTopology` in `ConduitLLM.Core.Messaging` (the declared event→queue
+topology Postgres point-to-point queues need where RabbitMQ derived it from exchanges):
 
-| Descriptor | Wolverine translation |
+| Descriptor | Wolverine translation (as landed) |
 |---|---|
-| `SingleActiveConsumer` / `ConcurrentMessageLimit = 1` (spend) | `ListenToPostgresQueue("spend-update-events").Sequential()` (single, ordered listener) |
-| `ConcurrentMessageLimit` / `PrefetchCount` | `.MaximumParallelMessages(n)` / buffered listener options |
-| `Retry` (Immediate/Incremental/Exponential) | `opts.OnException<…>().RetryWithCooldown(...)` / `policy.RetryTimes` per endpoint |
-| `DelayedRedeliveryIntervals` | `.ScheduleRetry(...)` intervals |
-| `CircuitBreaker` | `opts.Policies.OnException(...).Pause(...)` / app-level Polly retained where richer |
-| `RateLimit` (webhook 100/s) | endpoint throttle, or retain the existing app-level `IWebhookCircuitBreaker`/rate logic |
-| deferred retry (`SchedulePublishAsync`) | native `ScheduleAsync` (durable; better than today's unconfigured MT scheduler) |
+| `SingleActiveConsumer` / `ConcurrentMessageLimit = 1` (spend, image) | `ListenToPostgresqlQueue(name).ListenWithStrictOrdering()` — cluster-wide single active listener + sequential handling |
+| `ConcurrentMessageLimit` (webhook 75) | `.MaximumParallelMessages(n)`; `PrefetchCount` has no Postgres analogue |
+| `Retry` shapes | `EndpointRetryHandlerPolicy : IHandlerPolicy` scopes `RetryWithCooldown(...)` to each endpoint's message types (Wolverine's failure DSL is global-or-generic; the descriptors carry runtime `Type` lists). Cooldowns via `ComputeRetryCooldowns`: Immediate → zeros; Incremental → min + step·n; Exponential → min + step·(2ⁿ−1) capped at max |
+| `DelayedRedeliveryIntervals` | `ScheduleRetry(...)` after inline attempts (then Postgres dead-letter storage) |
+| `CircuitBreaker` | listener `CircuitBreaker` (TrackingPeriod/FailurePercentageThreshold/MinimumThreshold/PauseTime) |
+| `RateLimit` (webhook 100/s) | NOT translated — app-level webhook rate limiting/circuit breaking retained (as this plan allowed) |
+| `QuorumQueue` / `QueueArguments` | RabbitMQ-native, not applicable |
+| deferred retry (`SchedulePublishAsync`) | already native + durable since #925 |
 
-Acceptance: each endpoint's behavior matches the MassTransit baseline in tests (ordering,
-deferral, concurrency).
+**Topology** (single source of truth, applied identically on both hosts; a rule for a
+type a host never publishes is inert): 4 tuned queues + `gateway-events` (all other
+Gateway-consumed events) + `admin-events` (shared cache events; shared types fan out to
+BOTH service queues). Gateway listens tuned + `gateway-events`; Admin listens
+`admin-events`. Instances of a service compete on its queue — the same
+one-consumer-per-event semantics as today's per-service RabbitMQ queues (per-instance
+cache fan-out remains the Redis pub/sub cache bus's job). The Gateway bridge-extension
+`BridgedEventTypes` lists now derive from the topology so routing and bridge
+registration cannot drift (unit-tested: every bridged type routed exactly once).
+
+Acceptance: translation + topology invariants unit-tested; live ordering/deferral/
+concurrency behavior vs the MassTransit baseline is measured in I2.6/#929 (needs real
+Postgres + load).
 
 ## I2.4 — Transactional outbox (#927)
 


### PR DESCRIPTION
## ⚠️ Merge order

**Stacked on #946** (the stranded-#925 delivery). Merge #946 into `dev` first, then retarget/merge this. (Last time a stacked PR was merged into its base *after* the base had gone to dev, the commit got stranded — #946 exists to fix exactly that. Merging bottom-up avoids a repeat.)

## Summary

Lands **I2.3 (#926)**: the four tuned `ConduitEndpointPolicies` descriptors translated to Wolverine, plus the declared event→queue topology that Postgres point-to-point queues require where RabbitMQ derived it from exchange topology.

**`WolverineEndpointPolicy`** (Configuration):
- `SingleActiveConsumer`/`ConcurrentMessageLimit=1` → `ListenWithStrictOrdering()` — cluster-wide single sequential listener (spend-update-events, image-generation-events); the exact analogue of RabbitMQ's `x-single-active-consumer`.
- `ConcurrentMessageLimit` → `MaximumParallelMessages` (webhook 75); `PrefetchCount` has no Postgres analogue.
- Retry shapes → per-message-type `RetryWithCooldown` rules via an `IHandlerPolicy` (Wolverine's failure DSL is global-or-generically-typed; the descriptors carry runtime `Type` lists). Cooldown expansion mirrors MassTransit: Immediate → zeros, Incremental → min+step·n, Exponential → min+step·(2ⁿ−1) capped at max.
- `CircuitBreaker` → listener circuit breaker; `RateLimit` (webhook 100/s) intentionally stays app-level per the plan; `QuorumQueue`/`QueueArguments` are RabbitMQ-native.

**`ConduitMessagingTopology`** (Core — visible to both hosts):
- 4 tuned queues + `gateway-events` (all other Gateway-consumed events) + `admin-events`; shared cache events fan out to both service queues.
- Publish routing applied identically on both hosts (rules for types a host never publishes are inert) — **Admin→Gateway cache invalidation now flows on the Wolverine bus**, closing the cross-service gap noted in #945.
- Gateway's bridge-extension `BridgedEventTypes` lists now derive from the topology, so bridge registration and queue routing cannot drift.
- Instances of a service compete on its queue — same one-consumer-per-event semantics as today's per-service RabbitMQ queues (per-instance cache fan-out remains the Redis pub/sub cache bus's job).

## Verification

- `dotnet build` — full solution, 0 errors.
- Messaging suite **39/39**: retry-cooldown expansion for all four real policies, topology invariants (every bridged event type routed to exactly one Gateway queue; shared list consistency), strict-ordering flags.
- Full suite: 2791 pass / 44 fail — **baseline-identical** failure set.
- Live ordering/deferral/concurrency parity vs the MassTransit baseline is #929's gate (needs real Postgres + load infra), per the plan.

Refs #926 (epic #909)