### PR TITLE
feat(messaging): durable outbox + spend idempotency for financial publishes (#927)

### DIFF
--- a/Services/ConduitLLM.Gateway/EventHandlers/SpendUpdateProcessor.cs
+++ b/Services/ConduitLLM.Gateway/EventHandlers/SpendUpdateProcessor.cs
@@ -94,67 +94,84 @@ namespace ConduitLLM.Gateway.EventHandlers
                     return;
                 }
 
-                // Calculate new spend total at group level
-                var previousSpend = group.LifetimeSpent;
-                var newSpend = previousSpend + request.Amount;
                 var previousBalance = group.Balance;
+                var description = $"API usage by virtual key #{request.KeyId}";
 
-                // Update the group balance and lifetime spent
-                var newBalance = await groupRepository.AdjustBalanceAsync(
-                    group.Id,
-                    -request.Amount,
-                    $"API usage by virtual key #{request.KeyId}",
-                    "System",
-                    ReferenceType.VirtualKey,
-                    request.KeyId.ToString());
-                
-                var success = newBalance >= 0; // Success if we got a valid balance back
-                
-                if (success)
+                // Debit the group exactly once per RequestId (#927): the idempotency key
+                // rides the ledger row inside the same atomic save as the balance change,
+                // so an at-least-once redelivery cannot double-charge.
+                BalanceAdjustmentResult result;
+                if (!string.IsNullOrWhiteSpace(request.RequestId))
                 {
-                    // Publish SpendUpdated event for cache invalidation and audit
-                    await _eventBus.PublishAsync(new SpendUpdated
-                    {
-                        KeyId = request.KeyId,
-                        KeyHash = virtualKey.KeyHash,
-                        Amount = request.Amount,
-                        NewTotalSpend = newSpend,
-                        RequestId = request.RequestId,
-                        CorrelationId = request.CorrelationId
-                    });
-
-                    _logger.LogInformation(
-                        "Spend updated for virtual key {KeyId} in group {GroupId}: {PreviousSpend} + {Amount} = {NewSpend}, new balance: {NewBalance} (requestId: {RequestId})",
-                        request.KeyId, group.Id, previousSpend, request.Amount, newSpend, newBalance, request.RequestId);
-                    
-                    // Check if group balance is depleted
-                    if (newBalance <= 0 && previousBalance > 0)
-                    {
-                        // Balance just hit zero
-                        
-                        await _eventBus.PublishAsync(new SpendThresholdExceeded
-                        {
-                            VirtualKeyId = virtualKey.Id,
-                            VirtualKeyHash = virtualKey.KeyHash,
-                            KeyName = virtualKey.KeyName,
-                            CurrentSpend = newSpend,
-                            MaxBudget = previousBalance, // The balance that was available
-                            AmountOver = -newBalance, // How much we're over
-                            BudgetDuration = null, // No longer applicable in bank account model
-                            ExceededAt = DateTime.UtcNow,
-                            KeyDisabled = false, // We don't auto-disable in this handler
-                            CorrelationId = request.CorrelationId
-                        });
-                        
-                        _logger.LogWarning(
-                            "Virtual key group {GroupId} for key {KeyId} ({KeyName}) has depleted balance: {NewBalance:C}",
-                            group.Id, virtualKey.Id, virtualKey.KeyName, newBalance);
-                    }
+                    result = await groupRepository.AdjustBalanceIdempotentAsync(
+                        group.Id,
+                        -request.Amount,
+                        SpendIdempotency.KeyFor(request.RequestId),
+                        description,
+                        "System",
+                        ReferenceType.VirtualKey,
+                        request.KeyId.ToString());
                 }
                 else
                 {
-                    _logger.LogError("Failed to update spend for virtual key group {GroupId} (key {KeyId}) - balance adjustment failed", group.Id, request.KeyId);
-                    throw new InvalidOperationException($"Failed to update spend for virtual key group {group.Id}");
+                    var balance = await groupRepository.AdjustBalanceAsync(
+                        group.Id,
+                        -request.Amount,
+                        description,
+                        "System",
+                        ReferenceType.VirtualKey,
+                        request.KeyId.ToString());
+                    result = new BalanceAdjustmentResult(balance, group.LifetimeSpent + request.Amount, Applied: true);
+                }
+
+                var newBalance = result.NewBalance;
+                var newSpend = result.LifetimeSpent;
+
+                if (!result.Applied)
+                {
+                    _logger.LogWarning(
+                        "Spend update for key {KeyId} with requestId {RequestId} was already applied - republishing notification only",
+                        request.KeyId, request.RequestId);
+                }
+
+                // Publish SpendUpdated for cache invalidation and audit. Also republished on
+                // a duplicate delivery, in case the first attempt crashed after the debit
+                // committed but before this notification went out.
+                await _eventBus.PublishAsync(new SpendUpdated
+                {
+                    KeyId = request.KeyId,
+                    KeyHash = virtualKey.KeyHash,
+                    Amount = request.Amount,
+                    NewTotalSpend = newSpend,
+                    RequestId = request.RequestId,
+                    CorrelationId = request.CorrelationId
+                });
+
+                _logger.LogInformation(
+                    "Spend updated for virtual key {KeyId} in group {GroupId}: +{Amount} = {NewSpend}, new balance: {NewBalance} (requestId: {RequestId}, applied: {Applied})",
+                    request.KeyId, group.Id, request.Amount, newSpend, newBalance, request.RequestId, result.Applied);
+
+                // Check if this debit depleted the group balance (skipped on duplicate:
+                // the crossing was already reported when the debit first applied)
+                if (result.Applied && newBalance <= 0 && previousBalance > 0)
+                {
+                    await _eventBus.PublishAsync(new SpendThresholdExceeded
+                    {
+                        VirtualKeyId = virtualKey.Id,
+                        VirtualKeyHash = virtualKey.KeyHash,
+                        KeyName = virtualKey.KeyName,
+                        CurrentSpend = newSpend,
+                        MaxBudget = previousBalance, // The balance that was available
+                        AmountOver = -newBalance, // How much we're over
+                        BudgetDuration = null, // No longer applicable in bank account model
+                        ExceededAt = DateTime.UtcNow,
+                        KeyDisabled = false, // We don't auto-disable in this handler
+                        CorrelationId = request.CorrelationId
+                    });
+
+                    _logger.LogWarning(
+                        "Virtual key group {GroupId} for key {KeyId} ({KeyName}) has depleted balance: {NewBalance:C}",
+                        group.Id, virtualKey.Id, virtualKey.KeyName, newBalance);
                 }
             }
             catch (Exception ex)

--- a/Services/ConduitLLM.Gateway/Services/CachedApiVirtualKeyService.cs
+++ b/Services/ConduitLLM.Gateway/Services/CachedApiVirtualKeyService.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Extensions;
 using ConduitLLM.Configuration.DTOs.VirtualKey;
+using ConduitLLM.Configuration.Enums;
 using ConduitLLM.Configuration.Interfaces;
 using VirtualKeyUtilities = ConduitLLM.Configuration.Utilities.VirtualKeyUtilities;
 using ConduitLLM.Core.Events;
