### PR TITLE
fix(admin): Publish canonical Core.Events Provider events instead of controller-local shadows

### DIFF
--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Models.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Models.cs
@@ -76,48 +76,6 @@ namespace ConduitLLM.Admin.Controllers
     }
 
     /// <summary>
-    /// Event published when a provider is updated
-    /// </summary>
-    public class ProviderUpdated
-    {
-        /// <summary>
-        /// The ID of the updated provider
-        /// </summary>
-        public int ProviderId { get; set; }
-        
-        /// <summary>
-        /// Whether the provider is enabled after the update
-        /// </summary>
-        public bool IsEnabled { get; set; }
-        
-        /// <summary>
-        /// List of properties that were changed
-        /// </summary>
-        public string[] ChangedProperties { get; set; } = Array.Empty<string>();
-        
-        /// <summary>
-        /// Correlation ID for tracking the event
-        /// </summary>
-        public string CorrelationId { get; set; } = string.Empty;
-    }
-
-    /// <summary>
-    /// Event published when a provider is deleted
-    /// </summary>
-    public class ProviderDeleted
-    {
-        /// <summary>
-        /// The ID of the deleted provider
-        /// </summary>
-        public int ProviderId { get; set; }
-        
-        /// <summary>
-        /// Correlation ID for tracking the event
-        /// </summary>
-        public string CorrelationId { get; set; } = string.Empty;
-    }
-
-    /// <summary>
     /// Request model for creating a key credential
     /// </summary>
     public class CreateKeyRequest


### PR DESCRIPTION
## Summary
Fixes #956.

`ProviderCredentialsController.Models.cs` defined local `ProviderUpdated` and `ProviderDeleted` classes in the `ConduitLLM.Admin.Controllers` namespace. C# same-namespace resolution made `UpdateProvider`/`DeleteProvider` publish these duplicates instead of the canonical `ConduitLLM.Core.Events` records the Gateway's `ProviderCacheInvalidationHandler` subscribes to — so provider update/delete cache-invalidation events were never delivered (MassTransit dropped them silently; Wolverine logged "No routes can be determined").

## Change
- Delete the two controller-local classes. The publish sites in `ProviderCredentialsController.Providers.cs` now resolve to the `ConduitLLM.Core.Events` records via the existing `using ConduitLLM.Core.Events;` — no changes needed there, since the object initializers (`ProviderId`, `IsEnabled`, `ChangedProperties`, `CorrelationId`) match the records' `init` properties.

Net diff: **42 deletions, 0 additions.**

## Verification
- Full solution `dotnet build`: 0 errors.
- `dotnet test --filter "FullyQualifiedName~ProviderCredentialsController"`: 12/12 passed.
- Searched the repo for any remaining references to `ConduitLLM.Admin.Controllers.ProviderUpdated`/`ProviderDeleted` — none.

The issue also suggests a Roslyn analyzer/lint to prevent event-type shadowing from recurring; left out of this PR to keep it a minimal targeted fix.