### PR TITLE
feat(messaging): Wolverine bus health check + OTel bus metrics/tracing (#931)

### DIFF
--- a/Services/ConduitLLM.Admin/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Admin/Program.Monitoring.cs
@@ -17,7 +17,25 @@ public partial class Program
     private static void ConfigureMonitoringServices(WebApplicationBuilder builder, ILogger startupLogger)
     {
         // Add basic health checks
-        builder.Services.AddHealthChecks();
+        var healthChecksBuilder = builder.Services.AddHealthChecks();
+
+        // Wolverine bus health check (#931): probes the Postgres message store
+        // (inbox/outbox/scheduled/dead-letter counts). Only on the Postgresql
+        // transport — the in-memory dev/CI mode has no store to probe.
+        if (ConduitLLM.Configuration.Messaging.MessagingBackendResolver.Resolve(builder.Configuration)
+                == ConduitLLM.Configuration.Messaging.MessagingBackend.Wolverine
+            && !ConduitLLM.Configuration.Messaging.Wolverine.WolverineMessagingExtensions
+                .UsesInMemoryTransport(builder.Configuration))
+        {
+            var deadLetterThreshold = builder.Configuration.GetValue(
+                ConduitLLM.Configuration.Messaging.Wolverine.WolverineBusHealthCheck.DeadLetterThresholdKey, 1);
+
+            healthChecksBuilder.AddTypeActivatedCheck<ConduitLLM.Configuration.Messaging.Wolverine.WolverineBusHealthCheck>(
+                "wolverine_bus",
+                failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,
+                tags: new[] { "messaging", "wolverine", "ready" },
+                args: new object[] { deadLetterThreshold });
+        }
 
         // Add connection pool warmer with coordinated warming to prevent thundering herd during deployments
         builder.Services.AddCoordinatedConnectionPoolWarming(builder.Configuration, "AdminAPI");
@@ -41,6 +59,14 @@ public partial class Program
                     .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
                     .AddMeter("ConduitLLM.Admin.Requests")
                     .AddMeter("ConduitLLM.Providers")
+                    // Bus metrics (#931). Wolverine's meter is "Wolverine:{ServiceName}",
+                    // so the wildcard is required; it emits sent/succeeded/failure
+                    // counters, execution/effective-time histograms, and (on the Postgres
+                    // transport) inbox/outbox/scheduled depth gauges + dead-letter counts.
+                    // The MassTransit meter keeps the current backend measurable for the
+                    // #929 parity gate. Inactive meters cost nothing.
+                    .AddMeter("Wolverine*")
+                    .AddMeter("MassTransit")
                     .AddPrometheusExporter();
             });
 
@@ -62,6 +88,8 @@ public partial class Program
                     .AddHttpClientInstrumentation()
                     .AddSource("ConduitLLM.Admin.Requests")
                     .AddSource("ConduitLLM.Providers")
+                    // Wolverine message-processing spans (#931); inactive on MassTransit.
+                    .AddSource("Wolverine")
                     .AddOtlpExporter(options =>
                     {
                         options.Endpoint = new Uri(otlpEndpoint);

--- a/Services/ConduitLLM.Gateway/Extensions/ObservabilityExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/ObservabilityExtensions.cs
@@ -32,6 +32,14 @@ public static class ObservabilityExtensions
                     .AddMeter("ConduitLLM.MediaGeneration")
                     .AddMeter("ConduitLLM.Gateway.Requests")
                     .AddMeter("ConduitLLM.Providers")
+                    // Bus metrics (#931). Wolverine's meter is "Wolverine:{ServiceName}",
+                    // so the wildcard is required; it emits sent/succeeded/failure
+                    // counters, execution/effective-time histograms, and (on the Postgres
+                    // transport) inbox/outbox/scheduled depth gauges + dead-letter counts.
+                    // The MassTransit meter keeps the current backend measurable for the
+                    // #929 parity gate. Inactive meters cost nothing.
+                    .AddMeter("Wolverine*")
+                    .AddMeter("MassTransit")
                     .AddPrometheusExporter();
             });
 
@@ -60,6 +68,8 @@ public static class ObservabilityExtensions
                     .AddSource("ConduitLLM.MediaGeneration")
                     .AddSource("ConduitLLM.Gateway.Requests")
                     .AddSource("ConduitLLM.Providers")