@@ -187,7 +188,7 @@ namespace ConduitLLM.Gateway.Services
                     // Event-driven approach - publish SpendUpdateRequested event
                     var requestId = Guid.NewGuid().ToString();
 
-                    await PublishEventAsync(
+                    var published = await TryPublishEventAsync(
                         new SpendUpdateRequested
                         {
                             KeyId = keyId,
@@ -198,41 +199,29 @@ namespace ConduitLLM.Gateway.Services
                         $"spend update for key {keyId}",
                         new { KeyId = keyId, Amount = cost, RequestId = requestId });
 
-                    // Event-driven approach returns true immediately - processing happens asynchronously
-                    // The SpendUpdateProcessor will handle the actual database update and cache invalidation
-                    return true;
+                    if (published)
+                    {
+                        // Event-driven approach returns true immediately - processing happens asynchronously
+                        // The SpendUpdateProcessor will handle the actual database update and cache invalidation
+                        return true;
+                    }
+
+                    // Publish failure fallback (#927): charge directly instead of losing the
+                    // spend. The same RequestId-derived idempotency key is written to the
+                    // ledger, so if the event WAS actually delivered despite the reported
+                    // failure, the consumer's dedup makes it a no-op — no double charge.
+                    _logger.LogError(
+                        "Spend update event for key {KeyId} (requestId {RequestId}) could not be published - falling back to direct balance adjustment",
+                        keyId, requestId);
+
+                    return await UpdateSpendDirectAsync(keyId, cost, SpendIdempotency.KeyFor(requestId));
                 }
                 else
                 {
                     // FALLBACK: Direct database update approach when event bus not configured
                     _logger.LogDebug("Event publishing not configured - using direct database update for key {KeyId}", keyId);
 
-                    var virtualKey = await VirtualKeyRepository.GetByIdAsync(keyId);
-                    if (virtualKey == null)
-                    {
-                        _logger.LogWarning("Virtual key {KeyId} not found for spend update", keyId);
-                        return false;
-                    }
-
-                    // Get the key's group and adjust its balance
-                    var group = await GroupRepository.GetByKeyIdAsync(keyId);
-                    if (group == null)
-                    {
-                        _logger.LogWarning("No group found for virtual key with ID {KeyId}", keyId);
-                        return false;
-                    }
-
-                    var newBalance = await GroupRepository.AdjustBalanceAsync(group.Id, -cost);
-
-                    // Invalidate cache after spend update
-                    await _cache.InvalidateVirtualKeyAsync(virtualKey.KeyHash);
-
-                    _logger.LogInformation("Updated spend for key ID {KeyId} in group {GroupId}. New balance: {NewBalance}",
-                        keyId, group.Id, newBalance);
-
-                    bool success = true;
-
-                    return success;
+                    return await UpdateSpendDirectAsync(keyId, cost, idempotencyKey: null);
                 }
             }
             catch (Exception ex)
@@ -240,6 +229,56 @@ namespace ConduitLLM.Gateway.Services
                 _logger.LogError(ex, "Error updating spend for key ID {KeyId}.", keyId);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Adjusts the key's group balance directly, bypassing the event bus. Used when
+        /// event publishing is not configured, and as the durability fallback when a
+        /// spend publish fails (#927) — in the latter case with the RequestId-derived
+        /// idempotency key so the adjustment applies at most once across both paths.
+        /// </summary>
+        private async Task<bool> UpdateSpendDirectAsync(int keyId, decimal cost, string? idempotencyKey)
+        {
+            var virtualKey = await VirtualKeyRepository.GetByIdAsync(keyId);
+            if (virtualKey == null)
+            {
+                _logger.LogWarning("Virtual key {KeyId} not found for spend update", keyId);
+                return false;
+            }
+
+            // Get the key's group and adjust its balance
+            var group = await GroupRepository.GetByKeyIdAsync(keyId);
+            if (group == null)
+            {
+                _logger.LogWarning("No group found for virtual key with ID {KeyId}", keyId);
+                return false;
+            }
+
+            decimal newBalance;
+            if (idempotencyKey != null)
+            {
+                var result = await GroupRepository.AdjustBalanceIdempotentAsync(
+                    group.Id,
+                    -cost,
+                    idempotencyKey,
+                    $"API usage by virtual key #{keyId}",
+                    "System",
+                    ReferenceType.VirtualKey,
+                    keyId.ToString());
+                newBalance = result.NewBalance;
+            }
+            else
+            {
+                newBalance = await GroupRepository.AdjustBalanceAsync(group.Id, -cost);
+            }
+
+            // Invalidate cache after spend update
+            await _cache.InvalidateVirtualKeyAsync(virtualKey.KeyHash);
+
+            _logger.LogInformation("Updated spend for key ID {KeyId} in group {GroupId}. New balance: {NewBalance}",
+                keyId, group.Id, newBalance);
+
+            return true;
         }
 
         /// <inheritdoc />

--- a/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
+++ b/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
@@ -396,6 +396,12 @@ namespace ConduitLLM.Configuration
                 entity.HasIndex(e => e.ReferenceType);
                 entity.HasIndex(e => e.TransactionType);
 
+                // Idempotency for at-least-once spend processing (#927): one ledger row
+                // per idempotency key. Filtered so the many rows without a key are exempt.
+                entity.HasIndex(e => e.IdempotencyKey)
+                      .IsUnique()
+                      .HasFilter("\"IdempotencyKey\" IS NOT NULL");
+
                 // Store enums as integers
                 entity.Property(e => e.TransactionType)
                       .HasConversion<int>();

--- a/Shared/ConduitLLM.Configuration/Entities/VirtualKeyGroupTransaction.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/VirtualKeyGroupTransaction.cs
@@ -75,6 +75,15 @@ namespace ConduitLLM.Configuration.Entities
         public string? InitiatedByUserId { get; set; }
 
         /// <summary>
+        /// Idempotency key for at-least-once message processing (e.g. the
+        /// SpendUpdateRequested RequestId, prefixed with the flow name). Unique when
+        /// present: a redelivered message is detected by this key and the balance
+        /// adjustment is not applied twice.
+        /// </summary>
+        [MaxLength(100)]
+        public string? IdempotencyKey { get; set; }
+
+        /// <summary>
         /// When this transaction was created
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Shared/ConduitLLM.Configuration/Interfaces/IVirtualKeyGroupRepository.cs
+++ b/Shared/ConduitLLM.Configuration/Interfaces/IVirtualKeyGroupRepository.cs
@@ -54,6 +54,29 @@ public interface IVirtualKeyGroupRepository : IRepositoryBase<VirtualKeyGroup, i
     Task<decimal> AdjustBalanceAsync(int groupId, decimal amount, string? description, string? initiatedBy, ReferenceType referenceType, string? referenceId = null);
 
     /// <summary>
