### PR TITLE
docs(messaging): parity-gate runbook for #929 staging execution

### DIFF
--- a/docs/architecture/messaging-migration/phase2-parity-gate-runbook.md
+++ b/docs/architecture/messaging-migration/phase2-parity-gate-runbook.md
@@ -1,0 +1,157 @@
+# Phase 2 Parity Gate Runbook (I2.6 / #929)
+
+**Status: ready to execute — requires staging infrastructure (real Postgres + RabbitMQ +
+Redis + load tooling). This is the sign-off gate for the #930 cutover.**
+
+This gate certifies that the Wolverine backend behaves at parity with the MassTransit
+baseline under load. It **absorbs three obligations** carried forward from earlier
+issues:
+
+1. The **staging smoke** originally specified for the Phase 1 gate (#923, never run in
+   staging — Phase 1 shipped on the code-only gate).
+2. The **mandatory second review of the financial path** (#921/#927).
+3. The **crash fault-injection** acceptance for the transactional outbox (#927), which
+   needs real Postgres.
+
+## Prerequisites
+
+- [ ] `dev` contains #924–#928 and #931 (verify: `git merge-base --is-ancestor` for the
+      merge commits; do not trust PR badges — see the stacked-PR stranding incidents).
+- [ ] Staging runs both hosts with `ConduitLLM:Messaging:Backend` switchable at deploy
+      time; default `MassTransit`.
+- [ ] EF migration `AddIdempotencyKeyToVirtualKeyGroupTransactions` applied
+      (`dotnet ef database update`); verify the filtered unique index
+      `IX_VirtualKeyGroupTransactions_IdempotencyKey` exists.
+- [ ] Wolverine schema provisioning decided: staging may use
+      `ConduitLLM:Messaging:Wolverine:AutoProvision=true`; production uses scripted
+      provisioning (`false`).
+- [ ] `ConduitLLM:Messaging:Wolverine:Transport` is `Postgresql` (default) — the
+      in-memory mode is for dev/CI only and skips everything this gate certifies.
+- [ ] Observability reachable on both hosts: `/metrics` (Prometheus) and
+      `/health/ready`. On Wolverine expect the `wolverine_bus` check and the
+      `Wolverine:{service}` meters; on MassTransit expect `rabbitmq_comprehensive`
+      (Gateway) and the `MassTransit` meter.
+- [ ] Load tooling able to drive: virtual-key chat completions (spend), image/video
+      generation with webhook URLs, admin config edits. A webhook sink that records
+      receipt timestamps (e.g. requestbin-style with logging) is required for S3.
+
+## Execution order
+
+Run the **full scenario set twice**: first on `Backend=MassTransit` (baseline capture),
+then on `Backend=Wolverine` (candidate). Record the same measurements both times; the
+parity report is the side-by-side table.
+
+> Deploy note (from Phase 1): the bridge-named queues replaced per-consumer queues —
+> when flipping backends, drain in-flight messages first (see S7 rollback drill).
+
+## Scenarios
+
+### S1 — Functional smoke (absorbs #923)
+
+| Step | Verify |
+|---|---|
+| Admin edits a global setting / provider / model mapping / model cost / IP filter | Gateway cache invalidates (observe next request behavior or cache logs) — Admin→Gateway invalidation rides the bus on Wolverine (#926) |
+| Image generation request (async, with webhook) | Task completes; media stored; webhook delivered; spend debited |
+| Video generation request + cancel | Cancel honored; no spend for cancelled work beyond policy |
+| Direct webhook path failure (unreachable URL) | Retries at ~4s/8s/16s (2^(n+1)s, max 3), then dead-letter; `wolverine-dead-letter-queue` increments on Wolverine |
+| Spend update on a chat completion | Group balance debited once; `SpendUpdated` notification observed; ledger row has `IdempotencyKey = spend:{RequestId}` |
+
+### S2 — Spend ordering + exactly-once under load (FINANCIAL — HIGH RISK)
+
+The spend queue (`spend-update-events`) is single-active-consumer with
+`ConcurrentMessageLimit=1` (MassTransit/RabbitMQ) → `ListenWithStrictOrdering()`
+(Wolverine/Postgres). Target sustained load: **~17 msg/s** (the tuned production rate),
+mixed across ≥ 50 virtual keys in ≥ 10 groups, ≥ 10,000 total spend events.
+
+Measurements (identical on both backends):
+
+- [ ] **Per-key ordering**: for each key, ledger rows' `CreatedAt`/id order matches
+      publish order (embed a sequence number in the request description or correlate
+      via RequestId → publish log).
+- [ ] **Exactly-once**: `SUM(ledger debits per group) == SUM(published amounts per group)`
+      to the cent, AND `COUNT(DISTINCT IdempotencyKey) == COUNT(ledger rows with key)`
+      (no duplicate application), AND every published RequestId has exactly one ledger row.
+- [ ] **Zero loss**: no published RequestId missing from the ledger after drain
+      (allow the retry window to complete before reconciling).
+- [ ] Throughput ≥ baseline; consumer lag (`wolverine-inbox-count` for the spend queue /
+      RabbitMQ queue depth) returns to ~0 after load stops.
+
+### S3 — Webhook throughput + deferral timing
+
+Webhook endpoint: concurrency 75, app-level rate limit 100/s. Target: **1,000+
+webhooks/minute** for ≥ 10 minutes.
+
+- [ ] Delivery throughput ≥ 1,000/min sustained on both backends; zero loss
+      (sink receipt count == published count, dedup by `{TaskId}:{EventType}`).
+- [ ] Deferred retry timing: for a sink returning 500 on first two attempts, observe
+      gaps of ~4s then ~8s (`SchedulePublishAsync` → Postgres scheduled messages on
+      Wolverine; `wolverine-scheduled-count` rises and drains).
+- [ ] Rate limiting holds (≤ ~100/s egress) — app-level, so identical on both backends.
+
+### S4 — Crash fault-injection (#927 acceptance, FINANCIAL)
+
+On **Wolverine** only (this is the durability the migration buys):
+
+- [ ] **Kill the Gateway process** (SIGKILL/container kill) mid-load after publishes are
+      accepted but before consumers process them → on restart, the durability agent
+      recovers persisted envelopes; reconcile S2 invariants — **no lost spend**.
+- [ ] **Kill the Gateway between debit commit and ack**: pause the spend consumer under
+      load (breakpoint/toxiproxy on the queue ack path, or kill within the processing
+      window), confirm redelivery occurs, and the ledger shows the RequestId applied
+      **once** (idempotent skip logged: "already applied - republishing notification").
+- [ ] Baseline documentation: the same two kills on MassTransit are *expected* to lose
+      and/or double-apply events (fire-and-forget + no inbox) — capture actual behavior
+      for the report; this is the delta being purchased.
+
+### S5 — Backpressure & circuit breaker
+
+- [ ] Point image-generation at a deliberately failing provider under load: listener
+      circuit breaker pauses/resumes (Wolverine) as the RabbitMQ breaker did; failures
+      visible in `wolverine-execution-failure` tagged by exception type.
+- [ ] Health check reflects stress: `wolverine_bus` goes Degraded when dead-letters
+      accumulate; returns Healthy after replay/purge.
+
+### S6 — Rollback drill (required before #930)
+
+- [ ] Under light load, redeploy with `Backend=MassTransit`. Confirm clean startup,
+      RabbitMQ queues rebind, and traffic continues. Document the drain procedure for
+      in-flight Wolverine queue rows (wolverine schema tables) — either drain before
+      flip or replay after.
+- [ ] Record time-to-rollback; this becomes the #930 rollback SLA.
+
+## Financial-path second review (blocking)
+
+An engineer other than the implementer reviews, in staging context:
+
+- [ ] PR #949 diff (`SpendUpdateProcessor`, `AdjustBalanceIdempotentAsync`,
+      `CachedApiVirtualKeyService.UpdateSpendAsync` fallback, migration).
+- [ ] The negative-balance semantics change: the old `newBalance >= 0` throw-after-commit
+      is gone; depletion is signaled via `SpendThresholdExceeded`. Confirm downstream
+      consumers (key disabling, notifications) behave under over-spend.
+- [ ] The publish-failure fallback path: same RequestId key on both paths — confirm no
+      scenario double-charges (event delivered late after fallback applied).
+- [ ] `MediaGenerationOrchestrator.UpdateSpendAsync` (billing publish inside handler
+      scope — rides the handler outbox on Wolverine; failure fails the handler → retry).
+
+## Parity report + sign-off
+
+Produce `phase2-parity-report.md` with the side-by-side table (scenario × backend ×
+measurements), the fault-injection evidence, known deltas, and:
+
+```
+Gate result: PASS / FAIL
+Financial 2nd review: <name>, <date>
+Sign-off to cut over (#930): <name>, <date>
+```
+
+## Known/accepted deltas (do not fail the gate on these)
+
+- `PrefetchCount` has no Postgres analogue (documented in I2.3).
+- Webhook `RateLimit` is app-level on both backends (never transport-level on Wolverine).
+- `CorrelationId` on a bare publish: Wolverine auto-generates, MassTransit leaves null —
+  Conduit `DomainEvent`s carry their own, so no user-visible difference (#928 finding).
+- `PublishBatchAsync` is sequential on Wolverine (batch was an optimization, not a
+  semantic guarantee).
+- Residual risks accepted in I2.4: crash-before-publish on the request path loses spend
+  on BOTH backends (post-hoc billing); Admin invalidation crash-window (idempotent +
+  TTL-backed consumers).

--- a/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
+++ b/docs/architecture/messaging-migration/phase2-wolverine-implementation-plan.md
@@ -183,11 +183,14 @@ real Postgres runs with the #929 parity gate.
   required); running the FULL suite with the flag flipped to Wolverine in staging is
   part of the #929 gate.
 
-## I2.6 — Parity & ordering validation (#929) — GATE
+## I2.6 — Parity & ordering validation (#929) — GATE (runbook ready)
 
 - Side-by-side load: spend per-key ordering under ~17 msg/s, webhook deferral timing, 1000+
   webhooks/min throughput, zero message loss. Compare to captured MassTransit behavior.
 - **Requires real Postgres + load infra — runs in CI/staging, not a unit environment.**
+- **Execution runbook: [phase2-parity-gate-runbook.md](phase2-parity-gate-runbook.md)** —
+  absorbs the #923 staging smoke, the financial-path 2nd review, and the #927 crash
+  fault-injection; includes the rollback drill that sets the #930 rollback SLA.
 - Acceptance: documented parity report; sign-off to cut over.
 
 ## I2.7 — Staged cutover (#930)


### PR DESCRIPTION
## Summary

Docs-only. Makes the **#929 parity gate** (I2.6 — the sign-off gate for the #930 cutover) turnkey for staging execution. The runbook (`docs/architecture/messaging-migration/phase2-parity-gate-runbook.md`) covers:

- **Prerequisites** — including ancestry verification (per the two stacked-PR stranding incidents), the #927 migration/index check, and provisioning/transport flags.
- **Scenario matrix**, each run on MassTransit (baseline) then Wolverine:
  - S1 functional smoke — absorbs the never-run #923 staging gate (admin edit→gateway invalidation, image/video gen, webhook, spend)
  - S2 spend ordering + exactly-once under ~17 msg/s (ledger reconciliation via the #927 IdempotencyKey)
  - S3 1,000+/min webhook throughput + 4s/8s deferral timing
  - S4 crash fault-injection (the #927 acceptance) — with the expected MassTransit *failure* captured as the baseline delta the migration purchases
  - S5 circuit breaker + health-check behavior under stress
  - S6 rollback drill (sets the #930 rollback SLA)
- **Blocking financial-path 2nd-review checklist** (carried from #921/#927), including the negative-balance semantics change and the publish-failure fallback dedup.
- **Sign-off template** and the **known/accepted deltas** (PrefetchCount, app-level rate limit, CorrelationId divergence, sequential batch) that must not fail the gate.

Also links the runbook from the phase 2 plan's I2.6 section.

Part of #909; enables #929.