### PR TITLE
fix(core): media generation billing uses direct ModelCostId lookup (#955)

### DIFF
--- a/Shared/ConduitLLM.Core/Models/MediaProcessingContext.cs
+++ b/Shared/ConduitLLM.Core/Models/MediaProcessingContext.cs
@@ -70,6 +70,19 @@ namespace ConduitLLM.Core.Models
         public Provider? Provider { get; set; }
 
         /// <summary>
+        /// Gets or sets the ID of the ModelCost record linked to the resolved model association, if any.
+        /// When set, cost calculation uses a direct lookup instead of string matching on model ids.
+        /// </summary>
+        public int? ModelCostId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the canonical model identifier from the model's provider-type association.
+        /// Cost records are matched against this identifier during string-based cost lookup, so it is
+        /// preferred over <see cref="ModelId"/> (which may hold a stale legacy ProviderModelId value).
+        /// </summary>
+        public string? CostIdentifier { get; set; }
+
+        /// <summary>
         /// Gets the provider name.
         /// </summary>
         public string ProviderName => Provider?.ProviderName ?? Provider?.ProviderType.ToString() ?? "unknown";

--- a/Shared/ConduitLLM.Core/Services/Abstractions/MediaGenerationOrchestrator.cs
+++ b/Shared/ConduitLLM.Core/Services/Abstractions/MediaGenerationOrchestrator.cs
@@ -250,12 +250,21 @@ namespace ConduitLLM.Core.Services.Abstractions
                 return null;
             }
             
+            var association = mapping.ModelProviderTypeAssociation;
+
             return new GenerationModelInfo
             {
-                ModelId = mapping.ProviderModelId,
+                // The legacy ProviderModelId column can be stale on mappings created through the
+                // model-catalog flow; fall back to the association's canonical identifier so the
+                // provider call and cost lookup never receive an empty model id.
+                ModelId = !string.IsNullOrWhiteSpace(mapping.ProviderModelId)
+                    ? mapping.ProviderModelId
+                    : association?.Identifier ?? mapping.ModelAlias,
                 ModelAlias = mapping.ModelAlias,
                 ProviderId = mapping.ProviderId,
-                Provider = mapping.Provider // Use the Provider navigation property directly
+                Provider = mapping.Provider, // Use the Provider navigation property directly
+                ModelCostId = association?.ModelCostId,
+                CostIdentifier = association?.Identifier
             };
         }
 
@@ -317,7 +326,21 @@ namespace ConduitLLM.Core.Services.Abstractions
         protected virtual async Task<decimal> CalculateCostAsync(TEventRequest request, GenerationModelInfo modelInfo, ProcessedMedia media)
         {
             var usage = CreateUsageObject(request, media);
-            return await _costService.CalculateCostAsync(modelInfo.ModelId, usage);
+
+            // Prefer the ModelCost link resolved from the model association — string matching can
+            // silently return 0 when the mapping's legacy ProviderModelId doesn't match any cost
+            // record's identifier (see issue #955).
+            if (modelInfo.ModelCostId.HasValue)
+            {
+                return await _costService.CalculateCostByIdAsync(modelInfo.ModelCostId.Value, usage);
+            }
+
+            // Fall back to string matching using the association's canonical identifier, which is
+            // the value cost records are matched against.
+            var costLookupModelId = !string.IsNullOrWhiteSpace(modelInfo.CostIdentifier)
+                ? modelInfo.CostIdentifier
+                : modelInfo.ModelId;
+            return await _costService.CalculateCostAsync(costLookupModelId, usage);
         }
 
         protected virtual bool IsRetryableError(Exception ex)

--- a/Tests/ConduitLLM.Tests/Services/Orchestrators/MediaGenerationOrchestratorTestBase.cs
+++ b/Tests/ConduitLLM.Tests/Services/Orchestrators/MediaGenerationOrchestratorTestBase.cs
@@ -376,9 +376,138 @@ namespace ConduitLLM.Tests.Services.Orchestrators
             }
         }
 