+    /// Adjusts the balance of a virtual key group exactly once per idempotency key.
+    /// The key is stored on the transaction ledger row in the same atomic save as the
+    /// balance adjustment, so a redelivered message (at-least-once transport, #927)
+    /// is detected and not applied twice.
+    /// </summary>
+    /// <param name="groupId">The group ID</param>
+    /// <param name="amount">The amount to adjust (positive for credit, negative for debit)</param>
+    /// <param name="idempotencyKey">Unique key identifying this adjustment (e.g. "spend:{RequestId}")</param>
+    /// <param name="description">Description of the transaction</param>
+    /// <param name="initiatedBy">User who initiated the transaction</param>
+    /// <param name="referenceType">The type of reference that triggered this transaction</param>
+    /// <param name="referenceId">Optional reference ID (e.g., virtual key ID)</param>
+    /// <returns>The resulting balance state and whether the adjustment was applied (false = duplicate key)</returns>
+    Task<BalanceAdjustmentResult> AdjustBalanceIdempotentAsync(
+        int groupId,
+        decimal amount,
+        string idempotencyKey,
+        string? description,
+        string? initiatedBy,
+        ReferenceType referenceType,
+        string? referenceId = null);
+
+    /// <summary>
     /// Gets groups with low balance (below threshold) with pagination
     /// </summary>
     /// <param name="threshold">The balance threshold</param>
@@ -67,3 +90,11 @@ public interface IVirtualKeyGroupRepository : IRepositoryBase<VirtualKeyGroup, i
         int pageSize,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Result of an idempotent balance adjustment.
+/// </summary>
+/// <param name="NewBalance">Group balance after the operation (current balance when the adjustment was a duplicate).</param>
+/// <param name="LifetimeSpent">Group lifetime spend after the operation.</param>
+/// <param name="Applied">False when the idempotency key was already recorded and no adjustment was made.</param>
+public sealed record BalanceAdjustmentResult(decimal NewBalance, decimal LifetimeSpent, bool Applied);

--- a/Shared/ConduitLLM.Configuration/Messaging/MassTransit/MassTransitEventBus.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/MassTransit/MassTransitEventBus.cs
@@ -13,14 +13,15 @@ namespace ConduitLLM.Configuration.Messaging.MassTransit
     /// <c>IPublishEndpoint.Publish&lt;TEvent&gt;</c>, so MassTransit routes by the closed
     /// generic type just as the previous direct calls did.
     /// <para>
-    /// <b>Durability gap (flagged for #927):</b> this adapter does not itself swallow
-    /// failures — but the existing fire-and-forget seams
+    /// <b>Durability gap (closed on the Wolverine backend by I2.4/#927):</b> this adapter
+    /// does not itself swallow failures — but the fire-and-forget seams
     /// (<c>EventPublishingControllerBase</c> / <c>EventPublishingServiceBase</c>) call it
-    /// inside a background <c>Task.Run</c> and swallow exceptions, and there is no outbox.
-    /// A crash (or broker outage) between the business commit and the publish loses the
-    /// event. The Wolverine Postgres transactional outbox closes this in I2.4 (#927);
-    /// Phase 1 deliberately preserves the current (lossy) semantics for a zero-behavior
-    /// change checkpoint.
+    /// inside a background <c>Task.Run</c> and swallow exceptions, and MassTransit has no
+    /// outbox here, so a crash (or broker outage) between the business commit and the
+    /// publish loses the event. This MassTransit backend deliberately keeps those
+    /// semantics (zero-behavior-change rollback target); on Wolverine, sends are durable
+    /// and spend processing is idempotent, and the financial publish sites fall back to a
+    /// direct write on failure (see #927).
     /// </para>
     /// </remarks>
     public sealed class MassTransitEventBus : IEventBus

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventBus.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEventBus.cs
@@ -12,8 +12,9 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
     /// Registered scoped, like <c>MassTransitEventBus</c>: Wolverine's
     /// <see cref="IMessageBus"/> is itself scoped, and inside a handler scope it is the
     /// active <see cref="IMessageContext"/>, so follow-on publishes from handlers flow
-    /// through the current envelope (correlation-aware) and participate in the
-    /// transactional outbox once a transaction is applied (#927).
+    /// through the current envelope (correlation-aware) and flush atomically with
+    /// handler completion. All sending endpoints are durable (I2.4/#927), so an
+    /// accepted publish is persisted to the Postgres outbox before delivery.
     /// <para>
     /// Wolverine's publish APIs carry no <see cref="CancellationToken"/>; the token is
     /// honored by checking it before handing each event to the transport.

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -77,15 +77,21 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                 // share the existing Postgres database, in an isolated schema.
                 opts.UsePostgresqlPersistenceAndTransport(connectionString, schemaName);
 
-                // Wraps handlers in a database transaction where one applies — the
-                // foundation for the transactional outbox work in I2.4/#927.
+                // Wraps handlers in a database transaction where one applies.
                 opts.Policies.AutoApplyTransactions();
 
                 // Local queues (where in-process bridge handlers receive publishes) are
                 // backed by the Postgres durability tables, so buffered messages survive
                 // a crash — already an improvement on MassTransit's in-memory transport.
-                // Full outbox semantics for the financial paths land in I2.4/#927.
                 opts.Policies.UseDurableLocalQueues();
+
+                // Transactional outbox (I2.4/#927): every sending endpoint persists the
+                // envelope to the Postgres outbox before delivery, so a publish accepted
+                // by the bus survives a crash and is retried by the durability agent —
+                // the fire-and-forget publish seams no longer lose events on transient
+                // failure. Messages published from inside a handler additionally flush
+                // atomically with handler completion (the message-context outbox).
+                opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
 
                 // Conduit's IEventHandler<T> implementations are named *Handler/*Consumer
                 // with HandleAsync methods, which Wolverine's conventional discovery would

--- a/Shared/ConduitLLM.Configuration/Migrations/20260717081905_AddIdempotencyKeyToVirtualKeyGroupTransactions.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260717081905_AddIdempotencyKeyToVirtualKeyGroupTransactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717081905_AddIdempotencyKeyToVirtualKeyGroupTransactions")]
+    partial class AddIdempotencyKeyToVirtualKeyGroupTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260717081905_AddIdempotencyKeyToVirtualKeyGroupTransactions.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260717081905_AddIdempotencyKeyToVirtualKeyGroupTransactions.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdempotencyKeyToVirtualKeyGroupTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                table: "VirtualKeyGroupTransactions",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VirtualKeyGroupTransactions_IdempotencyKey",
+                table: "VirtualKeyGroupTransactions",
+                column: "IdempotencyKey",
+                unique: true,
+                filter: "\"IdempotencyKey\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_VirtualKeyGroupTransactions_IdempotencyKey",
+                table: "VirtualKeyGroupTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "IdempotencyKey",
+                table: "VirtualKeyGroupTransactions");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Repositories/VirtualKeyGroupRepository.cs
+++ b/Shared/ConduitLLM.Configuration/Repositories/VirtualKeyGroupRepository.cs
@@ -5,6 +5,8 @@ using ConduitLLM.Configuration.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
+using Npgsql;
+
 namespace ConduitLLM.Configuration.Repositories;
 
 /// <summary>
