### PR TITLE
fix(core): Resolve media-generation clients by provider ID instead of re-resolving ProviderModelId as an alias

### DIFF
--- a/Shared/ConduitLLM.Core/Caching/CachingServiceExtensions.cs
+++ b/Shared/ConduitLLM.Core/Caching/CachingServiceExtensions.cs
@@ -175,6 +175,28 @@ namespace ConduitLLM.Core.Caching
         }
 
         /// <inheritdoc />
+        public async Task<ILLMClient> GetClientByProviderIdAsync(int providerId, string providerModelId, CancellationToken cancellationToken = default)
+        {
+            // Get the original client from the inner factory
+            var client = await _innerFactory.GetClientByProviderIdAsync(providerId, providerModelId, cancellationToken);
+
+            // Always wrap the client - the wrapper checks LLMCachingEnabled at runtime
+            if (_cacheOptions.CurrentValue.IsEnabled)
+            {
+                var logger = _loggerFactory.CreateLogger<CachingLLMClient>();
+                return new CachingLLMClient(
+                    client,
+                    _cacheManager,
+                    _metricsService,
+                    _globalSettingsCache,
+                    _cacheOptions,
+                    logger);
+            }
+
+            return client;
+        }
+
+        /// <inheritdoc />
         public async Task<ILLMClient> GetClientByProviderTypeAsync(ConduitLLM.Configuration.ProviderType providerType, CancellationToken cancellationToken = default)
         {
             // Get the original client from the inner factory

--- a/Shared/ConduitLLM.Core/Interfaces/ILLMClientFactory.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ILLMClientFactory.cs
@@ -28,6 +28,19 @@ public interface ILLMClientFactory
     Task<ILLMClient> GetClientByProviderIdAsync(int providerId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Asynchronously gets an ILLMClient instance for the specified provider ID, configured with the
+    /// given provider model id. Use this when a model mapping has already been resolved — the
+    /// provider model id is not a model alias and must not go through alias resolution again.
+    /// </summary>
+    /// <param name="providerId">The ID of the provider.</param>
+    /// <param name="providerModelId">The provider's model identifier (e.g. the mapping's ProviderModelId).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An instance of ILLMClient for the specified provider and model.</returns>
+    /// <exception cref="ConfigurationException">Thrown if the configuration for the provider is invalid or missing.</exception>
+    /// <exception cref="UnsupportedProviderException">Thrown if the specified provider is not supported by this factory.</exception>
+    Task<ILLMClient> GetClientByProviderIdAsync(int providerId, string providerModelId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets provider metadata for the specified provider type without requiring credentials.
     /// </summary>
     /// <param name="providerType">The provider type to get metadata for.</param>

--- a/Shared/ConduitLLM.Core/Services/ImageGenerationOrchestrator.cs
+++ b/Shared/ConduitLLM.Core/Services/ImageGenerationOrchestrator.cs
@@ -81,8 +81,9 @@ namespace ConduitLLM.Core.Services
             VirtualKey virtualKey,
             CancellationToken cancellationToken)
         {
-            // Get the client for the model
-            var client = await _clientFactory.GetClientAsync(modelInfo.ModelId, cancellationToken);
+            // Get the client via the already-resolved provider — modelInfo.ModelId is the
+            // provider's model id, not a model alias, so it must not be re-resolved by name
+            var client = await _clientFactory.GetClientByProviderIdAsync(modelInfo.ProviderId, modelInfo.ModelId, cancellationToken);
             
             // Generate images
             return await client.CreateImageAsync(request, cancellationToken: cancellationToken);

--- a/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
+++ b/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
@@ -87,8 +87,8 @@ namespace ConduitLLM.Core.Services
             VirtualKey virtualKey,
             CancellationToken cancellationToken)
         {
-            // Get the client for the model
-            var client = await _clientFactory.GetClientAsync(modelInfo.ModelAlias, cancellationToken);
+            // Get the client via the already-resolved provider instead of re-resolving the alias
+            var client = await _clientFactory.GetClientByProviderIdAsync(modelInfo.ProviderId, modelInfo.ModelId, cancellationToken);
             if (client == null)
             {
                 throw new NotSupportedException($"No provider available for model {modelInfo.ModelAlias}");

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -89,9 +89,14 @@ namespace ConduitLLM.Providers
         }
 
         /// <inheritdoc />
-        public async Task<ILLMClient> GetClientByProviderIdAsync(int providerId, CancellationToken cancellationToken = default)
+        public Task<ILLMClient> GetClientByProviderIdAsync(int providerId, CancellationToken cancellationToken = default)
+            => GetClientByProviderIdAsync(providerId, "default-model-id", cancellationToken);
+
+        /// <inheritdoc />
+        public async Task<ILLMClient> GetClientByProviderIdAsync(int providerId, string providerModelId, CancellationToken cancellationToken = default)
         {
-            _logger.LogDebug("Getting client for provider ID {ProviderId} using database credentials", providerId);
+            _logger.LogDebug("Getting client for provider ID {ProviderId} and model {ProviderModelId} using database credentials",
+                providerId, providerModelId);
 
             var provider = await _credentialService.GetProviderByIdAsync(providerId);
 
@@ -102,7 +107,7 @@ namespace ConduitLLM.Providers
             }
 
             var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
-            return CreateClientForProvider(provider, primaryKey, "default-model-id");
+            return CreateClientForProvider(provider, primaryKey, providerModelId);
         }
 
         /// <inheritdoc />

--- a/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
@@ -152,6 +152,51 @@ namespace ConduitLLM.Tests.Providers
         }
 
         [Fact]
+        public async Task GetClientByProviderIdAsync_WithProviderModelId_DoesNotResolveModelAlias()
+        {
+            // Arrange - provider exists but has no key, so client creation stops after the
+            // provider lookup; the mapping service must never be consulted on this path
+            var providerId = 1;
+            var provider = new Provider
+            {
+                Id = providerId,
+                ProviderName = "TestProvider",
+                ProviderType = ProviderType.OpenAI,
+                IsEnabled = true
+            };
+
+            _mockCredentialService.Setup(x => x.GetProviderByIdAsync(providerId))
+                .ReturnsAsync(provider);
+            _mockCredentialService.Setup(x => x.GetKeyCredentialsByProviderIdAsync(providerId))
+                .ReturnsAsync(new List<ProviderKeyCredential>());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ConfigurationException>(
+                async () => await _factory.GetClientByProviderIdAsync(providerId, "gpt-image-1")
+            );
+
+            _mockMappingService.Verify(x => x.GetMappingByModelAliasAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GetClientByProviderIdAsync_WithProviderModelIdAndNonExistentProvider_ThrowsInvalidRequestException()
+        {
+            // Arrange
+            var providerId = 999;
+            _mockCredentialService.Setup(x => x.GetProviderByIdAsync(providerId))
+                .ReturnsAsync((Provider?)null);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidRequestException>(
+                async () => await _factory.GetClientByProviderIdAsync(providerId, "gpt-image-1")
+            );
+
+            Assert.Equal($"Provider with ID '{providerId}' not found.", exception.Message);
+            Assert.Equal("provider_not_found", exception.ErrorCode);
+            Assert.Equal("providerId", exception.Param);
+        }
+
+        [Fact]
         public async Task GetClientByProviderTypeAsync_WithNoProvider_ThrowsInvalidRequestException()
         {
             // Arrange

--- a/Tests/ConduitLLM.Tests/Services/Orchestrators/ImageGenerationOrchestratorTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/Orchestrators/ImageGenerationOrchestratorTests.cs
@@ -98,7 +98,7 @@ namespace ConduitLLM.Tests.Services.Orchestrators
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
             
-            ClientFactoryMock.Setup(x => x.GetClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ClientFactoryMock.Setup(x => x.GetClientByProviderIdAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockClient.Object);
             
             StorageServiceMock.Setup(x => x.StoreAsync(
@@ -116,7 +116,7 @@ namespace ConduitLLM.Tests.Services.Orchestrators
         protected override void SetupFailedGeneration(Exception exception)
         {
             // Setup to simulate failure during orchestration
-            ClientFactoryMock.Setup(x => x.GetClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ClientFactoryMock.Setup(x => x.GetClientByProviderIdAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
         }
 

--- a/Tests/ConduitLLM.Tests/Services/Orchestrators/MediaGenerationOrchestratorTestBase.cs
+++ b/Tests/ConduitLLM.Tests/Services/Orchestrators/MediaGenerationOrchestratorTestBase.cs
@@ -224,6 +224,28 @@ namespace ConduitLLM.Tests.Services.Orchestrators
         }
 
         [Fact]
+        public async Task HandleAsync_ShouldGetClientByResolvedProviderId_NotByReResolvingModelName()
+        {
+            // Arrange - the default mapping mock has ModelAlias "test-model" and
+            // ProviderModelId "provider-model-id" (deliberately different), so re-resolving
+            // the provider model id as an alias would fail (issue #958)
+            var request = CreateTestEventRequest();
+            var context = CreateEventContext();
+            var response = CreateTestResponse();
+
+            SetupSuccessfulGeneration(response);
+
+            // Act
+            await Orchestrator.HandleAsync(request, context);
+
+            // Assert
+            ClientFactoryMock.Verify(x => x.GetClientByProviderIdAsync(
+                1, "provider-model-id", It.IsAny<CancellationToken>()), Times.Once);
+            ClientFactoryMock.Verify(x => x.GetClientAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task HandleAsync_WhenGenerationFails_ShouldUpdateTaskAsFailed()
         {
             // Arrange

--- a/Tests/ConduitLLM.Tests/Services/Orchestrators/VideoGenerationOrchestratorTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/Orchestrators/VideoGenerationOrchestratorTests.cs
@@ -138,7 +138,7 @@ namespace ConduitLLM.Tests.Services.Orchestrators
             // Use test client that has CreateVideoAsync method for reflection
             var testClient = new TestVideoClient(response);
             
-            ClientFactoryMock.Setup(x => x.GetClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ClientFactoryMock.Setup(x => x.GetClientByProviderIdAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(testClient);
             
             StorageServiceMock.Setup(x => x.StoreAsync(
@@ -156,7 +156,7 @@ namespace ConduitLLM.Tests.Services.Orchestrators
         protected override void SetupFailedGeneration(Exception exception)
         {
             // Setup to simulate failure during orchestration
-            ClientFactoryMock.Setup(x => x.GetClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ClientFactoryMock.Setup(x => x.GetClientByProviderIdAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
         }
 


### PR DESCRIPTION
Fixes #958

## Problem
The media-generation orchestrators resolved the requested model alias to a `ModelProviderMapping`, then handed an identifier back to `ILLMClientFactory.GetClientAsync(...)`, which treats its argument as an **alias** and re-resolves it:

- `ImageGenerationOrchestrator` passed the mapped **`ProviderModelId`**, so image generation only worked when `ModelAlias == ProviderModelId`. Any renamed/branded alias (e.g. `smoke-image` → `mock-image`) failed with `ModelNotFoundException`.
- `VideoGenerationOrchestrator` passed the alias — functionally correct, but a redundant second alias lookup.

## Fix
Thread the already-resolved mapping through to the client factory, per the provider-architecture docs (Provider **ID** is the canonical identifier):

- Added `GetClientByProviderIdAsync(int providerId, string providerModelId, ...)` overload to `ILLMClientFactory`, implemented in `DatabaseAwareLLMClientFactory` (the existing single-arg overload now delegates to it) and the `CachingLLMClientFactory` decorator.
- Both `ImageGenerationOrchestrator` and `VideoGenerationOrchestrator` now call it with `modelInfo.ProviderId` + `modelInfo.ModelId` — no second alias resolution.

## Tests
- New shared regression test in `MediaGenerationOrchestratorTestBase` (runs for both Image and Video orchestrators) asserting the client is requested by resolved provider ID + provider model id and never via alias re-resolution. The base fixture's mapping deliberately has `ModelAlias` ≠ `ProviderModelId`, so the old code path fails this test.
- New `DatabaseAwareLLMClientFactory` tests: the overload never consults the alias-mapping service, and unknown provider IDs throw `InvalidRequestException`.
- `dotnet build` clean; orchestrator + factory + other `ILLMClientFactory`-touching test classes all pass (62 tests).

Co-authored-by: Claude <noreply@anthropic.com>