+                    // Wolverine message-processing spans (#931); inactive on MassTransit.
+                    .AddSource("Wolverine")
                     .AddOtlpExporter(options =>
                     {
                         options.Endpoint = new Uri(otlpEndpoint);

--- a/Services/ConduitLLM.Gateway/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Gateway/Program.Monitoring.cs
@@ -42,18 +42,36 @@ public partial class Program
             // Add basic health checks
             var healthChecksBuilder = builder.Services.AddHealthChecks();
 
+            var messagingBackend =
+                ConduitLLM.Configuration.Messaging.MessagingBackendResolver.Resolve(builder.Configuration);
+
             // Add comprehensive RabbitMQ health check if RabbitMQ is configured AND the
             // MassTransit backend is active — the check injects MassTransit's IBus, which
-            // is not registered on the Wolverine backend (#925; Wolverine-native health
-            // checks land in #931).
+            // is not registered on the Wolverine backend (#925).
             if (useRabbitMq
-                && ConduitLLM.Configuration.Messaging.MessagingBackendResolver.Resolve(builder.Configuration)
-                    == ConduitLLM.Configuration.Messaging.MessagingBackend.MassTransit)
+                && messagingBackend == ConduitLLM.Configuration.Messaging.MessagingBackend.MassTransit)
             {
                 healthChecksBuilder.AddCheck<ConduitLLM.Core.HealthChecks.RabbitMQHealthCheck>(
                     "rabbitmq_comprehensive",
                     failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,
                     tags: new[] { "messaging", "rabbitmq", "performance", "monitoring" });
+            }
+
+            // Wolverine bus health check (#931): probes the Postgres message store
+            // (inbox/outbox/scheduled/dead-letter counts). Only on the Postgresql
+            // transport — the in-memory dev/CI mode has no store to probe.
+            if (messagingBackend == ConduitLLM.Configuration.Messaging.MessagingBackend.Wolverine
+                && !ConduitLLM.Configuration.Messaging.Wolverine.WolverineMessagingExtensions
+                    .UsesInMemoryTransport(builder.Configuration))
+            {
+                var deadLetterThreshold = builder.Configuration.GetValue(
+                    ConduitLLM.Configuration.Messaging.Wolverine.WolverineBusHealthCheck.DeadLetterThresholdKey, 1);
+
+                healthChecksBuilder.AddTypeActivatedCheck<ConduitLLM.Configuration.Messaging.Wolverine.WolverineBusHealthCheck>(
+                    "wolverine_bus",
+                    failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,
+                    tags: new[] { "messaging", "wolverine", "ready" },
+                    args: new object[] { deadLetterThreshold });
             }
 
             // Add Redis health check if Redis is configured

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineBusHealthCheck.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineBusHealthCheck.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+using Wolverine.Persistence.Durability;
+
+namespace ConduitLLM.Configuration.Messaging.Wolverine
+{
+    /// <summary>
+    /// Health check for the Wolverine messaging backend (I2.8/#931) — the replacement
+    /// for <c>RabbitMQHealthCheck</c> once the flag is flipped. Probes the Postgres
+    /// message store (inbox/outbox/scheduled/dead-letter counts), so it verifies the
+    /// durability layer end-to-end rather than just DI resolution.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful on the Postgresql transport — hosts gate registration on
+    /// <see cref="WolverineMessagingExtensions.UsesInMemoryTransport"/> being false
+    /// (the in-memory dev/CI mode has no message store to probe).
+    /// <para>
+    /// Status mapping: store unreachable → Unhealthy (the bus cannot persist or deliver);
+    /// dead-letter count at or above the threshold → Degraded (messages are exhausting
+    /// their retries — for the financial queues that warrants investigation); otherwise
+    /// Healthy. The queue counts are always reported in the health entry's data.
+    /// </para>
+    /// </remarks>
+    public class WolverineBusHealthCheck : IHealthCheck
+    {
+        private readonly IMessageStore _messageStore;
+        private readonly ILogger<WolverineBusHealthCheck> _logger;
+        private readonly int _deadLetterDegradedThreshold;
+
+        /// <summary>
+        /// Configuration key for the dead-letter Degraded threshold (default 1 — any
+        /// dead-lettered message marks the bus Degraded).
+        /// </summary>
+        public const string DeadLetterThresholdKey =
+            "ConduitLLM:Messaging:Wolverine:HealthCheck:DeadLetterDegradedThreshold";
+
+        /// <summary>
+        /// Initializes the health check.
+        /// </summary>
+        /// <param name="messageStore">Wolverine's message store (registered by the Postgresql transport).</param>
+        /// <param name="logger">Logger.</param>
+        /// <param name="deadLetterDegradedThreshold">Dead-letter count at which the bus reports Degraded.</param>
+        public WolverineBusHealthCheck(
+            IMessageStore messageStore,
+            ILogger<WolverineBusHealthCheck> logger,
+            int deadLetterDegradedThreshold = 1)
+        {
+            _messageStore = messageStore ?? throw new ArgumentNullException(nameof(messageStore));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _deadLetterDegradedThreshold = deadLetterDegradedThreshold;
+        }
+
+        /// <inheritdoc />
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var counts = await _messageStore.Admin.FetchCountsAsync();
+
+                var data = new Dictionary<string, object>
+                {
+                    ["incoming"] = counts.Incoming,
+                    ["outgoing"] = counts.Outgoing,
+                    ["scheduled"] = counts.Scheduled,
+                    ["dead_letter"] = counts.DeadLetter,
+                    ["handled"] = counts.Handled
+                };
+
+                if (counts.DeadLetter >= _deadLetterDegradedThreshold)
+                {
+                    return HealthCheckResult.Degraded(
+                        $"Wolverine bus reachable but {counts.DeadLetter} message(s) are dead-lettered " +
+                        $"(threshold {_deadLetterDegradedThreshold})",
+                        data: data);
+                }
+
+                return HealthCheckResult.Healthy("Wolverine bus and message store reachable", data);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Wolverine message store health probe failed");
+                return HealthCheckResult.Unhealthy(
+                    "Wolverine message store unreachable - the bus cannot persist or deliver messages",
+                    ex);
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -135,6 +135,10 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
                     opts.AutoBuildMessageStorageOnStartup = autoProvision
                         ? AutoCreate.CreateOrUpdate
                         : AutoCreate.None;
+
+                    // The durability agent's periodic node-assignment checks would
+                    // otherwise emit a steady stream of no-op spans (#931).
+                    opts.Durability.NodeAssignmentHealthCheckTracingEnabled = false;
                 }
 
                 // Wraps handlers in a database transaction where one applies.

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineBusHealthCheckTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineBusHealthCheckTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Threading.Tasks;
+
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Wolverine.Logging;
+using Wolverine.Persistence.Durability;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Messaging
+{
+    /// <summary>
+    /// Tests for the Wolverine bus health check (I2.8/#931) — the RabbitMQHealthCheck
+    /// replacement: message-store counts map to Healthy/Degraded, store failures to
+    /// Unhealthy.
+    /// </summary>
+    public class WolverineBusHealthCheckTests
+    {
+        private readonly Mock<IMessageStore> _storeMock = new();
+        private readonly Mock<IMessageStoreAdmin> _adminMock = new();
+        private readonly ILogger<WolverineBusHealthCheck> _logger =
+            new Mock<ILogger<WolverineBusHealthCheck>>().Object;
+
+        public WolverineBusHealthCheckTests()
+        {
+            _storeMock.SetupGet(s => s.Admin).Returns(_adminMock.Object);
+        }
+
+        private WolverineBusHealthCheck CreateCheck(int threshold = 1) =>
+            new(_storeMock.Object, _logger, threshold);
+
+        private static HealthCheckContext Context() => new()
+        {
+            Registration = new HealthCheckRegistration(
+                "wolverine_bus", _ => null!, HealthStatus.Unhealthy, null)
+        };
+
+        [Fact]
+        public async Task CheckHealthAsync_WithReachableStore_ReturnsHealthyWithCounts()
+        {
+            _adminMock
+                .Setup(a => a.FetchCountsAsync())
+                .ReturnsAsync(new PersistedCounts
+                {
+                    Incoming = 2,
+                    Outgoing = 3,
+                    Scheduled = 4,
+                    DeadLetter = 0,
+                    Handled = 5
+                });
+
+            var result = await CreateCheck().CheckHealthAsync(Context());
+
+            result.Status.Should().Be(HealthStatus.Healthy);
+            result.Data["incoming"].Should().Be(2);
+            result.Data["outgoing"].Should().Be(3);
+            result.Data["scheduled"].Should().Be(4);
+            result.Data["dead_letter"].Should().Be(0);
+            result.Data["handled"].Should().Be(5);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_WithDeadLettersAtThreshold_ReturnsDegraded()
+        {
+            _adminMock
+                .Setup(a => a.FetchCountsAsync())
+                .ReturnsAsync(new PersistedCounts { DeadLetter = 3 });
+
+            var result = await CreateCheck(threshold: 1).CheckHealthAsync(Context());
+
+            result.Status.Should().Be(HealthStatus.Degraded);
+            result.Description.Should().Contain("3");
+            result.Data["dead_letter"].Should().Be(3);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_WithDeadLettersBelowThreshold_ReturnsHealthy()
+        {
+            _adminMock
+                .Setup(a => a.FetchCountsAsync())
+                .ReturnsAsync(new PersistedCounts { DeadLetter = 2 });
+
+            var result = await CreateCheck(threshold: 5).CheckHealthAsync(Context());
+
+            result.Status.Should().Be(HealthStatus.Healthy);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_WhenStoreThrows_ReturnsUnhealthy()
+        {
+            _adminMock
+                .Setup(a => a.FetchCountsAsync())
+                .ThrowsAsync(new InvalidOperationException("connection refused"));
+
+            var result = await CreateCheck().CheckHealthAsync(Context());
+
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+            result.Exception.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Constructor_WithNullStore_Throws()
+        {
+            var act = () => new WolverineBusHealthCheck(null!, _logger);
+
+            act.Should().Throw<ArgumentNullException>().WithParameterName("messageStore");
+        }
+    }
+}

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -196,12 +196,30 @@ real Postgres runs with the #929 parity gate.
   switchable for instant rollback for one release cycle. Both backends remain in the build.
 - **Operational rollout — performed in the deployment pipeline, not from a code change.**
 
-## I2.8 — Observability (#931)
+## I2.8 — Observability (#931) — ✅ implemented (dashboards/alerts = ops-side at #930)
 
-- Wolverine OpenTelemetry metrics/tracing + health checks; replace `RabbitMQHealthCheck`
-  with a bus/queue-depth health check; update dashboards/alerts.
-- Acceptance: Wolverine queue depth/failures/retries visible; health endpoint reflects the
-  new bus.
+- **Health check**: `WolverineBusHealthCheck` (Configuration/Messaging/Wolverine) probes
+  `IMessageStore.Admin.FetchCountsAsync()` — Unhealthy when the Postgres message store is
+  unreachable, Degraded at ≥ `…:Wolverine:HealthCheck:DeadLetterDegradedThreshold`
+  (default 1) dead-lettered messages, counts always in the health entry data. Registered
+  in BOTH hosts as `wolverine_bus` (tags `messaging`/`wolverine`/`ready`), gated on
+  backend == Wolverine AND the Postgresql transport (the in-memory mode has no store).
+  Unlike the `RabbitMQHealthCheck` it replaces (which only proved `IBus` resolved, and
+  was Gateway-only), it verifies the durability layer end-to-end. `RabbitMQHealthCheck`
+  itself stays until Phase 3 (#932) for instant rollback.
+- **Metrics/tracing**: both hosts' OTel registrations add meter `Wolverine*` (the meter
+  name is `Wolverine:{ServiceName}` — wildcard required) → sent/succeeded/failure
+  counters, execution/effective-time histograms, dead-letter counter, and
+  inbox/outbox/scheduled queue-depth gauges on the Postgres transport; plus meter
+  `MassTransit` so the current backend is measurable for the #929 parity comparison.
+  Tracing adds source `Wolverine`; `NodeAssignmentHealthCheckTracingEnabled = false` in
+  `AddConduitWolverine` suppresses the durability agent's no-op span noise. Everything
+  exports through the existing Prometheus `/metrics` + OTLP pipeline.
+- Ops docs updated: `docs/operations/monitoring/health-checks.md` gained a "Message Bus
+  Health & Metrics" section (check semantics, metric names, suggested alerts). Actual
+  dashboard/alert provisioning happens with the cutover (#930).
+- Acceptance: queue depth/failures/dead-letters visible at `/metrics`; health endpoint
+  reflects the active bus on both hosts; unit tests cover the status mapping.
 
 ## Why this is staged, not done in one PR
 

--- a/docs/operations/monitoring/health-checks.md
+++ b/docs/operations/monitoring/health-checks.md
@@ -447,3 +447,45 @@ For internal monitoring dashboards, additional detailed endpoints are available:
 - `/api/health/history` - Health metrics history (Admin API)
 
 These endpoints return the same `404 Not Found` for unauthorized external requests.
+
+## Message Bus Health & Metrics
+
+The event bus health check depends on the active messaging backend
+(`ConduitLLM:Messaging:Backend`, epic #909):
+
+| Backend | Check name | What it verifies |
+|---------|------------|------------------|
+| MassTransit (default) | `rabbitmq_comprehensive` (Gateway only) | MassTransit `IBus` resolves (RabbitMQ connectivity at startup) |
+| Wolverine | `wolverine_bus` (Gateway + Admin) | Postgres message store reachable; reports inbox/outbox/scheduled/dead-letter counts in the health entry data |
+
+`wolverine_bus` surfaces on `/health` and `/health/ready` (tags `messaging`,
+`wolverine`, `ready`) and reports:
+
+- **Unhealthy** — the message store is unreachable (the bus cannot persist or
+  deliver messages).
+- **Degraded** — dead-lettered messages at or above
+  `ConduitLLM:Messaging:Wolverine:HealthCheck:DeadLetterDegradedThreshold`
+  (default `1`) — messages are exhausting their retries; for the spend/webhook
+  queues this warrants investigation.
+- It is only registered on the Postgresql transport
+  (`ConduitLLM:Messaging:Wolverine:Transport` = `Postgresql`); the in-memory
+  dev/CI mode has no message store to probe.
+
+### Bus metrics (`/metrics`, Prometheus)
+
+Both hosts export bus metrics through OpenTelemetry:
+
+- **Wolverine** (meter `Wolverine:{service}`): `wolverine-messages-sent`,
+  `wolverine-messages-succeeded`, `wolverine-execution-failure` (tagged by
+  exception type), `wolverine-dead-letter-queue`, execution/effective-time
+  histograms, and queue-depth gauges `wolverine-inbox-count`,
+  `wolverine-outbox-count`, `wolverine-scheduled-count` (Postgres transport).
+- **MassTransit** (meter `MassTransit`): built-in consume/publish counters and
+  durations — exported so the #929 parity gate can compare backends.
+
+Wolverine message-processing traces are exported under the `Wolverine`
+activity source when `Telemetry:TracingEnabled` is on.
+
+Suggested alerts: `wolverine-dead-letter-queue` rate > 0 (financial queues),
+`wolverine-inbox-count` sustained growth (consumer lag), health endpoint
+Degraded/Unhealthy transitions.


### PR DESCRIPTION
## Summary (I2.8 / #931 — epic #909)

Makes the Wolverine backend observable so the #929 parity gate and #930 cutover have something to watch.

### Health check
`WolverineBusHealthCheck` probes `IMessageStore.Admin.FetchCountsAsync()` — a real end-to-end durability-layer check, unlike the `RabbitMQHealthCheck` it replaces (which only proved MassTransit's `IBus` resolved, and was Gateway-only):

- **Unhealthy** — Postgres message store unreachable (the bus cannot persist or deliver)
- **Degraded** — dead-lettered messages ≥ `ConduitLLM:Messaging:Wolverine:HealthCheck:DeadLetterDegradedThreshold` (default 1)
- inbox/outbox/scheduled/dead-letter counts always reported in the health entry data

Registered as `wolverine_bus` in **both** hosts (tags `messaging`/`wolverine`/`ready`), gated on backend == Wolverine **and** the Postgresql transport (the #928 in-memory mode has no store to probe). `RabbitMQHealthCheck` stays until Phase 3 (#932) for instant rollback.

### Metrics & tracing
Both hosts' existing OTel pipelines (Prometheus `/metrics` + OTLP) gain:

- meter `Wolverine*` (the meter name is `Wolverine:{ServiceName}` — wildcard required): sent/succeeded/failure counters, execution + effective-time histograms, dead-letter counter, and `wolverine-inbox/outbox/scheduled-count` queue-depth gauges on the Postgres transport
- meter `MassTransit` — the current backend becomes measurable too, giving #929 a baseline for parity comparison
- tracing source `Wolverine`; `NodeAssignmentHealthCheckTracingEnabled = false` suppresses the durability agent's no-op span noise

Inactive meters/sources cost nothing, so both are registered unconditionally.

### Docs
`docs/operations/monitoring/health-checks.md` gains a **Message Bus Health & Metrics** section (per-backend check table, metric names, suggested alerts: dead-letter rate > 0 on financial queues, sustained inbox growth = consumer lag). Dashboard/alert provisioning is ops-side at cutover (#930), per the phase plan.

## Verification
- 5 new unit tests (status mapping: healthy counts, degraded threshold, unhealthy store failure), all green.
- Full suite: **2821 passed / 44 failed** — failure set identical to the environment baseline.

Closes #931 (on release to master). Part of #909.