### PR TITLE
fix(core): fall back to DB when cached model mapping loses its capability graph

### DIFF
--- a/Shared/ConduitLLM.Core/Services/CachedModelProviderMappingService.cs
+++ b/Shared/ConduitLLM.Core/Services/CachedModelProviderMappingService.cs
@@ -63,6 +63,11 @@ namespace ConduitLLM.Core.Services
                     Region,
                     CacheTtl);
 
+                if (IsMissingNavigationGraph(cached))
+                {
+                    return await ReloadAndRecacheAsync(cacheKey, () => _innerService.GetMappingByIdAsync(id), $"ID {id}");
+                }
+
                 _logger.LogDebug("Retrieved model provider mapping by ID {Id} from cache", id);
                 return cached;
             }
@@ -94,6 +99,11 @@ namespace ConduitLLM.Core.Services
                     Region,
                     CacheTtl);
 
+                if (IsMissingNavigationGraph(cached))
+                {
+                    return await ReloadAndRecacheAsync(cacheKey, () => _innerService.GetMappingByModelAliasAsync(modelAlias), $"alias '{modelAlias}'");
+                }
+
                 _logger.LogDebug("Retrieved model provider mapping for alias '{ModelAlias}' from cache", modelAlias);
                 return cached;
             }
@@ -116,6 +126,14 @@ namespace ConduitLLM.Core.Services
                     async () => await _innerService.GetAllMappingsAsync(),
                     Region,
                     CacheTtl);
+
+                if (cached == null || cached.Any(IsMissingNavigationGraph))
+                {
+                    LogIncompleteCacheEntry("all-mappings list");
+                    var fresh = await _innerService.GetAllMappingsAsync();
+                    await _cacheManager.SetAsync(AllMappingsKey, fresh, Region, CacheTtl);
+                    return fresh;
+                }
 
                 _logger.LogDebug("Retrieved all model provider mappings from cache");
                 return cached;
@@ -237,6 +255,55 @@ namespace ConduitLLM.Core.Services
         public async Task<List<(int Id, string ProviderName)>> GetAvailableProvidersAsync()
         {
             return await _innerService.GetAvailableProvidersAsync();
+        }
+
+        /// <summary>
+        /// Detects cache entries that lost their navigation graph while round-tripping the
+        /// distributed cache. ModelProviderTypeAssociation.Model is [JsonIgnore] (to break
+        /// serialization cycles), so entries deserialized from Redis come back with a null Model
+        /// and all capability flags read false. A mapping loaded from the repository always has
+        /// Provider, ModelProviderTypeAssociation, and Model populated.
+        /// </summary>
+        private static bool IsMissingNavigationGraph(ModelProviderMapping? mapping)
+        {
+            return mapping != null &&
+                   (mapping.Provider == null ||
+                    mapping.ModelProviderTypeAssociation == null ||
+                    mapping.ModelProviderTypeAssociation.Model == null);
+        }
+
+        /// <summary>
+        /// Reloads a mapping from the database when the cached entry is missing its navigation
+        /// graph, and refreshes the cache (repopulating the memory tier with the full object).
+        /// </summary>
+        private async Task<ModelProviderMapping?> ReloadAndRecacheAsync(
+            string cacheKey,
+            Func<Task<ModelProviderMapping?>> loader,
+            string identifier)
+        {
+            LogIncompleteCacheEntry(identifier);
+
+            var fresh = await loader();
+            if (fresh != null)
+            {
+                await _cacheManager.SetAsync(cacheKey, fresh, Region, CacheTtl);
+            }
+            else
+            {
+                // The mapping no longer exists; drop the stale entry so it stops resurfacing.
+                await _cacheManager.RemoveAsync(cacheKey, Region);
+            }
+
+            return fresh;
+        }
+
+        private void LogIncompleteCacheEntry(string identifier)
+        {
+            _logger.LogWarning(
+                "Cached model provider mapping for {Identifier} is missing its navigation graph " +
+                "(entries deserialized from the distributed cache lose [JsonIgnore] navigation properties); " +
+                "reloading from database",
+                identifier);
         }
 
         /// <summary>