@@ -165,45 +167,8 @@ public class VirtualKeyGroupRepository : RepositoryBase<VirtualKeyGroup, int>, I
         {
             return await ExecuteAsync(async context =>
             {
-                var group = await GetDbSet(context).FirstOrDefaultAsync(g => g.Id == groupId);
-                if (group == null)
-                {
-                    throw new InvalidOperationException($"Virtual key group {groupId} not found");
-                }
-
-                var previousBalance = group.Balance;
-                group.Balance += amount;
-
-                if (amount > 0)
-                {
-                    group.LifetimeCreditsAdded += amount;
-                }
-                else
-                {
-                    group.LifetimeSpent += Math.Abs(amount);
-                }
-
-                group.UpdatedAt = DateTime.UtcNow;
-
-                // Create transaction record
-                var transaction = CreateTransaction(
-                    groupId,
-                    amount,
-                    group.Balance,
-                    amount > 0 ? TransactionType.Credit : TransactionType.Debit,
-                    referenceType,
-                    description ?? (amount > 0 ? "Credits added" : "Usage deducted"),
-                    referenceId,
-                    initiatedBy ?? "System"
-                );
-
-                context.VirtualKeyGroupTransactions.Add(transaction);
-
-                await context.SaveChangesAsync();
-
-                Logger.LogInformation("Adjusted balance for group {GroupId} by {Amount}. Previous: {PreviousBalance}, New: {Balance}, ReferenceType: {ReferenceType}",
-                    groupId, amount, previousBalance, group.Balance, referenceType);
-
+                var group = await ApplyBalanceAdjustmentAsync(
+                    context, groupId, amount, description, initiatedBy, referenceType, referenceId, idempotencyKey: null);
                 return group.Balance;
             });
         }
