### PR TITLE
test(messaging): in-memory Wolverine transport + dual-backend contract tests (#928)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -28,20 +28,29 @@ public partial class Program
             var (_, wolverineConnectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
                 .GetProviderAndConnectionString("AdminAPI", msg => startupLogger.LogInformation("{Message}", msg));
 
+            var postgresTransport = !WolverineMessagingExtensions.UsesInMemoryTransport(builder.Configuration);
+
             builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin", opts =>
             {
                 ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
 
                 // Event→queue topology (#926): the same publish routing as the Gateway
                 // (so Admin publishes land on the Gateway's queues), listening only on
-                // admin-events (the shared cache events).
-                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
-                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitAdmin(opts);
+                // admin-events (the shared cache events). Postgres queues only exist on
+                // the Postgresql transport — in-memory mode (dev/CI, #928) routes
+                // everything to local queues instead, like MassTransit in-memory.
+                if (postgresTransport)
+                {
+                    ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
+                    ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitAdmin(opts);
+                }
             });
 
             startupLogger.LogInformation(
-                "Event bus configured with the Wolverine backend (PostgreSQL transport, durable persistence, " +
-                "shared event->queue topology). Admin publishes route to the Gateway's tuned queues");
+                postgresTransport
+                    ? "Event bus configured with the Wolverine backend (PostgreSQL transport, durable persistence, " +
+                      "shared event->queue topology). Admin publishes route to the Gateway's tuned queues"
+                    : "Event bus configured with the Wolverine backend (in-memory transport, local queues only - dev/CI mode)");
             return;
         }
 

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -225,6 +225,8 @@ public partial class Program
         var (_, connectionString) = new ConduitLLM.Core.Data.ConnectionStringManager()
             .GetProviderAndConnectionString("CoreAPI");
 
+        var postgresTransport = !WolverineMessagingExtensions.UsesInMemoryTransport(builder.Configuration);
+
         builder.Host.AddConduitWolverine(builder.Configuration, connectionString, "conduit-gateway", opts =>
         {
             ConduitLLM.Gateway.Extensions.CacheInvalidationMessagingExtensions.AddGatewayCacheInvalidationBridges(opts);
@@ -238,9 +240,14 @@ public partial class Program
             opts.AddEventBridge<ConduitLLM.Configuration.Events.BatchSpendFlushRequestedEvent>();
 
             // Event→queue topology (#926): publish routing identical on all hosts;
-            // the Gateway listens on the four tuned queues + gateway-events.
-            ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
-            ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitGateway(opts);
+            // the Gateway listens on the four tuned queues + gateway-events. Postgres
+            // queues only exist on the Postgresql transport — in-memory mode (dev/CI,
+            // #928) routes everything to local queues instead, like MassTransit in-memory.
+            if (postgresTransport)
+            {
+                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ApplyConduitPublishRouting(opts);
+                ConduitLLM.Core.Messaging.ConduitMessagingTopology.ListenAsConduitGateway(opts);
+            }
         });
 
         // Batch webhook publisher: publishes via IEventBus, so it is backend-agnostic.

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -35,6 +35,37 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         public const string AutoProvisionKey = "ConduitLLM:Messaging:Wolverine:AutoProvision";
 
         /// <summary>