--- a/Tests/ConduitLLM.Tests/Configuration/Services/CachedModelProviderMappingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Services/CachedModelProviderMappingServiceTests.cs
@@ -36,13 +36,41 @@ namespace ConduitLLM.Tests.Configuration.Services
                 _mockCacheManager.Object,
                 _mockLogger.Object);
 
-            _testMapping = new ModelProviderMapping
+            _testMapping = CreateFullyLoadedMapping();
+        }
+
+        /// <summary>
+        /// Creates a mapping with the full navigation graph the repository always loads
+        /// (Provider, ModelProviderTypeAssociation, and Model).
+        /// </summary>
+        private static ModelProviderMapping CreateFullyLoadedMapping()
+        {
+            return new ModelProviderMapping
             {
                 Id = TestMappingId,
                 ModelAlias = TestModelAlias,
                 ProviderId = 1,
                 ProviderModelId = "gpt-4-0613",
-                IsEnabled = true
+                IsEnabled = true,
+                Provider = new Provider
+                {
+                    Id = 1,
+                    ProviderName = "OpenAI",
+                    ProviderType = ProviderType.OpenAI
+                },
+                ModelProviderTypeAssociationId = 10,
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation
+                {
+                    Id = 10,
+                    ModelId = 20,
+                    Identifier = "gpt-4-0613",
+                    Model = new Model
+                    {
+                        Id = 20,
+                        Name = "GPT-4",
+                        SupportsImageGeneration = true
+                    }
+                }
             };
         }
 
@@ -384,6 +412,204 @@ namespace ConduitLLM.Tests.Configuration.Services
                 CacheRegion.ModelMetadata,
                 It.IsAny<TimeSpan>(),
                 It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        #endregion