@@ -216,6 +181,146 @@ public class VirtualKeyGroupRepository : RepositoryBase<VirtualKeyGroup, int>, I
             Logger.LogError(ex, "Error adjusting balance for virtual key group {GroupId}", groupId);
             throw;
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<BalanceAdjustmentResult> AdjustBalanceIdempotentAsync(
+        int groupId,
+        decimal amount,
+        string idempotencyKey,
+        string? description,
+        string? initiatedBy,
+        ReferenceType referenceType,
+        string? referenceId = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+
+        try
+        {
+            return await ExecuteAsync(async context =>
+            {
+                // Includes soft-deleted rows: a deleted ledger entry still proves the
+                // adjustment was applied once.
+                var duplicate = await context.VirtualKeyGroupTransactions
+                    .IgnoreQueryFilters()
+                    .AsNoTracking()
+                    .AnyAsync(t => t.IdempotencyKey == idempotencyKey);
+
+                if (duplicate)
+                {
+                    Logger.LogWarning(
+                        "Duplicate balance adjustment for group {GroupId} with idempotency key {IdempotencyKey} - skipping",
+                        groupId, idempotencyKey);
+                    return await GetCurrentStateAsync(context, groupId, applied: false);
+                }
+
+                var group = await ApplyBalanceAdjustmentAsync(
+                    context, groupId, amount, description, initiatedBy, referenceType, referenceId, idempotencyKey);
+                return new BalanceAdjustmentResult(group.Balance, group.LifetimeSpent, Applied: true);
+            });
+        }
+        catch (DbUpdateException ex) when (IsIdempotencyKeyViolation(ex))
+        {
+            // Race backstop: a concurrent delivery inserted the key between the check
+            // and the save. The unique index guarantees single application.
+            Logger.LogWarning(
+                "Concurrent duplicate balance adjustment for group {GroupId} with idempotency key {IdempotencyKey} - skipping",
+                groupId, idempotencyKey);
+            return await ExecuteAsync(context => GetCurrentStateAsync(context, groupId, applied: false));
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adjusting balance idempotently for virtual key group {GroupId}", groupId);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Applies a balance adjustment and its ledger row in one atomic save on the
+    /// supplied context. The optional idempotency key is stored on the ledger row,
+    /// whose unique index enforces exactly-once application (#927).
+    /// </summary>
+    private async Task<VirtualKeyGroup> ApplyBalanceAdjustmentAsync(
+        ConduitDbContext context,
+        int groupId,
+        decimal amount,
+        string? description,
+        string? initiatedBy,
+        ReferenceType referenceType,
+        string? referenceId,
+        string? idempotencyKey)
+    {
+        var group = await GetDbSet(context).FirstOrDefaultAsync(g => g.Id == groupId);
+        if (group == null)
+        {
+            throw new InvalidOperationException($"Virtual key group {groupId} not found");
+        }
+
+        var previousBalance = group.Balance;
+        group.Balance += amount;
+
+        if (amount > 0)
+        {
+            group.LifetimeCreditsAdded += amount;
+        }
+        else
+        {
+            group.LifetimeSpent += Math.Abs(amount);
+        }
+
+        group.UpdatedAt = DateTime.UtcNow;
+
+        // Create transaction record
+        var transaction = CreateTransaction(
+            groupId,
+            amount,
+            group.Balance,
+            amount > 0 ? TransactionType.Credit : TransactionType.Debit,
+            referenceType,
+            description ?? (amount > 0 ? "Credits added" : "Usage deducted"),
+            referenceId,
+            initiatedBy ?? "System"
+        );
+        transaction.IdempotencyKey = idempotencyKey;
+
+        context.VirtualKeyGroupTransactions.Add(transaction);
+
+        await context.SaveChangesAsync();
+
+        Logger.LogInformation("Adjusted balance for group {GroupId} by {Amount}. Previous: {PreviousBalance}, New: {Balance}, ReferenceType: {ReferenceType}",
+            groupId, amount, previousBalance, group.Balance, referenceType);
+
+        return group;
+    }
+
+    private async Task<BalanceAdjustmentResult> GetCurrentStateAsync(ConduitDbContext context, int groupId, bool applied)
+    {
+        var group = await GetDbSet(context).AsNoTracking().FirstOrDefaultAsync(g => g.Id == groupId);
+        if (group == null)
+        {
+            throw new InvalidOperationException($"Virtual key group {groupId} not found");
+        }
+
+        return new BalanceAdjustmentResult(group.Balance, group.LifetimeSpent, applied);
+    }
+
+    private static bool IsIdempotencyKeyViolation(DbUpdateException ex)
+    {
+        for (Exception? inner = ex.InnerException; inner != null; inner = inner.InnerException)
+        {
+            if (inner is PostgresException pg &&
+                pg.SqlState == PostgresErrorCodes.UniqueViolation &&
+                pg.ConstraintName?.Contains("IdempotencyKey", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <inheritdoc />

--- a/Shared/ConduitLLM.Core/Controllers/EventPublishingControllerBase.cs
+++ b/Shared/ConduitLLM.Core/Controllers/EventPublishingControllerBase.cs
@@ -83,8 +83,10 @@ namespace ConduitLLM.Core.Controllers
                 var sw = Stopwatch.StartNew();
                 try
                 {
-                    // NOTE(#927): failures are swallowed below (fire-and-forget, no outbox);
-                    // the transactional outbox in Phase 2 closes this durability gap.
+                    // Failures are swallowed below (fire-and-forget). Acceptable here:
+                    // these call sites are non-financial (media requests, admin config).
+                    // On the Wolverine backend an accepted publish is durable (#927);
+                    // financial paths use TryPublishEventAsync + direct-write fallback.
                     await _eventBus.PublishAsync(domainEvent);
                     sw.Stop();
                     _logger.LogDebug(
@@ -140,8 +142,10 @@ namespace ConduitLLM.Core.Controllers
                 var sw = Stopwatch.StartNew();
                 try
                 {
-                    // NOTE(#927): failures are swallowed below (fire-and-forget, no outbox);
-                    // the transactional outbox in Phase 2 closes this durability gap.
+                    // Failures are swallowed below (fire-and-forget). Acceptable here:
+                    // these call sites are non-financial (media requests, admin config).
+                    // On the Wolverine backend an accepted publish is durable (#927);
+                    // financial paths use TryPublishEventAsync + direct-write fallback.
                     await _eventBus.PublishAsync(domainEvent);
                     sw.Stop();
                     _logger.LogDebug(

--- a/Shared/ConduitLLM.Core/Events/DomainEvents.VirtualKey.cs
+++ b/Shared/ConduitLLM.Core/Events/DomainEvents.VirtualKey.cs
@@ -133,6 +133,20 @@ namespace ConduitLLM.Core.Events
     }
 
     /// <summary>
+    /// Idempotency-key convention for spend processing (#927). A spend debit is applied
+    /// at most once per <see cref="SpendUpdateRequested.RequestId"/>, whether it arrives
+    /// via the event bus or the publish-failure direct-write fallback.
+    /// </summary>
+    public static class SpendIdempotency
+    {
+        /// <summary>
+        /// Builds the ledger idempotency key for a spend update request.
+        /// </summary>
+        /// <param name="requestId">The spend update's RequestId.</param>
+        public static string KeyFor(string requestId) => $"spend:{requestId}";
+    }
+
+    /// <summary>
     /// Confirmation that virtual key spend was updated
     /// Used for cache invalidation and audit logging
     /// </summary>

--- a/Shared/ConduitLLM.Core/Services/EventPublishingServiceBase.cs
+++ b/Shared/ConduitLLM.Core/Services/EventPublishingServiceBase.cs
@@ -132,6 +132,55 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <summary>
+        /// Publishes a domain event and reports whether the bus accepted it, so callers
+        /// on financial paths can fall back to a direct write instead of losing the
+        /// event (#927). Failures are logged, never thrown.
+        /// </summary>
+        /// <typeparam name="TEvent">The type of event to publish.</typeparam>
+        /// <param name="domainEvent">The event to publish.</param>
+        /// <param name="operationName">A descriptive name for the operation that triggered the event.</param>
+        /// <param name="contextData">Optional context data to include in log messages.</param>
+        /// <returns>True when the event was handed to the bus; false when event publishing
+        /// is not configured or the publish failed.</returns>
+        protected async Task<bool> TryPublishEventAsync<TEvent>(
+            TEvent domainEvent,
+            string operationName,
+            object? contextData = null) where TEvent : class
+        {
+            if (domainEvent == null)
+            {
+                _logger.LogWarning(
+                    "Attempted to publish null event of type {EventType} for {Operation}",
+                    nameof(TEvent), operationName);
+                return false;
+            }
+
+            if (_eventBus == null)
+            {
+                _logger.LogDebug(
+                    "Event publishing not configured - skipping {EventType} for {Operation}",
+                    nameof(TEvent), operationName);
+                return false;
+            }
+
+            try
+            {
+                await _eventBus.PublishAsync(domainEvent);
+                _logger.LogDebug(
+                    "Published {EventType} event for {Operation} with context {ContextData}",
+                    nameof(TEvent), operationName, contextData);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to publish {EventType} event for {Operation} with context {ContextData} - reporting failure to caller",
+                    nameof(TEvent), operationName, contextData);
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Logs the event publishing configuration status on service initialization.
         /// </summary>
         /// <param name="serviceName">The name of the service for logging context.</param>

--- a/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyGroupRepositoryIdempotencyTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyGroupRepositoryIdempotencyTests.cs
@@ -1,0 +1,134 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Enums;
+using ConduitLLM.Configuration.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Configuration.Repositories
+{
+    /// <summary>
+    /// Tests for the idempotent balance adjustment used by spend processing (#927):
+    /// one application per idempotency key, with the key recorded on the ledger row
+    /// in the same atomic save as the balance change.
+    /// </summary>
+    public class VirtualKeyGroupRepositoryIdempotencyTests
+    {
+        private readonly DbContextOptions<ConduitDbContext> _options;
+        private readonly VirtualKeyGroupRepository _repository;
+
+        public VirtualKeyGroupRepositoryIdempotencyTests()
+        {
+            _options = new DbContextOptionsBuilder<ConduitDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            var dbContextFactoryMock = new Mock<IDbContextFactory<ConduitDbContext>>();
+            dbContextFactoryMock
+                .Setup(f => f.CreateDbContext())
+                .Returns(() => new ConduitDbContext(_options));
+            dbContextFactoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new ConduitDbContext(_options));
+
+            _repository = new VirtualKeyGroupRepository(
+                dbContextFactoryMock.Object,
+                new Mock<ILogger<VirtualKeyGroupRepository>>().Object);
+
+            using var context = new ConduitDbContext(_options);
+            context.VirtualKeyGroups.Add(new VirtualKeyGroup
+            {
+                Id = 1,
+                GroupName = "Test Group",
+                Balance = 100m,
+                LifetimeCreditsAdded = 100m,
+                LifetimeSpent = 0m,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task AdjustBalanceIdempotentAsync_SameKeyTwice_AppliesOnce()
+        {
+            // Act
+            var first = await _repository.AdjustBalanceIdempotentAsync(
+                1, -10m, "spend:req-1", "usage", "System", ReferenceType.VirtualKey, "1");
+            var second = await _repository.AdjustBalanceIdempotentAsync(
+                1, -10m, "spend:req-1", "usage", "System", ReferenceType.VirtualKey, "1");
+
+            // Assert
+            Assert.True(first.Applied);
+            Assert.Equal(90m, first.NewBalance);
+            Assert.Equal(10m, first.LifetimeSpent);
+
+            Assert.False(second.Applied);
+            Assert.Equal(90m, second.NewBalance);
+            Assert.Equal(10m, second.LifetimeSpent);
+
+            using var context = new ConduitDbContext(_options);
+            var group = await context.VirtualKeyGroups.SingleAsync(g => g.Id == 1);
+            Assert.Equal(90m, group.Balance);
+            Assert.Equal(10m, group.LifetimeSpent);
+
+            var ledgerRows = await context.VirtualKeyGroupTransactions
+                .Where(t => t.IdempotencyKey == "spend:req-1")
+                .ToListAsync();
+            Assert.Single(ledgerRows);
+        }
+
+        [Fact]
+        public async Task AdjustBalanceIdempotentAsync_DistinctKeys_BothApply()
+        {
+            // Act
+            var first = await _repository.AdjustBalanceIdempotentAsync(
+                1, -10m, "spend:req-a", "usage", "System", ReferenceType.VirtualKey, "1");
+            var second = await _repository.AdjustBalanceIdempotentAsync(
+                1, -20m, "spend:req-b", "usage", "System", ReferenceType.VirtualKey, "1");
+
+            // Assert
+            Assert.True(first.Applied);
+            Assert.True(second.Applied);
+            Assert.Equal(70m, second.NewBalance);
+            Assert.Equal(30m, second.LifetimeSpent);
+        }
+
+        [Fact]
+        public async Task AdjustBalanceIdempotentAsync_WithMissingGroup_Throws()
+        {
+            // Act
+            var act = () => _repository.AdjustBalanceIdempotentAsync(
+                999, -10m, "spend:req-x", "usage", "System", ReferenceType.VirtualKey, "1");
+
+            // Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(act);
+        }
+
+        [Fact]
+        public async Task AdjustBalanceIdempotentAsync_WithEmptyKey_Throws()
+        {
+            // Act
+            var act = () => _repository.AdjustBalanceIdempotentAsync(
+                1, -10m, " ", "usage", "System", ReferenceType.VirtualKey, "1");
+
+            // Assert
+            await Assert.ThrowsAsync<ArgumentException>(act);
+        }
+
+        [Fact]
+        public async Task AdjustBalanceAsync_StoresNoIdempotencyKey()
+        {
+            // Act
+            await _repository.AdjustBalanceAsync(1, -10m, "usage", "System", ReferenceType.VirtualKey, "1");
+
+            // Assert
+            using var context = new ConduitDbContext(_options);
+            var ledgerRow = await context.VirtualKeyGroupTransactions.SingleAsync();
+            Assert.Null(ledgerRow.IdempotencyKey);
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/EventHandlers/SpendUpdateProcessorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/EventHandlers/SpendUpdateProcessorTests.cs
@@ -90,14 +90,15 @@ namespace ConduitLLM.Tests.Http.EventHandlers
                 .Returns(Task.FromResult(group));
 
             _groupRepositoryMock
-                .Setup(r => r.AdjustBalanceAsync(
+                .Setup(r => r.AdjustBalanceIdempotentAsync(
                     1,
                     -50m,
+                    "spend:req-123",
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     ReferenceType.VirtualKey,
                     It.IsAny<string>()))
-                .Returns(Task.FromResult(50m)); // New balance
+                .Returns(Task.FromResult(new BalanceAdjustmentResult(50m, 150m, Applied: true)));
 
             var @event = new SpendUpdateRequested
             {
@@ -112,10 +113,11 @@ namespace ConduitLLM.Tests.Http.EventHandlers
             await _processor.HandleAsync(@event, new TestEventContext());
 
             // Assert
-            // Verify group balance was adjusted with correct reference type
-            _groupRepositoryMock.Verify(r => r.AdjustBalanceAsync(
+            // Verify group balance was adjusted idempotently with correct reference type
+            _groupRepositoryMock.Verify(r => r.AdjustBalanceIdempotentAsync(
                 1,
                 -50m,
+                "spend:req-123",
                 "API usage by virtual key #123",
                 "System",
                 ReferenceType.VirtualKey,
@@ -238,9 +240,131 @@ namespace ConduitLLM.Tests.Http.EventHandlers
         }
 
         [Fact]
-        public async Task HandleAsync_WithUpdateFailure_ThrowsException()
+        public async Task HandleAsync_WithBalanceDepleted_PublishesThresholdExceeded()
         {
             // Arrange
+            SetupRepositories(keyId: 222, keyHash: "test-hash-222", groupBalance: 20m, groupLifetimeSpent: 100m);
+
+            // Debit takes the balance negative — a legitimate depletion, not a failure
+            _groupRepositoryMock
+                .Setup(r => r.AdjustBalanceIdempotentAsync(
+                    1,
+                    -30m,
+                    "spend:req-222",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    ReferenceType.VirtualKey,
+                    It.IsAny<string>()))
+                .Returns(Task.FromResult(new BalanceAdjustmentResult(-10m, 130m, Applied: true)));
+
+            var @event = new SpendUpdateRequested
+            {
+                EventId = Guid.NewGuid().ToString(),
+                KeyId = 222,
+                Amount = 30m,
+                RequestId = "req-222",
+                CorrelationId = "corr-222"
+            };
+
+            // Act
+            await _processor.HandleAsync(@event, new TestEventContext());
+
+            // Assert
+            _eventBusMock.Verify(p => p.PublishAsync(It.Is<SpendUpdated>(su =>
+                su.KeyId == 222 &&
+                su.NewTotalSpend == 130m),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            _eventBusMock.Verify(p => p.PublishAsync(It.Is<SpendThresholdExceeded>(ste =>
+                ste.VirtualKeyId == 222 &&
+                ste.CurrentSpend == 130m &&
+                ste.AmountOver == 10m),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithDuplicateRequestId_SkipsThresholdButRepublishesNotification()
+        {
+            // Arrange - previous balance positive and result balance negative, so ONLY the
+            // duplicate (Applied=false) guard prevents the threshold event from firing again
+            SetupRepositories(keyId: 333, keyHash: "test-hash-333", groupBalance: 20m, groupLifetimeSpent: 130m);
+
+            // Repository reports the idempotency key was already recorded
+            _groupRepositoryMock
+                .Setup(r => r.AdjustBalanceIdempotentAsync(
+                    1,
+                    -30m,
+                    "spend:req-333",
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    ReferenceType.VirtualKey,
+                    It.IsAny<string>()))
+                .Returns(Task.FromResult(new BalanceAdjustmentResult(-10m, 130m, Applied: false)));
+
+            var @event = new SpendUpdateRequested
+            {
+                EventId = Guid.NewGuid().ToString(),
+                KeyId = 333,
+                Amount = 30m,
+                RequestId = "req-333"
+            };
+
+            // Act
+            await _processor.HandleAsync(@event, new TestEventContext());
+
+            // Assert - notification republished (in case the first attempt crashed before
+            // publishing), but the threshold crossing is not reported a second time
+            _eventBusMock.Verify(p => p.PublishAsync(It.Is<SpendUpdated>(su =>
+                su.KeyId == 333 &&
+                su.NewTotalSpend == 130m),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            _eventBusMock.Verify(p => p.PublishAsync(It.IsAny<SpendThresholdExceeded>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithoutRequestId_FallsBackToNonIdempotentAdjustment()
+        {
+            // Arrange
+            SetupRepositories(keyId: 444, keyHash: "test-hash-444", groupBalance: 100m, groupLifetimeSpent: 100m);
+
+            _groupRepositoryMock
+                .Setup(r => r.AdjustBalanceAsync(
+                    1,
+                    -50m,
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    ReferenceType.VirtualKey,
+                    It.IsAny<string>()))
+                .Returns(Task.FromResult(50m));
+
+            var @event = new SpendUpdateRequested
+            {
+                EventId = Guid.NewGuid().ToString(),
+                KeyId = 444,
+                Amount = 50m,
+                RequestId = string.Empty
+            };
+
+            // Act
+            await _processor.HandleAsync(@event, new TestEventContext());
+
+            // Assert
+            _groupRepositoryMock.Verify(r => r.AdjustBalanceAsync(
+                1, -50m, It.IsAny<string>(), It.IsAny<string>(), ReferenceType.VirtualKey, It.IsAny<string>()),
+                Times.Once);
+            _groupRepositoryMock.Verify(r => r.AdjustBalanceIdempotentAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<ReferenceType>(), It.IsAny<string>()),
+                Times.Never);
+
+            _eventBusMock.Verify(p => p.PublishAsync(It.IsAny<SpendUpdated>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void SetupRepositories(int keyId, string keyHash, decimal groupBalance, decimal groupLifetimeSpent)
+        {
             _serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IVirtualKeyRepository)))
                 .Returns(_virtualKeyRepositoryMock.Object);
@@ -250,51 +374,26 @@ namespace ConduitLLM.Tests.Http.EventHandlers
 
             var virtualKey = new VirtualKey
             {
-                Id = 222,
-                KeyHash = "test-hash-222",
+                Id = keyId,
+                KeyHash = keyHash,
                 VirtualKeyGroupId = 1
             };
-            
+
             var group = new VirtualKeyGroup
             {
                 Id = 1,
                 GroupName = "Test Group",
-                Balance = 100m
+                Balance = groupBalance,
+                LifetimeSpent = groupLifetimeSpent
             };
 
             _virtualKeyRepositoryMock
-                .Setup(r => r.GetByIdAsync(222, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdAsync(keyId, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(virtualKey));
-            
+
             _groupRepositoryMock
                 .Setup(r => r.GetByIdAsync(1))
                 .Returns(Task.FromResult(group));
-
-            // AdjustBalanceAsync returns negative balance indicating failure
-            _groupRepositoryMock
-                .Setup(r => r.AdjustBalanceAsync(
-                    1,
-                    -30m,
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    ReferenceType.VirtualKey,
-                    It.IsAny<string>()))
-                .Returns(Task.FromResult(-1m));
-
-            var @event = new SpendUpdateRequested
-            {
-                EventId = Guid.NewGuid().ToString(),
-                KeyId = 222,
-                Amount = 30m,
-                RequestId = "req-222"
-            };
-
-            // Act
-            var act = () => _processor.HandleAsync(@event, new TestEventContext());
-
-            // Assert
-            await act.Should().ThrowAsync<InvalidOperationException>()
-                .WithMessage("Failed to update spend for virtual key group 1");
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Gateway/Services/CachedApiVirtualKeyServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Services/CachedApiVirtualKeyServiceTests.cs
@@ -246,6 +246,95 @@ namespace ConduitLLM.Tests.Http.Services
             _virtualKeyRepositoryMock.Verify(r => r.GetByKeyHashAsync(keyHash, default), Times.Once);
         }
 
+        [Fact]
+        public async Task UpdateSpendAsync_WhenPublishSucceeds_ReturnsTrueWithoutDirectWrite()
+        {
+            // Arrange - event bus accepts the publish
+            _publishEndpointMock
+                .Setup(p => p.PublishAsync(It.IsAny<ConduitLLM.Core.Events.SpendUpdateRequested>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _service.UpdateSpendAsync(1, 5m);
+
+            // Assert
+            Assert.True(result);
+            _publishEndpointMock.Verify(p => p.PublishAsync(
+                It.Is<ConduitLLM.Core.Events.SpendUpdateRequested>(e => e.KeyId == 1 && e.Amount == 5m),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            // No direct write on the happy path - the SpendUpdateProcessor owns the debit
+            _virtualKeyRepositoryMock.Verify(r => r.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+            _groupRepositoryMock.Verify(g => g.AdjustBalanceIdempotentAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<ConduitLLM.Configuration.Enums.ReferenceType>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UpdateSpendAsync_WhenPublishFails_FallsBackToIdempotentDirectWrite()
+        {
+            // Arrange - event bus rejects the publish (#927 durability fallback)
+            _publishEndpointMock
+                .Setup(p => p.PublishAsync(It.IsAny<ConduitLLM.Core.Events.SpendUpdateRequested>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("bus unavailable"));
+
+            var virtualKey = CreateEnabledVirtualKey();
+            _virtualKeyRepositoryMock
+                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(virtualKey);
+            _groupRepositoryMock
+                .Setup(g => g.GetByKeyIdAsync(1))
+                .ReturnsAsync(CreateGroupWithBalance(100m));
+            _groupRepositoryMock
+                .Setup(g => g.AdjustBalanceIdempotentAsync(
+                    1, -5m, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    ConduitLLM.Configuration.Enums.ReferenceType.VirtualKey, "1"))
+                .ReturnsAsync(new BalanceAdjustmentResult(95m, 105m, Applied: true));
+
+            // Act
+            var result = await _service.UpdateSpendAsync(1, 5m);
+
+            // Assert - the charge is applied directly with a RequestId-derived idempotency
+            // key, so a late event delivery cannot double-charge
+            Assert.True(result);
+            _groupRepositoryMock.Verify(g => g.AdjustBalanceIdempotentAsync(
+                1, -5m, It.Is<string>(k => k.StartsWith("spend:")), It.IsAny<string>(), "System",
+                ConduitLLM.Configuration.Enums.ReferenceType.VirtualKey, "1"), Times.Once);
+            _cacheMock.Verify(c => c.InvalidateVirtualKeyAsync(virtualKey.KeyHash), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateSpendAsync_WithoutEventBus_UsesDirectWrite()
+        {
+            // Arrange - service constructed without an event bus
+            var service = new CachedApiVirtualKeyService(
+                _virtualKeyRepositoryMock.Object,
+                _spendHistoryRepositoryMock.Object,
+                _groupRepositoryMock.Object,
+                _cacheMock.Object,
+                eventBus: null,
+                _loggerMock.Object);
+
+            var virtualKey = CreateEnabledVirtualKey();
+            _virtualKeyRepositoryMock
+                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(virtualKey);
+            _groupRepositoryMock
+                .Setup(g => g.GetByKeyIdAsync(1))
+                .ReturnsAsync(CreateGroupWithBalance(100m));
+            _groupRepositoryMock
+                .Setup(g => g.AdjustBalanceAsync(1, -5m))
+                .ReturnsAsync(95m);
+
+            // Act
+            var result = await service.UpdateSpendAsync(1, 5m);
+
+            // Assert
+            Assert.True(result);
+            _groupRepositoryMock.Verify(g => g.AdjustBalanceAsync(1, -5m), Times.Once);
+            _cacheMock.Verify(c => c.InvalidateVirtualKeyAsync(virtualKey.KeyHash), Times.Once);
+        }
+
         /// <summary>
         /// Creates an enabled virtual key for testing
         /// </summary>

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -114,16 +114,49 @@ Acceptance: translation + topology invariants unit-tested; live ordering/deferra
 concurrency behavior vs the MassTransit baseline is measured in I2.6/#929 (needs real
 Postgres + load).
 
-## I2.4 — Transactional outbox (#927)
+## I2.4 — Transactional outbox (#927) — ✅ implemented (fault injection on real Postgres = #929)
 
-- Turn on the Postgres-backed outbox for spend/financial + webhook publishes
-  (`AutoApplyTransactions` + durable outbox), closing the fire-and-forget swallow gap
-  flagged in `MassTransitEventBus` and [I0.3](admin-gateway-cache-trace.md). The
-  invalidation/spend publish commits in the **same transaction** as the business write.
-- Add an inbox / idempotency key where consumers are not naturally idempotent (spend is
-  keyed by `RequestId`).
-- Acceptance: a crash injected between business commit and publish no longer loses the
-  event (fault-injection test).
+Investigation reshaped the plan: **the financial paths have no business-commit-then-publish
+pair on the publish side.** Spend publishes (`CachedApiVirtualKeyService.UpdateSpendAsync`,
+`MediaGenerationOrchestrator.UpdateSpendAsync`) and webhook publishes are publish-only —
+the financial DB write happens in the *consumer* (`SpendUpdateProcessor`), which had **no**
+RequestId idempotency (it was log-only), so at-least-once redelivery could double-charge.
+As landed:
+
+- **Durable sends** — `opts.Policies.UseDurableOutboxOnAllSendingEndpoints()` in
+  `AddConduitWolverine`: every publish persists the envelope to the Postgres outbox before
+  delivery; the durability agent retries, so an accepted publish survives a crash.
+  Publishes from inside a handler additionally flush atomically with handler completion
+  (the scoped `IMessageBus` *is* the message context — this covers the consumer's
+  follow-on `SpendUpdated`/`SpendThresholdExceeded` and the webhook retry re-publish).
+- **Spend inbox / idempotency** — the idempotency key rides the existing
+  `VirtualKeyGroupTransaction` ledger row (nullable `IdempotencyKey` + filtered unique
+  index; migration `AddIdempotencyKeyToVirtualKeyGroupTransactions`), written in the
+  **same atomic save** as the balance adjustment
+  (`IVirtualKeyGroupRepository.AdjustBalanceIdempotentAsync`, key = `spend:{RequestId}`
+  via `SpendIdempotency.KeyFor`). A redelivered `SpendUpdateRequested` republishes the
+  `SpendUpdated` notification (in case the first attempt crashed pre-publish) but cannot
+  debit twice. This also fixed a latent bug: the old `newBalance >= 0` "success" check
+  threw *after* the debit committed whenever a balance legitimately went negative, so
+  each endpoint retry re-charged the group.
+- **Publish-failure fallback** — `EventPublishingServiceBase.TryPublishEventAsync`
+  reports failure instead of swallowing; `CachedApiVirtualKeyService.UpdateSpendAsync`
+  falls back to a **direct idempotent balance adjustment with the same RequestId key**,
+  so the charge is never lost and a late event delivery dedups against the fallback row.
+- **Webhook path** — consumer is Redis-tracker idempotent already; its deferred retry
+  (`SchedulePublishAsync`) is durable since #925. `BatchWebhookPublisher`'s in-memory
+  drop-on-overflow queue has **no production call sites** (orchestrators publish
+  directly) — flagged for Phase 3 removal rather than hardened.
+
+Residual risks (accepted, documented): a crash *before* the publish call on the request
+path loses the spend (nothing was committed anywhere — inherent to post-hoc billing, not
+fixable by an outbox); Admin config-invalidation publishes still have the tiny
+crash-between-commit-and-publish window (idempotent + TTL-backed consumers; true
+same-transaction enrollment would require re-plumbing every Admin service through an EF
+outbox and is deliberately out of scope).
+
+Acceptance: dedup/atomicity/fallback covered by unit tests; the crash fault-injection on
+real Postgres runs with the #929 parity gate.
 
 ## I2.5 — Port the test suite (#928)
 


### PR DESCRIPTION
## Summary (I2.4 / #927 — epic #909)

Closes the fire-and-forget durability gap on the financial paths. Investigation reshaped the plan: the financial paths have **no business-commit-then-publish pair on the publish side** — spend/webhook publishes are publish-only and the financial DB write happens in the consumer, which had no RequestId idempotency (log-only), so at-least-once redelivery could double-charge. Delivered:

### 1. Durable sends (Wolverine backend)
`opts.Policies.UseDurableOutboxOnAllSendingEndpoints()` in `AddConduitWolverine`: every publish persists the envelope to the Postgres outbox before delivery; the durability agent retries. Publishes from inside a handler flush atomically with handler completion (covers the consumer's follow-on `SpendUpdated`/`SpendThresholdExceeded` and the webhook retry re-publish).

### 2. Spend inbox / idempotency (both backends)
The idempotency key rides the existing `VirtualKeyGroupTransaction` ledger row — nullable `IdempotencyKey` + filtered unique index (migration `AddIdempotencyKeyToVirtualKeyGroupTransactions`) — written in the **same atomic save** as the balance adjustment (`AdjustBalanceIdempotentAsync`, key `spend:{RequestId}`). A redelivered `SpendUpdateRequested` republishes the notification but cannot debit twice.

⚠️ Also fixes a latent double-charge bug: the old `newBalance >= 0` success check in `SpendUpdateProcessor` threw **after** the debit committed whenever a balance legitimately went negative, so each endpoint retry re-charged the group.

### 3. Publish-failure fallback
`EventPublishingServiceBase.TryPublishEventAsync` reports failure instead of swallowing; `CachedApiVirtualKeyService.UpdateSpendAsync` falls back to a **direct idempotent balance adjustment with the same RequestId key** — the charge is never lost, and a late event delivery dedups against the fallback row (no double charge in either direction).

### Not hardened (documented in the plan doc)
- `BatchWebhookPublisher`'s drop-on-overflow in-memory queue has no production call sites — flagged for Phase 3 removal instead.
- Admin config-invalidation publishes keep the tiny crash-between-commit-and-publish window (idempotent + TTL-backed consumers); true same-transaction enrollment would mean re-plumbing every Admin service through an EF outbox — deliberately out of scope.
- A crash *before* the publish call on the request path loses the spend — inherent to post-hoc billing, not fixable by an outbox.

## Verification
- New tests: repository dedup/atomicity (5), processor duplicate/depletion/no-RequestId (updated + 3 new), publish-failure fallback (3).
- Full suite: **2801 passed / 44 failed** — failure set name-identical to the environment baseline (no local Redis/Docker).
- Crash fault-injection on real Postgres runs with the #929 parity gate, per the phase plan.

⚠️ **This is a financial-path change — needs the mandatory second review.**

Closes #927 (on release to master). Part of #909.