### PR TITLE
fix(gateway): enable MassTransit message scheduler so webhook deferred retries work

### DIFF
--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -100,7 +100,12 @@ public partial class Program
                     
                     // Configure prefetch count for consumer concurrency
                     cfg.PrefetchCount = rabbitMqConfig.PrefetchCount;
-                    
+
+                    // Enable message scheduling via the RabbitMQ delayed-message-exchange plugin.
+                    // Required for context.ScheduleSend (e.g. WebhookDeliveryConsumer deferred retries);
+                    // without it every ScheduleSend throws and faults the consume.
+                    cfg.UseDelayedMessageScheduler();
+
                     // Configure retry policy for reliability
                     cfg.UseMessageRetry(r => r.Incremental(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
                     
@@ -240,7 +245,11 @@ public partial class Program
                 {
                     // NOTE: Using in-memory transport for single-instance deployments
                     // Configure RabbitMQ environment variables for multi-instance production
-                    
+
+                    // Enable message scheduling (in-memory transport supports delayed delivery natively).
+                    // Required for context.ScheduleSend (e.g. WebhookDeliveryConsumer deferred retries).
+                    cfg.UseDelayedMessageScheduler();
+
                     // Configure retry policy for reliability
                     cfg.UseMessageRetry(r => r.Incremental(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)));
                     

--- a/Tests/ConduitLLM.Tests/Integration/WebhookDeliveryRetrySchedulingTests.cs
+++ b/Tests/ConduitLLM.Tests/Integration/WebhookDeliveryRetrySchedulingTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
+using ConduitLLM.Gateway.Consumers;
+using ConduitLLM.Gateway.Services;
+
+namespace ConduitLLM.Tests.Integration
+{
+    /// <summary>
+    /// Regression tests for issue #957: WebhookDeliveryConsumer's deferred retry uses
+    /// context.ScheduleSend, which throws ("The payload was not found:
+    /// MassTransit.MessageSchedulerContext") unless the bus configures a message scheduler
+    /// via UseDelayedMessageScheduler(). These tests mirror the production bus configuration
+    /// and verify the deferred retry ladder actually runs.
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class WebhookDeliveryRetrySchedulingTests : IAsyncLifetime
+    {
+        private ServiceProvider _serviceProvider;
+        private ITestHarness _harness;
+        private Mock<IWebhookNotificationService> _webhookService;
+
+        public async Task InitializeAsync()
+        {
+            _webhookService = new Mock<IWebhookNotificationService>();
+
+            var deliveryTracker = new Mock<IWebhookDeliveryTracker>();
+            deliveryTracker.Setup(x => x.IsDeliveredAsync(It.IsAny<string>())).ReturnsAsync(false);
+
+            var circuitBreaker = new Mock<IWebhookCircuitBreaker>();
+            circuitBreaker.Setup(x => x.IsOpen(It.IsAny<string>())).Returns(false);
+
+            var services = new ServiceCollection();
+            services.AddMassTransitTestHarness(cfg =>
+            {
+                cfg.AddConsumer<WebhookDeliveryConsumer>();
+
+                cfg.UsingInMemory((context, busCfg) =>
+                {
+                    // Mirrors Program.Messaging.cs — without this line ScheduleSend throws
+                    // and the deferred retry never happens (issue #957)
+                    busCfg.UseDelayedMessageScheduler();
+                    busCfg.ConfigureEndpoints(context);
+                });
+            });
+
+            services.AddSingleton(_webhookService.Object);
+            services.AddSingleton(deliveryTracker.Object);
+            services.AddSingleton(circuitBreaker.Object);
+            services.AddSingleton(Mock.Of<IWebhookDeliveryNotificationService>());
+            services.AddSingleton(Mock.Of<ILogger<WebhookDeliveryConsumer>>());
+
+            _serviceProvider = services.BuildServiceProvider();
+            _harness = _serviceProvider.GetRequiredService<ITestHarness>();
+            _harness.TestTimeout = TimeSpan.FromSeconds(15);
+
+            await _harness.Start();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _harness.Stop();
+            if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else
+            {
+                _serviceProvider?.Dispose();
+            }
+        }
+
+        private static WebhookDeliveryRequested CreateRequest(int retryCount = 0) => new()
+        {
+            TaskId = "task-957",
+            TaskType = "video",
+            WebhookUrl = "https://example.com/webhook",
+            EventType = WebhookEventType.TaskCompleted,
+            PayloadJson = "{\"status\":\"completed\"}",
+            RetryCount = retryCount
+        };
+
+        [Fact]
+        public async Task FailedDelivery_SchedulesDeferredRetry_WithIncrementedRetryCount()
+        {
+            // Webhook endpoint always fails
+            _webhookService
+                .Setup(x => x.SendTaskCompletionWebhookAsync(
+                    It.IsAny<string>(), It.IsAny<object>(),
+                    It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            await _harness.Bus.Publish(CreateRequest(retryCount: 0));
+
+            // First consume must complete WITHOUT faulting — before the fix, ScheduleSend
+            // threw and faulted the consume, so the transport retried the same message
+            // with RetryCount stuck at 0 instead of running the deferred ladder
+            Assert.True(await _harness.Consumed.Any<WebhookDeliveryRequested>(
+                x => x.Context.Message.RetryCount == 0));
+            Assert.False(await _harness.Consumed.Any<WebhookDeliveryRequested>(
+                x => x.Context.Message.RetryCount == 0 && x.Exception != null));
+
+            // The scheduled retry (2^1 = 2s delay) must arrive with RetryCount incremented
+            var retryConsumed = await WaitForConsumedAsync(
+                m => m.RetryCount == 1, TimeSpan.FromSeconds(10));
+            Assert.True(retryConsumed, "Deferred retry with RetryCount=1 was never consumed");
+        }
+
+        [Fact]
+        public async Task FailedDelivery_AtMaxRetries_GivesUpWithoutScheduling()
+        {
+            _webhookService
+                .Setup(x => x.SendTaskCompletionWebhookAsync(
+                    It.IsAny<string>(), It.IsAny<object>(),
+                    It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            // RetryCount already at the max (3) — consumer should take the give-up path
+            await _harness.Bus.Publish(CreateRequest(retryCount: 3));
+
+            Assert.True(await _harness.Consumed.Any<WebhookDeliveryRequested>(
+                x => x.Context.Message.RetryCount == 3));
+
+            // Give-up path throws InvalidOperationException so MassTransit dead-letters it
+            Assert.True(await _harness.Consumed.Any<WebhookDeliveryRequested>(
+                x => x.Context.Message.RetryCount == 3
+                     && x.Exception is InvalidOperationException));
+
+            // No further retry message may be scheduled past the max
+            Assert.DoesNotContain(
+                _harness.Consumed.Select<WebhookDeliveryRequested>(),
+                x => x.Context.Message.RetryCount > 3);
+        }
+
+        private async Task<bool> WaitForConsumedAsync(
+            Func<WebhookDeliveryRequested, bool> predicate, TimeSpan timeout)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            while (stopwatch.Elapsed < timeout)
+            {
+                if (_harness.Consumed
+                    .Select<WebhookDeliveryRequested>()
+                    .Any(x => predicate(x.Context.Message)))
+                {
+                    return true;
+                }
+                await Task.Delay(250);
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #957.

`WebhookDeliveryConsumer` schedules its deferred retries (~4s/8s/16s, max 3, then give up) via `context.ScheduleSend`, but the bus never configured a message scheduler, so every scheduling attempt threw:

```
The payload was not found: MassTransit.MessageSchedulerContext
```

The throw faulted the consume; transport retry + the 5/15/30-minute delayed-redelivery tiers then redelivered the *original* message with `RetryCount` stuck at 0 — ~16 HTTP attempts across 4 delivery cycles, and the max-3/give-up accounting was unreachable.

## Changes
- Add `cfg.UseDelayedMessageScheduler()` to both Gateway bus configurations in `Program.Messaging.cs`:
  - **RabbitMQ**: uses the delayed-message-exchange plugin (already enabled — `UseDelayedRedelivery` uses it today)
  - **In-memory**: uses the transport's native delayed delivery
- Add harness-based regression tests (`WebhookDeliveryRetrySchedulingTests`) that mirror the production bus config and verify:
  - a failed delivery's consume does **not** fault, and the deferred retry actually arrives with `RetryCount` incremented
  - at `RetryCount = 3` the consumer takes the give-up path (dead-letter via `InvalidOperationException`) and schedules nothing further

Admin API is untouched — it has no consumer that calls `ScheduleSend`.

## Production behavior change (intentional)
Failed webhook deliveries now follow the *designed* ladder: bounded, shorter retries (deferred 4s/8s/16s, then give up) instead of the accidental long tail of transport redeliveries. This matches the behavior Wolverine already exhibits with the #929 W1/W2 fixes, so the two stacks now agree ahead of the #930 cutover.

## Testing
- `dotnet build` — full solution, 0 errors
- `dotnet test --filter FullyQualifiedName~WebhookDeliveryRetrySchedulingTests` — 2/2 passed
- Not verified against the live dev docker stack (worktree isn't wired to the compose mounts); the harness tests exercise the in-memory path, and the RabbitMQ path uses the same plugin `UseDelayedRedelivery` already exercises