+        /// Configuration key selecting the Wolverine transport (I2.5/#928):
+        /// <c>Postgresql</c> (default — durable persistence + cross-service queues) or
+        /// <c>InMemory</c> (local queues only, no Postgres required — dev/CI parity with
+        /// MassTransit's in-memory mode). Unrecognized values throw at boot.
+        /// </summary>
+        public const string TransportKey = "ConduitLLM:Messaging:Wolverine:Transport";
+
+        /// <summary>
+        /// Resolves whether the in-memory transport is selected (see <see cref="TransportKey"/>).
+        /// Hosts use this to skip the Postgres queue topology, which only exists on the
+        /// Postgresql transport.
+        /// </summary>
+        public static bool UsesInMemoryTransport(IConfiguration configuration)
+        {
+            var transport = configuration[TransportKey] ?? "Postgresql";
+
+            if (transport.Equals("Postgresql", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (transport.Equals("InMemory", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            throw new InvalidOperationException(
+                $"Unrecognized value '{transport}' for '{TransportKey}'. Valid values: Postgresql, InMemory.");
+        }
+
+        /// <summary>
         /// Adds the Wolverine host on the PostgreSQL transport with durable persistence.
         /// </summary>
         /// <param name="host">The host builder.</param>
@@ -61,6 +92,7 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         {
             var schemaName = configuration[SchemaNameKey] ?? "wolverine";
             var autoProvision = configuration.GetValue(AutoProvisionKey, true);
+            var inMemory = UsesInMemoryTransport(configuration);
 
             return host.UseWolverine(opts =>
             {
@@ -73,25 +105,40 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                 // ('codegen write' + TypeLoadMode.Static) is a cutover optimization (#930).
                 opts.UseRuntimeCompilation();
 
-                // Persistence (inbox/outbox/scheduled messages) AND the message transport
-                // share the existing Postgres database, in an isolated schema.
-                opts.UsePostgresqlPersistenceAndTransport(connectionString, schemaName);
+                if (inMemory)
+                {
+                    // In-memory transport (I2.5/#928): local queues only, no persistence —
+                    // dev/CI can run the Wolverine backend without Postgres, matching the
+                    // durability level of MassTransit's in-memory mode. Solo skips the
+                    // multi-node leader-election agents a single test host never needs.
+                    opts.Durability.Mode = DurabilityMode.Solo;
+                }
+                else
+                {
+                    // Persistence (inbox/outbox/scheduled messages) AND the message
+                    // transport share the existing Postgres database, in an isolated schema.
+                    opts.UsePostgresqlPersistenceAndTransport(connectionString, schemaName);
+
+                    // Local queues (where in-process bridge handlers receive publishes) are
+                    // backed by the Postgres durability tables, so buffered messages survive
+                    // a crash — already an improvement on MassTransit's in-memory transport.
+                    opts.Policies.UseDurableLocalQueues();
+
+                    // Transactional outbox (I2.4/#927): every sending endpoint persists the
+                    // envelope to the Postgres outbox before delivery, so a publish accepted
+                    // by the bus survives a crash and is retried by the durability agent —
+                    // the fire-and-forget publish seams no longer lose events on transient
+                    // failure. Messages published from inside a handler additionally flush
+                    // atomically with handler completion (the message-context outbox).
+                    opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+                    opts.AutoBuildMessageStorageOnStartup = autoProvision
+                        ? AutoCreate.CreateOrUpdate
+                        : AutoCreate.None;
+                }
 
                 // Wraps handlers in a database transaction where one applies.
                 opts.Policies.AutoApplyTransactions();
-
-                // Local queues (where in-process bridge handlers receive publishes) are
-                // backed by the Postgres durability tables, so buffered messages survive
-                // a crash — already an improvement on MassTransit's in-memory transport.
-                opts.Policies.UseDurableLocalQueues();
-
-                // Transactional outbox (I2.4/#927): every sending endpoint persists the
-                // envelope to the Postgres outbox before delivery, so a publish accepted
-                // by the bus survives a crash and is retried by the durability agent —
-                // the fire-and-forget publish seams no longer lose events on transient
-                // failure. Messages published from inside a handler additionally flush
-                // atomically with handler completion (the message-context outbox).
-                opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
 
                 // Conduit's IEventHandler<T> implementations are named *Handler/*Consumer
                 // with HandleAsync methods, which Wolverine's conventional discovery would
@@ -99,10 +146,6 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                 // Dispatch goes exclusively through the explicit bridge registrations
                 // added in I2.2/#925.
                 opts.Discovery.DisableConventionalDiscovery();
-
-                opts.AutoBuildMessageStorageOnStartup = autoProvision
-                    ? AutoCreate.CreateOrUpdate
-                    : AutoCreate.None;
 
                 configure?.Invoke(opts);
             });

--- a/Tests/ConduitLLM.Tests/Messaging/EventBusBackendContractTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/EventBusBackendContractTests.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.MassTransit;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using MassTransit;
+using MassTransit.Testing;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Wolverine;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Backend-agnostic contract for the messaging abstraction (I2.5/#928): the same
+    /// assertions run against BOTH the MassTransit backend (in-memory test harness) and
+    /// the Wolverine backend (in-memory local queues), so the two implementations of
+    /// <see cref="IEventBus"/>/<see cref="IEventHandler{TEvent}"/> cannot drift apart.
+    /// Concrete subclasses supply only the host bootstrap.
+    /// </summary>
+    public abstract class EventBusBackendContractTests : IAsyncLifetime
+    {
+        public record ContractEvent(string Payload);
+        public record FollowOnEvent(string Payload);
+
+        public sealed class ContractSink
+        {
+            public ConcurrentQueue<ContractEvent> Primary { get; } = new();
+            public ConcurrentQueue<ContractEvent> Secondary { get; } = new();
+            public ConcurrentQueue<FollowOnEvent> FollowOns { get; } = new();
+            public Guid? LastMessageId { get; set; }
+            public string? LastCorrelationId { get; set; }
+
+            public TaskCompletionSource<bool> PrimarySignal { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource<bool> SecondarySignal { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public TaskCompletionSource<bool> FollowOnSignal { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private int _expectedPrimary = 1;
+            public void ExpectPrimary(int count) => _expectedPrimary = count;
+
+            public void RecordPrimary(ContractEvent @event, IEventContext context)
+            {
+                Primary.Enqueue(@event);
+                LastMessageId = context.MessageId;
+                LastCorrelationId = context.CorrelationId;
+                if (Primary.Count >= _expectedPrimary)
+                {
+                    PrimarySignal.TrySetResult(true);
+                }
+            }
+        }
+
+        public sealed class PrimaryHandler : IEventHandler<ContractEvent>
+        {
+            private readonly ContractSink _sink;
+            public PrimaryHandler(ContractSink sink) => _sink = sink;
+
+            public Task HandleAsync(ContractEvent @event, IEventContext context)
+            {
+                _sink.RecordPrimary(@event, context);
+                return Task.CompletedTask;
+            }
+        }
+
+        public sealed class SecondaryHandler : IEventHandler<ContractEvent>
+        {
+            private readonly ContractSink _sink;
+            public SecondaryHandler(ContractSink sink) => _sink = sink;
+
+            public Task HandleAsync(ContractEvent @event, IEventContext context)
+            {
+                _sink.Secondary.Enqueue(@event);
+                _sink.SecondarySignal.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>Publishes a follow-on event through the delivery context.</summary>
+        public sealed class CascadingHandler : IEventHandler<ContractEvent>
+        {
+            public async Task HandleAsync(ContractEvent @event, IEventContext context)
+            {
+                await context.PublishAsync(new FollowOnEvent(@event.Payload + "-cascaded"));
+            }
+        }
+
+        public sealed class FollowOnHandler : IEventHandler<FollowOnEvent>
+        {
+            private readonly ContractSink _sink;
+            public FollowOnHandler(ContractSink sink) => _sink = sink;
+
+            public Task HandleAsync(FollowOnEvent @event, IEventContext context)
+            {
+                _sink.FollowOns.Enqueue(@event);
+                _sink.FollowOnSignal.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+        protected ContractSink Sink { get; } = new();
+
+        /// <summary>
+        /// Boots the backend under test with the given handler registrations and one
+        /// bridge per event type. The sink is pre-registered.
+        /// </summary>
+        protected abstract Task StartHostAsync(
+            Action<IServiceCollection> registerHandlers,
+            params Type[] bridgedEventTypes);
+
+        /// <summary>Root provider of the running host.</summary>
+        protected abstract IServiceProvider Services { get; }
+
+        protected abstract Task StopHostAsync();
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public Task DisposeAsync() => StopHostAsync();
+
+        [Fact]
+        public async Task Publish_DispatchesToHandler_WithEnvelopeMetadata()
+        {
+            await StartHostAsync(
+                services => services.AddScoped<IEventHandler<ContractEvent>, PrimaryHandler>(),
+                typeof(ContractEvent));
+
+            using (var scope = Services.CreateScope())
+            {
+                var bus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                await bus.PublishAsync(new ContractEvent("hello"));
+            }
+
+            await Sink.PrimarySignal.Task.WaitAsync(Timeout);
+            Sink.Primary.Should().ContainSingle().Which.Payload.Should().Be("hello");
+            Sink.LastMessageId.Should().NotBeNull();
+            // CorrelationId is deliberately NOT part of the cross-backend contract for a
+            // bare publish: Wolverine auto-generates one, MassTransit leaves it null
+            // unless the publisher sets it (Conduit's DomainEvents carry their own).
+        }
+
+        [Fact]
+        public async Task Publish_DispatchesToAllRegisteredHandlers()
+        {
+            await StartHostAsync(
+                services =>
+                {
+                    services.AddScoped<IEventHandler<ContractEvent>, PrimaryHandler>();
+                    services.AddScoped<IEventHandler<ContractEvent>, SecondaryHandler>();
+                },
+                typeof(ContractEvent));
+
+            using (var scope = Services.CreateScope())
+            {
+                var bus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                await bus.PublishAsync(new ContractEvent("fan-out"));
+            }
+
+            await Sink.PrimarySignal.Task.WaitAsync(Timeout);
+            await Sink.SecondarySignal.Task.WaitAsync(Timeout);
+            Sink.Primary.Should().ContainSingle();
+            Sink.Secondary.Should().ContainSingle();
+        }
+
+        [Fact]
+        public async Task PublishBatch_DispatchesEveryEvent()
+        {
+            Sink.ExpectPrimary(3);
+
+            await StartHostAsync(
+                services => services.AddScoped<IEventHandler<ContractEvent>, PrimaryHandler>(),
+                typeof(ContractEvent));
+
+            using (var scope = Services.CreateScope())
+            {
+                var bus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                await bus.PublishBatchAsync(new List<ContractEvent>
+                {
+                    new("one"), new("two"), new("three")
+                });
+            }
+
+            await Sink.PrimarySignal.Task.WaitAsync(Timeout);
+            Sink.Primary.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public async Task HandlerCascade_PublishesFollowOnEvent_ThroughContext()
+        {
+            await StartHostAsync(
+                services =>
+                {
+                    services.AddScoped<IEventHandler<ContractEvent>, CascadingHandler>();
+                    services.AddScoped<IEventHandler<FollowOnEvent>, FollowOnHandler>();
+                },
+                typeof(ContractEvent), typeof(FollowOnEvent));
+
+            using (var scope = Services.CreateScope())
+            {
+                var bus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                await bus.PublishAsync(new ContractEvent("origin"));
+            }
+
+            await Sink.FollowOnSignal.Task.WaitAsync(Timeout);
+            Sink.FollowOns.Should().ContainSingle().Which.Payload.Should().Be("origin-cascaded");
+        }
+    }
+
+    /// <summary>MassTransit backend run of the contract (in-memory test harness).</summary>
+    public class MassTransitEventBusContractTests : EventBusBackendContractTests
+    {
+        private ServiceProvider? _provider;
+        private ITestHarness? _harness;
+
+        protected override IServiceProvider Services =>
+            _provider ?? throw new InvalidOperationException("Host not started");
+
+        protected override async Task StartHostAsync(
+            Action<IServiceCollection> registerHandlers,
+            params Type[] bridgedEventTypes)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(Sink);
+            registerHandlers(services);
+            services.AddMassTransitEventBus();
+            services.AddMassTransitTestHarness(x =>
+            {
+                foreach (var eventType in bridgedEventTypes)
+                {
+                    x.AddEventBridge(eventType);
+                }
+            });
+
+            _provider = services.BuildServiceProvider(true);
+            _harness = _provider.GetRequiredService<ITestHarness>();
+            await _harness.Start();
+        }
+
+        protected override async Task StopHostAsync()
+        {
+            if (_harness != null)
+            {
+                await _harness.Stop();
+            }
+
+            if (_provider != null)
+            {
+                await _provider.DisposeAsync();
+            }
+        }
+    }
+
+    /// <summary>Wolverine backend run of the contract (in-memory local queues).</summary>
+    public class WolverineEventBusContractTests : EventBusBackendContractTests
+    {
+        private IHost? _host;
+
+        protected override IServiceProvider Services =>
+            _host?.Services ?? throw new InvalidOperationException("Host not started");
+
+        protected override async Task StartHostAsync(
+            Action<IServiceCollection> registerHandlers,
+            params Type[] bridgedEventTypes)
+        {
+            _host = await Host.CreateDefaultBuilder()
+                .UseWolverine(opts =>
+                {
+                    // Production parity with AddConduitWolverine, minus Postgres.
+                    opts.Discovery.DisableConventionalDiscovery();
+                    opts.UseRuntimeCompilation();
+
+                    foreach (var eventType in bridgedEventTypes)
+                    {
+                        opts.AddEventBridge(eventType);
+                    }
+
+                    opts.Services.AddSingleton(Sink);
+                    registerHandlers(opts.Services);
+                    opts.Services.AddWolverineEventBus();
+                })
+                .StartAsync();
+        }
+
+        protected override async Task StopHostAsync()
+        {
+            if (_host != null)
+            {
+                await _host.StopAsync();
+                _host.Dispose();
+            }
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineInMemoryTransportTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineInMemoryTransportTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Tests for the Wolverine in-memory transport mode (I2.5/#928): the PRODUCTION
+    /// composition path (<see cref="WolverineMessagingExtensions.AddConduitWolverine"/>)
+    /// boots and delivers events without Postgres when
+    /// <c>ConduitLLM:Messaging:Wolverine:Transport = InMemory</c> — this is what lets
+    /// dev/CI run the whole suite on the Wolverine backend.
+    /// </summary>
+    public class WolverineInMemoryTransportTests
+    {
+        public record InMemoryPilotEvent(string Payload);
+
+        public sealed class PilotSink
+        {
+            public List<InMemoryPilotEvent> Received { get; } = new();
+            public TaskCompletionSource<InMemoryPilotEvent> Signal { get; } =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public sealed class RecordingPilotHandler : IEventHandler<InMemoryPilotEvent>
+        {
+            private readonly PilotSink _sink;
+            public RecordingPilotHandler(PilotSink sink) => _sink = sink;
+
+            public Task HandleAsync(InMemoryPilotEvent @event, IEventContext context)
+            {
+                _sink.Received.Add(@event);
+                _sink.Signal.TrySetResult(@event);
+                return Task.CompletedTask;
+            }
+        }
+
+        private static IConfiguration BuildConfiguration(string? transport)
+        {
+            var values = new Dictionary<string, string?>();
+            if (transport != null)
+            {
+                values[WolverineMessagingExtensions.TransportKey] = transport;
+            }
+
+            return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        }
+
+        [Fact]
+        public void UsesInMemoryTransport_DefaultsToPostgresql()
+        {
+            WolverineMessagingExtensions.UsesInMemoryTransport(BuildConfiguration(null))
+                .Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("Postgresql", false)]
+        [InlineData("postgresql", false)]
+        [InlineData("InMemory", true)]
+        [InlineData("inmemory", true)]
+        public void UsesInMemoryTransport_ResolvesKnownValues(string transport, bool expected)
+        {
+            WolverineMessagingExtensions.UsesInMemoryTransport(BuildConfiguration(transport))
+                .Should().Be(expected);
+        }
+
+        [Fact]
+        public void UsesInMemoryTransport_ThrowsOnUnrecognizedValue()
+        {
+            var act = () => WolverineMessagingExtensions.UsesInMemoryTransport(
+                BuildConfiguration("RabbitMQ"));
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*RabbitMQ*Postgresql, InMemory*");
+        }
+
+        [Fact]
+        public async Task AddConduitWolverine_InMemoryTransport_BootsAndDeliversWithoutPostgres()
+        {
+            var sink = new PilotSink();
+            var configuration = BuildConfiguration("InMemory");
+
+            // The connection string is deliberately unusable: in-memory mode must never
+            // touch it (Postgres persistence, transport, and outbox are all skipped).
+            using var host = await Host.CreateDefaultBuilder()
+                .AddConduitWolverine(configuration, "Host=unreachable;Database=none", "conduit-test", opts =>
+                {
+                    opts.AddEventBridge<InMemoryPilotEvent>();
+                    opts.Services.AddSingleton(sink);
+                    opts.Services.AddScoped<IEventHandler<InMemoryPilotEvent>, RecordingPilotHandler>();
+                    opts.Services.AddWolverineEventBus();
+                })
+                .StartAsync();
+
+            try
+            {
+                using (var scope = host.Services.CreateScope())
+                {
+                    var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+                    eventBus.Should().BeOfType<WolverineEventBus>();
+                    await eventBus.PublishAsync(new InMemoryPilotEvent("no-postgres"));
+                }
+
+                var received = await sink.Signal.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                received.Payload.Should().Be("no-postgres");
+                sink.Received.Should().ContainSingle();
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+    }
+}

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -158,14 +158,30 @@ outbox and is deliberately out of scope).
 Acceptance: dedup/atomicity/fallback covered by unit tests; the crash fault-injection on
 real Postgres runs with the #929 parity gate.
 
-## I2.5 — Port the test suite (#928)
+## I2.5 — Port the test suite (#928) — ✅ implemented
 
-- Dev/CI uses Wolverine **in-memory local queues** (`opts.UseInMemory...` / `Durability =
-  DurabilityMode.MediatorOnly` style) so the suite runs without Postgres.
-- Extend the Phase 1 test doubles: run the abstraction/handler tests against BOTH backends
-  (parameterize the pilot harness). `TestEventContext` already covers handler-level tests
-  unchanged.
-- Acceptance: suite green on the Wolverine backend in CI.
+- **In-memory transport mode**: `ConduitLLM:Messaging:Wolverine:Transport` = `Postgresql`
+  (default) | `InMemory` (unrecognized → throw at boot). `InMemory` skips Postgres
+  persistence/transport and the durability policies (durable local queues, sending-endpoint
+  outbox, storage auto-provisioning) and runs `DurabilityMode.Solo` on in-memory local
+  queues — the same durability level as MassTransit's in-memory mode, no Postgres needed.
+  Hosts gate the #926 queue topology on the transport (`ApplyConduitPublishRouting` /
+  `ListenAsConduit*` are Postgres-queue APIs); in-memory mode routes everything to local
+  queues, exactly like MassTransit in-memory. Verified by
+  `WolverineInMemoryTransportTests`: the production `AddConduitWolverine` composition
+  boots and delivers end-to-end with a deliberately unusable connection string.
+- **Dual-backend contract**: `EventBusBackendContractTests` — one abstract contract
+  (publish→handler dispatch with envelope metadata, multi-handler fan-out,
+  `PublishBatchAsync`, handler cascade via `IEventContext.PublishAsync`) with a subclass
+  per backend (MassTransit in-memory test harness / Wolverine in-memory local queues),
+  so the two `IEventBus` implementations cannot drift. `TestEventContext` continues to
+  cover handler-level tests unchanged. **Contract note discovered by these tests:**
+  `CorrelationId` on a bare publish is backend-dependent (Wolverine auto-generates,
+  MassTransit leaves it null) — it is deliberately excluded from the contract; Conduit's
+  `DomainEvent`s carry their own correlation ids.
+- Acceptance: suite green with both backends' harnesses in CI (no Postgres/RabbitMQ
+  required); running the FULL suite with the flag flipped to Wolverine in staging is
+  part of the #929 gate.
 
 ## I2.6 — Parity & ordering validation (#929) — GATE
 


### PR DESCRIPTION
## Summary (I2.5 / #928 — epic #909)

Ports the test story to the Wolverine backend so dev/CI can exercise it **without Postgres**, and locks the two backends to one behavioral contract.

### In-memory transport mode
New knob `ConduitLLM:Messaging:Wolverine:Transport` = `Postgresql` (default) | `InMemory` (unrecognized → throw at boot, same convention as the backend flag).

- **InMemory** skips Postgres persistence/transport and the durability policies (durable local queues, sending-endpoint outbox, storage auto-provisioning) and runs `DurabilityMode.Solo` on in-memory local queues — the same durability level as MassTransit's in-memory mode.
- Both hosts gate the #926 queue topology on the transport (`ApplyConduitPublishRouting`/`ListenAsConduit*` are Postgres-queue APIs); in-memory mode routes everything to local queues, exactly like MassTransit in-memory.
- `WolverineInMemoryTransportTests` proves the **production** `AddConduitWolverine` composition boots and delivers end-to-end with a deliberately unusable connection string.

### Dual-backend contract tests
`EventBusBackendContractTests` — one abstract contract, one subclass per backend (MassTransit in-memory test harness / Wolverine in-memory local queues):
- publish → handler dispatch with envelope metadata
- multi-handler fan-out
- `PublishBatchAsync` delivers every event
- handler cascade via `IEventContext.PublishAsync`

**Contract note the tests surfaced:** `CorrelationId` on a bare publish is backend-dependent (Wolverine auto-generates one, MassTransit leaves it null) — deliberately excluded from the contract; Conduit's `DomainEvent`s carry their own correlation ids.

## Verification
- 15 new tests, all green.
- Full suite: **2816 passed / 44 failed** — failure set is the environment baseline (no local Redis/Docker), identical to dev.
- Running the full suite with the flag flipped in staging remains part of the #929 gate.

Closes #928 (on release to master). Part of #909.