+        [Fact]
+        public async Task HandleAsync_WhenMappingHasModelCostId_ShouldUseDirectCostLookupAndPublishSpend()
+        {
+            // Arrange - mapping resolved through the model catalog: legacy ProviderModelId is stale
+            // ("unknown"), but the association carries a direct ModelCost link (issue #955)
+            SetupMappingWithAssociation(providerModelId: "unknown", modelCostId: 42, identifier: "canonical-model-id");
+
+            CostServiceMock.Setup(x => x.CalculateCostByIdAsync(
+                42,
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(0.05m);
+
+            var request = CreateTestEventRequest();
+            var context = CreateEventContext();
+            var response = CreateTestResponse();
+
+            SetupSuccessfulGeneration(response);
+
+            // Act
+            await Orchestrator.HandleAsync(request, context);
+
+            // Assert - direct lookup used, string matching skipped
+            CostServiceMock.Verify(x => x.CalculateCostByIdAsync(
+                42,
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            CostServiceMock.Verify(x => x.CalculateCostAsync(
+                It.IsAny<string>(),
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+
+            // Assert - spend event published with the calculated cost
+            EventBusMock.Verify(x => x.PublishAsync(
+                It.Is<SpendUpdateRequested>(e => e.KeyId == 1 && e.Amount == 0.05m),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenNoModelCostId_ShouldFallBackToAssociationIdentifierLookup()
+        {
+            // Arrange - no direct cost link; the string fallback must use the association's
+            // canonical identifier (what cost records match against), not the stale ProviderModelId
+            SetupMappingWithAssociation(providerModelId: "unknown", modelCostId: null, identifier: "canonical-model-id");
+
+            var request = CreateTestEventRequest();
+            var context = CreateEventContext();
+            var response = CreateTestResponse();
+
+            SetupSuccessfulGeneration(response);
+
+            // Act
+            await Orchestrator.HandleAsync(request, context);
+
+            // Assert
+            CostServiceMock.Verify(x => x.CalculateCostAsync(
+                "canonical-model-id",
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            CostServiceMock.Verify(x => x.CalculateCostByIdAsync(
+                It.IsAny<int>(),
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenCostIsZero_ShouldNotPublishSpendEvent()
+        {
+            // Arrange
+            SetupMappingWithAssociation(providerModelId: "unknown", modelCostId: 42, identifier: "canonical-model-id");
+
+            CostServiceMock.Setup(x => x.CalculateCostByIdAsync(
+                42,
+                It.IsAny<Usage>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(0m);
+
+            var request = CreateTestEventRequest();
+            var context = CreateEventContext();
+            var response = CreateTestResponse();
+
+            SetupSuccessfulGeneration(response);
+
+            // Act
+            await Orchestrator.HandleAsync(request, context);
+
+            // Assert
+            EventBusMock.Verify(x => x.PublishAsync(
+                It.IsAny<SpendUpdateRequested>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
         // ==========================================
         // Helper Methods
         // ==========================================
+
+        /// <summary>
+        /// Configures the model mapping service to return a mapping whose
+        /// ModelProviderTypeAssociation carries the given cost linkage.
+        /// </summary>
+        protected void SetupMappingWithAssociation(string providerModelId, int? modelCostId, string identifier)
+        {
+            var testProvider = new Provider
+            {
+                Id = 1,
+                ProviderName = "Test Provider",
+                ProviderType = ProviderType.OpenAI,
+                IsEnabled = true
+            };
+
+            ModelMappingServiceMock.Setup(x => x.GetMappingByModelAliasAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ModelProviderMapping
+                {
+                    Id = 1,
+                    ModelAlias = "test-model",
+                    ProviderModelId = providerModelId,
+                    ProviderId = 1,
+                    Provider = testProvider,
+                    IsEnabled = true,
+                    ModelProviderTypeAssociationId = 10,
+                    ModelProviderTypeAssociation = new ModelProviderTypeAssociation
+                    {
+                        Id = 10,
+                        ModelId = 100,
+                        Identifier = identifier,
+                        ModelCostId = modelCostId,
+                        IsEnabled = true
+                    }
+                });
+        }
 
         protected abstract void SetupSuccessfulGeneration(TResponse response);
         protected abstract void SetupFailedGeneration(Exception exception);


### PR DESCRIPTION
## Problem

Async media generation (image and video) billed **$0**. `MediaGenerationOrchestrator.CalculateCostAsync` passed `modelInfo.ModelId` — populated from the mapping's legacy `ProviderModelId` column, which can hold a stale placeholder like `"unknown"` on mappings created through the model-catalog flow — to the string-matching cost service. No `ModelCost` matched, the lookup returned 0, and since spend is only published when `cost > 0`, **no `SpendUpdateRequested` was ever published for media generation**.

Found during the #929 S1 functional smoke (see `docs/architecture/messaging-migration/phase2-s1-smoke-report-dev.md`); backend-independent (identical on MassTransit and Wolverine).

## Fix

Follows the direction suggested in #955 — prefer the direct `ModelCostId` link over string matching, mirroring what `VideosController` stores in `HttpContextKeys.ModelCostId`:

- `GenerationModelInfo` gains `ModelCostId` and `CostIdentifier`, resolved from the mapping's `ModelProviderTypeAssociation` during `GetModelInfoAsync` (the repository already eager-loads that navigation).
- `CalculateCostAsync` uses `CalculateCostByIdAsync(ModelCostId)` when the direct link exists; otherwise falls back to string matching keyed on the association's canonical `Identifier` — the value `GetCostForModelAsync` actually matches against — instead of the possibly-stale `ProviderModelId`.
- `ModelId` now falls back to the association `Identifier` / alias when the legacy column is empty, so downstream provider calls and logs never see an empty id. When `ProviderModelId` is populated it still wins, so provider-specific overrides (e.g. custom deployment names) are unaffected.

The fix lives in the shared orchestrator base, so both image and video generation are covered.

## Tests

Three new base-class tests (run for both image and video orchestrators, 6 total):
- direct `ModelCostId` lookup is used, string matching skipped, and `SpendUpdateRequested` publishes with the calculated amount — even when `ProviderModelId` is `"unknown"`;
- with no `ModelCostId`, the string fallback uses the association `Identifier`;
- zero cost still publishes no spend event.

`dotnet build` clean; orchestrator suite 34/34 and cost-calculation suite 65/65 passing.

## Out of scope (pre-existing, noted in the smoke report)

- The orchestrator passes the provider model id to `GetClientAsync`, which resolves by alias — generation only works when alias == provider model id.
- `UsageTrackingMiddleware` logging `Model=unknown` on the request path.

Fixes #955