+
+        #region Incomplete Cache Entry Fallback Tests (issue #959)
+
+        /// <summary>
+        /// Simulates what the distributed cache tier does to a mapping: a System.Text.Json
+        /// round-trip, which drops [JsonIgnore] navigation properties like
+        /// ModelProviderTypeAssociation.Model (and its capability flags with it).
+        /// </summary>
+        private static ModelProviderMapping RoundTripThroughJson(ModelProviderMapping mapping)
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(mapping);
+            return System.Text.Json.JsonSerializer.Deserialize<ModelProviderMapping>(json)!;
+        }
+
+        [Fact]
+        public void JsonRoundTrip_DropsModelNavigationProperty()
+        {
+            // Documents the root cause of issue #959: the distributed cache serializes entities
+            // with System.Text.Json, and [JsonIgnore] strips the Model graph.
+            var lossy = RoundTripThroughJson(CreateFullyLoadedMapping());
+
+            Assert.NotNull(lossy.ModelProviderTypeAssociation);
+            Assert.Null(lossy.ModelProviderTypeAssociation.Model);
+        }
+
+        [Fact]
+        public async Task GetMappingByModelAliasAsync_CachedEntryMissingModelGraph_ReloadsFromDatabaseAndRecaches()
+        {
+            // Arrange
+            var cacheKey = $"model:mapping:{TestModelAlias}";
+            var lossyMapping = RoundTripThroughJson(_testMapping);
+
+            _mockCacheManager
+                .Setup(x => x.GetOrCreateAsync(
+                    cacheKey,
+                    It.IsAny<Func<Task<ModelProviderMapping?>>>(),
+                    CacheRegion.ModelMetadata,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(lossyMapping);
+
+            _mockInnerService
+                .Setup(x => x.GetMappingByModelAliasAsync(TestModelAlias))
+                .ReturnsAsync(_testMapping);
+
+            // Act
+            var result = await _cachedService.GetMappingByModelAliasAsync(TestModelAlias);
+
+            // Assert - the incomplete cached entry is bypassed and the full mapping returned
+            Assert.NotNull(result);
+            Assert.NotNull(result.ModelProviderTypeAssociation?.Model);
+            Assert.True(result.ModelProviderTypeAssociation.Model.SupportsImageGeneration);
+
+            _mockInnerService.Verify(x => x.GetMappingByModelAliasAsync(TestModelAlias), Times.Once);
+
+            // The full mapping is re-cached (repopulating the memory tier)
+            _mockCacheManager.Verify(x => x.SetAsync(
+                cacheKey,
+                _testMapping,
+                CacheRegion.ModelMetadata,
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetMappingByModelAliasAsync_CachedEntryMissingModelGraph_MappingDeleted_RemovesStaleEntry()
+        {
+            // Arrange
+            var cacheKey = $"model:mapping:{TestModelAlias}";
+            var lossyMapping = RoundTripThroughJson(_testMapping);
+
+            _mockCacheManager
+                .Setup(x => x.GetOrCreateAsync(
+                    cacheKey,
+                    It.IsAny<Func<Task<ModelProviderMapping?>>>(),
+                    CacheRegion.ModelMetadata,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(lossyMapping);
+
+            _mockInnerService
+                .Setup(x => x.GetMappingByModelAliasAsync(TestModelAlias))
+                .ReturnsAsync((ModelProviderMapping?)null);
+
+            // Act
+            var result = await _cachedService.GetMappingByModelAliasAsync(TestModelAlias);
+
+            // Assert
+            Assert.Null(result);
+
+            _mockCacheManager.Verify(x => x.RemoveAsync(
+                cacheKey,
+                CacheRegion.ModelMetadata,
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetMappingByIdAsync_CachedEntryMissingModelGraph_ReloadsFromDatabaseAndRecaches()
+        {
+            // Arrange
+            var cacheKey = $"model:mapping:id:{TestMappingId}";
+            var lossyMapping = RoundTripThroughJson(_testMapping);
+
+            _mockCacheManager
+                .Setup(x => x.GetOrCreateAsync(
+                    cacheKey,
+                    It.IsAny<Func<Task<ModelProviderMapping?>>>(),
+                    CacheRegion.ModelMetadata,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(lossyMapping);
+
+            _mockInnerService
+                .Setup(x => x.GetMappingByIdAsync(TestMappingId))
+                .ReturnsAsync(_testMapping);
+
+            // Act
+            var result = await _cachedService.GetMappingByIdAsync(TestMappingId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotNull(result.ModelProviderTypeAssociation?.Model);
+
+            _mockInnerService.Verify(x => x.GetMappingByIdAsync(TestMappingId), Times.Once);
+            _mockCacheManager.Verify(x => x.SetAsync(
+                cacheKey,
+                _testMapping,
+                CacheRegion.ModelMetadata,
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllMappingsAsync_CachedEntryMissingModelGraph_ReloadsFromDatabaseAndRecaches()
+        {
+            // Arrange
+            var lossyMappings = new List<ModelProviderMapping> { RoundTripThroughJson(_testMapping) };
+            var freshMappings = new List<ModelProviderMapping> { _testMapping };
+
+            _mockCacheManager
+                .Setup(x => x.GetOrCreateAsync(
+                    "model:mapping:all",
+                    It.IsAny<Func<Task<List<ModelProviderMapping>>>>(),
+                    CacheRegion.ModelMetadata,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(lossyMappings);
+
+            _mockInnerService
+                .Setup(x => x.GetAllMappingsAsync())
+                .ReturnsAsync(freshMappings);
+
+            // Act
+            var result = await _cachedService.GetAllMappingsAsync();
+
+            // Assert
+            Assert.Single(result);
+            Assert.NotNull(result[0].ModelProviderTypeAssociation?.Model);
+
+            _mockInnerService.Verify(x => x.GetAllMappingsAsync(), Times.Once);
+            _mockCacheManager.Verify(x => x.SetAsync(
+                "model:mapping:all",
+                freshMappings,
+                CacheRegion.ModelMetadata,
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetMappingByModelAliasAsync_CachedEntryComplete_DoesNotHitDatabase()
+        {
+            // Arrange
+            var cacheKey = $"model:mapping:{TestModelAlias}";
+
+            _mockCacheManager
+                .Setup(x => x.GetOrCreateAsync(
+                    cacheKey,
+                    It.IsAny<Func<Task<ModelProviderMapping?>>>(),
+                    CacheRegion.ModelMetadata,
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_testMapping);
+
+            // Act
+            var result = await _cachedService.GetMappingByModelAliasAsync(TestModelAlias);
+
+            // Assert
+            Assert.NotNull(result);
+            _mockInnerService.Verify(x => x.GetMappingByModelAliasAsync(It.IsAny<string>()), Times.Never);
+            _mockCacheManager.Verify(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<ModelProviderMapping>(),
+                It.IsAny<CacheRegion>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()), Times.Never);
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Configuration/Services/ModelMappingCacheColdStartTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Services/ModelMappingCacheColdStartTests.cs
@@ -1,0 +1,129 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Core.Services;
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Configuration.Services
+{
+    /// <summary>
+    /// Regression tests for issue #959: on a cold start the Gateway's memory cache is empty,
+    /// but the distributed cache (Redis) survives the restart and serves model mapping entries
+    /// whose [JsonIgnore] navigation properties (ModelProviderTypeAssociation.Model) were
+    /// dropped during JSON serialization. Capability checks then read false until a
+    /// ModelMappingChanged invalidation repopulates the entry.
+    ///
+    /// These tests use the real CacheManager and a real serializing IDistributedCache shared
+    /// across two service instances to simulate a restart.
+    /// </summary>
+    public class ModelMappingCacheColdStartTests
+    {
+        private const string TestModelAlias = "smoke-image";
+
+        private static ModelProviderMapping CreateFullyLoadedMapping()
+        {
+            return new ModelProviderMapping
+            {
+                Id = 5,
+                ModelAlias = TestModelAlias,
+                ProviderId = 1,
+                ProviderModelId = "image-model-1",
+                IsEnabled = true,
+                Provider = new Provider
+                {
+                    Id = 1,
+                    ProviderName = "Test Provider",
+                    ProviderType = ProviderType.OpenAI
+                },
+                ModelProviderTypeAssociationId = 10,
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation
+                {
+                    Id = 10,
+                    ModelId = 20,
+                    Identifier = "image-model-1",
+                    Model = new Model
+                    {
+                        Id = 20,
+                        Name = "Image Model",
+                        SupportsImageGeneration = true
+                    }
+                }
+            };
+        }
+
+        private static CachedModelProviderMappingService CreateService(
+            IDistributedCache distributedCache,
+            IModelProviderMappingService innerService)
+        {
+            var cacheManager = new CacheManager(
+                new MemoryCache(Microsoft.Extensions.Options.Options.Create(new MemoryCacheOptions())),
+                distributedCache,
+                Mock.Of<ILogger<CacheManager>>());
+
+            return new CachedModelProviderMappingService(
+                innerService,
+                cacheManager,
+                Mock.Of<ILogger<CachedModelProviderMappingService>>());
+        }
+
+        [Fact]
+        public async Task ColdStart_EntryServedFromDistributedCache_StillReportsCapabilities()
+        {
+            // A real serializing distributed cache, shared across both "instances" the way
+            // Redis is shared across Gateway restarts.
+            var sharedDistributedCache = new MemoryDistributedCache(
+                Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions()));
+
+            var innerService = new Mock<IModelProviderMappingService>();
+            innerService
+                .Setup(x => x.GetMappingByModelAliasAsync(TestModelAlias))
+                .ReturnsAsync(CreateFullyLoadedMapping);
+
+            // Instance 1 (before restart): populates memory + distributed cache from the DB.
+            var serviceBeforeRestart = CreateService(sharedDistributedCache, innerService.Object);
+            var warm = await serviceBeforeRestart.GetMappingByModelAliasAsync(TestModelAlias);
+            Assert.True(warm?.ModelProviderTypeAssociation?.Model?.SupportsImageGeneration);
+
+            // Instance 2 (after restart): empty memory cache, same distributed cache. The
+            // distributed entry lost its Model graph during serialization, so without the
+            // fallback the capability check reads false here.
+            var serviceAfterRestart = CreateService(sharedDistributedCache, innerService.Object);
+            var cold = await serviceAfterRestart.GetMappingByModelAliasAsync(TestModelAlias);
+
+            Assert.NotNull(cold);
+            Assert.NotNull(cold.ModelProviderTypeAssociation?.Model);
+            Assert.True(cold.ModelProviderTypeAssociation.Model.SupportsImageGeneration);
+        }
+
+        [Fact]
+        public async Task ColdStart_SubsequentRequests_ServeFullGraphFromMemoryWithoutExtraDbCalls()
+        {
+            var sharedDistributedCache = new MemoryDistributedCache(
+                Microsoft.Extensions.Options.Options.Create(new MemoryDistributedCacheOptions()));
+
+            var innerService = new Mock<IModelProviderMappingService>();
+            innerService
+                .Setup(x => x.GetMappingByModelAliasAsync(TestModelAlias))
+                .ReturnsAsync(CreateFullyLoadedMapping);
+
+            var serviceBeforeRestart = CreateService(sharedDistributedCache, innerService.Object);
+            await serviceBeforeRestart.GetMappingByModelAliasAsync(TestModelAlias);
+
+            var serviceAfterRestart = CreateService(sharedDistributedCache, innerService.Object);
+            var first = await serviceAfterRestart.GetMappingByModelAliasAsync(TestModelAlias);
+            var second = await serviceAfterRestart.GetMappingByModelAliasAsync(TestModelAlias);
+
+            Assert.True(first?.ModelProviderTypeAssociation?.Model?.SupportsImageGeneration);
+            Assert.True(second?.ModelProviderTypeAssociation?.Model?.SupportsImageGeneration);
+
+            // One DB call to warm instance 1, one fallback reload on instance 2's cold start;
+            // the second cold request is served from instance 2's refreshed memory tier.
+            innerService.Verify(x => x.GetMappingByModelAliasAsync(TestModelAlias), Times.Exactly(2));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #959 — on cold start, capability checks for mapped models read false from the model-mapping cache until a `ModelMappingChanged` invalidation repopulated the entry, causing media-capable models to 400 (`unsupported_model`) after every deploy/restart.

## Root cause

Not a difference in include-graphs — both population paths load the full entity graph. The culprit is cache serialization:

- `CacheRegion.ModelMetadata` is two-tier: in-memory + Redis, and Redis survives Gateway restarts.
- `CacheManager` serializes entries with `System.Text.Json`; `ModelProviderTypeAssociation.Model` is `[JsonIgnore]` (to break serialization cycles), so the Redis copy of every mapping silently loses the Model graph and its capability flags.
- **Cold start:** memory tier empty → lossy Redis entry served → `Model` null → `SupportsImageGeneration` false → 400. `GetAsync` then promotes the lossy entry into the memory tier with the region's 24h default TTL.
- **After invalidation:** both tiers are deleted, the next request repopulates from the DB, and the memory tier holds the live object with the full graph → same request succeeds. The rewritten Redis entry is lossy again, which is why every restart reproduced the bug.

## Fix

`CachedModelProviderMappingService` now detects cached entries missing their navigation graph (`Provider`, `ModelProviderTypeAssociation`, or `.Model` null — a repository-loaded mapping always has all three), logs a warning, reloads from the database, and re-caches so the memory tier holds the full object. If the mapping no longer exists, the stale entry is removed. Applied to the by-alias, by-ID, and all-mappings paths.

Cost: one extra DB read per alias per restart; steady-state caching unchanged.

## Verification

- New `ModelMappingCacheColdStartTests` uses the real `CacheManager` with a real serializing distributed cache shared across two service instances to simulate a Gateway restart. **Negative control: both tests fail against the unfixed code** and pass with the fix.
- New unit tests in `CachedModelProviderMappingServiceTests` build the lossy entry via an actual JSON round-trip, documenting the root cause; 22/22 tests in the two classes pass.
- Full solution builds with no new warnings.

Note: `dev` currently has an unrelated test-project compile error (`WebhookDeliveryRetrySchedulingTests.cs` from #964 uses MassTransit `AddConsumer` on a consumer migrated to `IEventHandler<T>` — CS0311). I verified locally with that file temporarily set aside; it is untouched by this PR.

## Follow-up (out of scope)

Any entity cached through the distributed tier with `[JsonIgnore]` navigations has the same lossy-round-trip hazard; caching purpose-built DTOs instead of EF entities would eliminate the class of bug.