### PR TITLE
CI: Wolverine build-ahead codegen check + two-host Postgres listener assertion (#961)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,33 @@ jobs:
         env:
           TEST_REDIS_CONNECTION: localhost:6379
           DATABASE_URL: postgresql://conduit:conduitpass@localhost:5432/conduitdb
-      
+
+      # Wolverine build-ahead codegen check (#961): compiles the handler chain for EVERY
+      # registered event type up front via JasperFx's `codegen preview`, so codegen /
+      # service-location incompatibilities (the class of defect behind W2 in the #929 S1
+      # smoke, which only surfaced at first message delivery) fail the build instead.
+      - name: Wolverine codegen check
+        run: |
+          check_codegen() {
+            local log="/tmp/codegen-$2.log"
+            if dotnet run --project "$1" --no-build -- codegen preview > "$log" 2>&1; then
+              echo "$2 codegen OK ($(grep -c '// START:' "$log") generated types)"
+            else
+              echo "$2 codegen FAILED:"
+              cat "$log"
+              return 1
+            fi
+          }
+          check_codegen Services/ConduitLLM.Gateway gateway
+          check_codegen Services/ConduitLLM.Admin admin
+        env:
+          ConduitLLM__Messaging__Backend: Wolverine
+          ConduitLLM__Messaging__Wolverine__Transport: Postgresql
+          CONDUIT_MIGRATION_MODE: Skip
+          ASPNETCORE_ENVIRONMENT: Production
+          DATABASE_URL: postgresql://conduit:conduitpass@localhost:5432/conduitdb
+          REDIS_URL: redis://localhost:6379
+
       - name: NPM Build
         run: |
           cd SDKs/Node
@@ -88,6 +114,58 @@ jobs:
           rm -rf .next
           npm run lint
           npm run type-check
+
+  # Two-host Wolverine listener assertion (#961): boots the REAL Gateway + Admin hosts
+  # against real Postgres with ConduitLLM:Messaging:Backend=Wolverine and asserts that
+  # each service forms its own node cluster (per-service durability schema) and that the
+  # Gateway starts listeners for all five queues, including the exclusive strict-ordered
+  # spend-update-events / image-generation-events. Guards against W1 from the #929 S1
+  # smoke (shared agent cluster => financial queue dead), which only exists with two
+  # real hosts on real Postgres and is invisible to the in-memory dual-backend tests.
+  wolverine-two-host:
+    name: Wolverine Two-Host Smoke
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: conduit
+          POSTGRES_PASSWORD: conduitpass
+          POSTGRES_DB: conduitdb
+        options: >-
+          --health-cmd "pg_isready -U conduit -d conduitdb"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build services
+        run: |
+          dotnet build Services/ConduitLLM.Gateway
+          dotnet build Services/ConduitLLM.Admin
+
+      - name: Two-host listener assertion
+        run: pwsh ./scripts/test/wolverine-two-host-smoke.ps1 -NoBuild
+        env:
+          DATABASE_URL: postgresql://conduit:conduitpass@localhost:5432/conduitdb
+          REDIS_URL: redis://localhost:6379
 
   # Build Docker images (push only from master)
   docker:

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -8,6 +8,8 @@ using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Core.Converters;
 using ConduitLLM.Security.Middleware;
 
+using JasperFx;
+
 using Scalar.AspNetCore;
 
 namespace ConduitLLM.Admin;
@@ -147,9 +149,13 @@ public partial class Program
             app.Environment.EnvironmentName,
             string.Join(", ", app.Urls));
 
-        app.Run();
-
-        return 0;
+        // JasperFx command-line integration (#961): with no arguments this runs the web
+        // host exactly like app.Run(); with a command verb (e.g. `dotnet run -- codegen
+        // preview`) it executes the JasperFx command instead — CI uses `codegen preview`
+        // to compile every Wolverine handler chain build-ahead, so codegen/service-
+        // location defects (the class that hid W2, #929) fail at build time rather than
+        // first delivery.
+        return await app.RunJasperFxCommands(args);
     }
 }
 

--- a/Services/ConduitLLM.Gateway/Program.cs
+++ b/Services/ConduitLLM.Gateway/Program.cs
@@ -1,3 +1,5 @@
+using JasperFx;
+
 // "migrate" verb: run the standalone migrator (release-hook entry point) instead of
 // the web host — e.g. `dotnet ConduitLLM.Gateway.dll migrate`.
 if (ConduitLLM.Configuration.Data.MigrationCommand.Matches(args))
@@ -32,9 +34,12 @@ await Program.ConfigureMiddleware(app);
 // Configure endpoints
 Program.ConfigureEndpoints(app);
 
-app.Run();
-
-return 0;
+// JasperFx command-line integration (#961): with no arguments this runs the web host
+// exactly like app.Run(); with a command verb (e.g. `dotnet run -- codegen preview`)
+// it executes the JasperFx command instead — CI uses `codegen preview` to compile
+// every Wolverine handler chain build-ahead, so codegen/service-location defects
+// (the class that hid W2, #929) fail at build time rather than first delivery.
+return await app.RunJasperFxCommands(args);
 
 // Make Program class accessible for testing
 public partial class Program { }

--- a/docs/architecture/messaging-migration/phase2-parity-gate-runbook.md
+++ b/docs/architecture/messaging-migration/phase2-parity-gate-runbook.md
@@ -35,6 +35,28 @@ issues:
       generation with webhook URLs, admin config edits. A webhook sink that records
       receipt timestamps (e.g. requestbin-style with logging) is required for S3.
 
+## Standing CI guards (#961)
+
+Two CI checks close the gap that let S1's W1/W2 hide from the in-memory dual-backend
+tests (#928); both run on every push/PR in `.github/workflows/ci.yml`:
+
+- **Build-ahead codegen check** (`validate` job): `dotnet run -- codegen preview` for
+  Gateway and Admin with `Backend=Wolverine` compiles the handler chain for every
+  registered event type up front, so codegen/service-location incompatibilities (W2's
+  class) fail the build instead of first message delivery. This is also the checking
+  half of the #930 static-codegen (`codegen write` + `TypeLoadMode.Static`) cutover
+  optimization — the JasperFx command line is wired into both hosts' `Program`.
+- **Two-host listener assertion** (`wolverine-two-host` job): boots the real Admin
+  host first (recreating W1's leadership scenario), then the real Gateway, against
+  real Postgres, and asserts per-service node clusters, the exclusive
+  `spend-update-events` / `image-generation-events` listener agents assigned and
+  started, all five Gateway queues listening, and logs free of
+  `InvalidAgentException` / `InvalidServiceLocationException`. Runbook:
+  `scripts/test/wolverine-two-host-smoke.ps1` (header documents a local-run recipe).
+
+These guards are necessary but not sufficient for cutover — they prove topology and
+codegen, not load behavior. S2–S6 below remain mandatory.
+
 ## Execution order
 
 Run the **full scenario set twice**: first on `Backend=MassTransit` (baseline capture),

--- a/scripts/test/wolverine-two-host-smoke.ps1
+++ b/scripts/test/wolverine-two-host-smoke.ps1
@@ -1,0 +1,225 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Two-host Wolverine listener-assignment smoke (#961).
+
+.DESCRIPTION
+    Boots the real Admin API and Gateway API hosts against a real PostgreSQL database
+    with ConduitLLM:Messaging:Backend=Wolverine and asserts the multi-node agent
+    topology that the in-memory dual-backend tests (#928) cannot see:
+
+      1. Each service forms its OWN single-node agent cluster (per-service durability
+         schema: wolverine_conduit_gateway / wolverine_conduit_admin). A shared cluster
+         is defect W1 (#929): when the Admin node wins leadership it cannot assign the
+         Gateway-only exclusive listeners and the spend/image queues go dead.
+      2. The Gateway's exclusive strict-ordered listener agents
+         (wolverine-listener://postgresql/spend-update-events and
+         .../image-generation-events) are actually assigned and started.
+      3. The Admin node is never assigned a queue listener agent it does not declare.
+      4. The Gateway starts message listening on all five queues (gateway-events,
+         webhook-delivery, video-generation-events, spend-update-events,
+         image-generation-events).
+      5. Neither host logs InvalidAgentException / InvalidServiceLocationException.
+
+    The Admin host is started FIRST deliberately — that recreates the W1 leadership
+    scenario (the Admin winning the election) which is only dangerous if the durability
+    schemas ever regress to being shared.
+
+.PARAMETER DatabaseUrl
+    PostgreSQL URL for both hosts. Defaults to $env:DATABASE_URL.
+
+.PARAMETER RedisUrl
+    Redis URL for both hosts. Defaults to $env:REDIS_URL.
+
+.PARAMETER PsqlCommand
+    Command used to reach psql for the SQL assertions. Defaults to `psql <DatabaseUrl>`
+    (works on GitHub runners, where the postgres client is preinstalled). For a local
+    dev run against a Docker postgres, pass e.g.:
+        -PsqlCommand 'docker exec my-postgres psql -U conduit -d conduitdb'
+    NOTE: tokens are split on spaces, so paths/arguments with spaces are not supported.
+
+.PARAMETER NoBuild
+    Skip `dotnet build` of the two service projects (CI builds them beforehand).
+
+.PARAMETER Configuration
+    Build configuration of the service outputs (default Debug).
+
+.EXAMPLE
+    # CI (after `dotnet build` of both services):
+    ./scripts/test/wolverine-two-host-smoke.ps1 -NoBuild
+
+.EXAMPLE
+    # Local, against throwaway containers:
+    docker run -d --name pg961 -e POSTGRES_USER=conduit -e POSTGRES_PASSWORD=conduitpass \
+        -e POSTGRES_DB=conduitdb -p 15432:5432 postgres:16
+    docker run -d --name redis961 -p 16379:6379 redis:7-alpine
+    ./scripts/test/wolverine-two-host-smoke.ps1 `
+        -DatabaseUrl 'postgresql://conduit:conduitpass@localhost:15432/conduitdb' `
+        -RedisUrl 'redis://localhost:16379' `
+        -PsqlCommand 'docker exec pg961 psql -U conduit -d conduitdb'
+#>
+[CmdletBinding()]
+param(
+    [string]$DatabaseUrl = $env:DATABASE_URL,
+    [string]$RedisUrl = $env:REDIS_URL,
+    [string]$PsqlCommand,
+    [switch]$NoBuild,
+    [string]$Configuration = 'Debug',
+    [int]$AdminPort = 15002,
+    [int]$GatewayPort = 15000,
+    [int]$TimeoutSeconds = 240
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $DatabaseUrl) { Write-Error 'DatabaseUrl not set (pass -DatabaseUrl or set DATABASE_URL).' }
+if (-not $PsqlCommand) { $PsqlCommand = "psql $DatabaseUrl" }
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+$adminProject = Join-Path $repoRoot 'Services' 'ConduitLLM.Admin'
+$gatewayProject = Join-Path $repoRoot 'Services' 'ConduitLLM.Gateway'
+$logDir = Join-Path ([System.IO.Path]::GetTempPath()) "wolverine-two-host-$PID"
+New-Item -ItemType Directory -Force $logDir | Out-Null
+
+$script:failures = [System.Collections.Generic.List[string]]::new()
+
+function Invoke-Sql([string]$Sql) {
+    $tokens = $PsqlCommand -split ' '
+    $rest = if ($tokens.Length -gt 1) { $tokens[1..($tokens.Length - 1)] } else { @() }
+    $result = & $tokens[0] @($rest) -tAc $Sql 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "psql failed for [$Sql]: $result" }
+    return ($result | Out-String).Trim()
+}
+
+function Assert([bool]$Condition, [string]$Name) {
+    if ($Condition) {
+        Write-Host "  PASS  $Name" -ForegroundColor Green
+    } else {
+        Write-Host "  FAIL  $Name" -ForegroundColor Red
+        $script:failures.Add($Name)
+    }
+}
+
+function Wait-ForSql([string]$Sql, [string]$Expected, [string]$What) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        try {
+            if ((Invoke-Sql $Sql) -eq $Expected) { return $true }
+        } catch {
+            # schema/tables may not exist yet while the host is still provisioning
+        }
+        Start-Sleep -Seconds 3
+    }
+    Write-Host "  timed out waiting for: $What" -ForegroundColor Yellow
+    return $false
+}
+
+function Start-ServiceHost([string]$Project, [string]$Name, [int]$Port) {
+    $dll = Join-Path $Project 'bin' $Configuration 'net10.0' "$Name.dll"
+    if (-not (Test-Path $dll)) { throw "Build output not found: $dll (build first or drop -NoBuild)" }
+    $out = Join-Path $logDir "$Name.out.log"
+    $err = Join-Path $logDir "$Name.err.log"
+    $env:ASPNETCORE_URLS = "http://localhost:$Port"
+    $proc = Start-Process dotnet -ArgumentList @($dll) `
+        -WorkingDirectory (Split-Path $dll) `
+        -RedirectStandardOutput $out -RedirectStandardError $err `
+        -PassThru -NoNewWindow
+    Write-Host "Started $Name (pid $($proc.Id)) on port $Port; logs: $out"
+    return $proc
+}
+
+function Get-HostLog([string]$Name) {
+    $text = ''
+    foreach ($suffix in 'out', 'err') {
+        $file = Join-Path $logDir "$Name.$suffix.log"
+        if (Test-Path $file) { $text += (Get-Content -Raw $file) }
+    }
+    return $text
+}
+
+# Environment shared by both hosts (ASPNETCORE_URLS is set per host).
+$env:DATABASE_URL = $DatabaseUrl
+if ($RedisUrl) { $env:REDIS_URL = $RedisUrl }
+$env:ConduitLLM__Messaging__Backend = 'Wolverine'
+$env:CONDUIT_MIGRATION_MODE = 'Skip'   # migrations are applied via the migrate verb below
+$env:ASPNETCORE_ENVIRONMENT = 'Production'
+$env:CONDUIT_ENABLE_HTTPS_REDIRECTION = 'false'
+
+if (-not $NoBuild) {
+    Write-Host '== Building Gateway + Admin =='
+    dotnet build $gatewayProject -c $Configuration
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+    dotnet build $adminProject -c $Configuration
+    if ($LASTEXITCODE -ne 0) { exit 1 }
+}
+
+Write-Host '== Applying EF migrations (migrate verb) =='
+dotnet (Join-Path $adminProject 'bin' $Configuration 'net10.0' 'ConduitLLM.Admin.dll') migrate
+if ($LASTEXITCODE -ne 0) { Write-Error 'migrate verb failed' }
+
+$admin = $null
+$gateway = $null
+$exitCode = 1
+try {
+    # Admin FIRST: recreates the W1 leadership scenario (see .DESCRIPTION).
+    Write-Host '== Booting Admin API (Wolverine backend) =='
+    $admin = Start-ServiceHost $adminProject 'ConduitLLM.Admin' $AdminPort
+    $adminUp = Wait-ForSql 'SELECT count(*) FROM wolverine_conduit_admin.wolverine_nodes' '1' 'Admin node registration'
+
+    Write-Host '== Booting Gateway API (Wolverine backend) =='
+    $gateway = Start-ServiceHost $gatewayProject 'ConduitLLM.Gateway' $GatewayPort
+    $gatewayUp = Wait-ForSql @'
+SELECT count(*) FROM wolverine_conduit_gateway.wolverine_node_assignments
+ WHERE id IN ('wolverine-listener://postgresql/spend-update-events',
+              'wolverine-listener://postgresql/image-generation-events')
+   AND started IS NOT NULL
+'@ '2' 'Gateway exclusive listener assignments'
+
+    Write-Host '== Assertions =='
+    Assert $adminUp 'Admin registers a Wolverine node'
+    Assert $gatewayUp 'Gateway exclusive listeners (spend-update-events, image-generation-events) assigned and started'
+
+    # (1) Separate single-node clusters — the W1 guard.
+    Assert ((Invoke-Sql 'SELECT count(*) FROM wolverine_conduit_admin.wolverine_nodes') -eq '1') `
+        'Admin durability schema holds exactly its own node (no shared cluster)'
+    Assert ((Invoke-Sql 'SELECT count(*) FROM wolverine_conduit_gateway.wolverine_nodes') -eq '1') `
+        'Gateway durability schema holds exactly its own node (no shared cluster)'
+
+    # (3) The Admin cluster must never be assigned queue listener agents.
+    Assert ((Invoke-Sql "SELECT count(*) FROM wolverine_conduit_admin.wolverine_node_assignments WHERE id LIKE 'wolverine-listener://%'") -eq '0') `
+        'Admin node has no queue listener agents assigned'
+
+    # (4) Gateway listens on all five queues (log wording from Wolverine.Transports.ListeningAgent).
+    $gatewayLog = Get-HostLog 'ConduitLLM.Gateway'
+    foreach ($queue in 'gateway_events', 'webhook_delivery', 'video_generation_events', 'spend_update_events', 'image_generation_events') {
+        Assert ($gatewayLog -match [regex]::Escape("Started message listening at postgresql://$queue/")) `
+            "Gateway listening on $queue"
+    }
+
+    # (5) No agent-assignment or codegen service-location failures on either host.
+    $adminLog = Get-HostLog 'ConduitLLM.Admin'
+    foreach ($bad in 'InvalidAgentException', 'InvalidServiceLocationException') {
+        Assert (-not ($gatewayLog -match $bad)) "Gateway log free of $bad"
+        Assert (-not ($adminLog -match $bad)) "Admin log free of $bad"
+    }
+
+    if ($script:failures.Count -eq 0) {
+        Write-Host "`nWolverine two-host smoke: PASS" -ForegroundColor Green
+        $exitCode = 0
+    } else {
+        Write-Host "`nWolverine two-host smoke: FAIL ($($script:failures.Count) assertion(s))" -ForegroundColor Red
+        Write-Host "`n===== Gateway log ====="
+        Get-HostLog 'ConduitLLM.Gateway' | Write-Host
+        Write-Host "`n===== Admin log ====="
+        Get-HostLog 'ConduitLLM.Admin' | Write-Host
+    }
+}
+finally {
+    foreach ($proc in $gateway, $admin) {
+        if ($proc -and -not $proc.HasExited) {
+            try { Stop-Process -Id $proc.Id -Force -Confirm:$false } catch {}
+        }
+    }
+}
+
+exit $exitCode


### PR DESCRIPTION
Closes #961. Part of #909 — the "make sure it can't hide again" step before the #930 cutover: both Wolverine cutover blockers found by the #929 S1 smoke (W1/W2) were invisible to the #928 in-memory dual-backend tests.

## 1. Build-ahead codegen check (`validate` job)

- Wires the JasperFx command line into both hosts: `app.Run(); return 0;` → `return await app.RunJasperFxCommands(args);` (`RunJasperFxCommands` ships transitively with WolverineFx 6.14 / JasperFx 2.13 — no new package). With no arguments this runs the web host exactly as before; verified by booting both hosts normally after the change.
- New CI step runs `dotnet run -- codegen preview` for Gateway and Admin with `ConduitLLM__Messaging__Backend=Wolverine`, compiling the handler chain for **every** registered event type up front. Full generated output is logged only on failure.
- **Negative test performed locally**: temporarily reverting `ServiceLocationPolicy` to `NotAllowed` (the W2 condition) makes the check exit 1 with `InvalidServiceLocationException` — i.e., this check would have caught W2 at build time. Positive run: exit 0, 40 generated handler chains on Gateway.
- This is also the checking half of the #930 static-codegen (`codegen write` + `TypeLoadMode.Static`) cutover optimization; ops now has the `codegen` verbs available on both hosts.

## 2. Two-host Postgres listener assertion (`wolverine-two-host` job)

New `scripts/test/wolverine-two-host-smoke.ps1` (+ CI job with Postgres 16 + Redis services) boots the **real** Admin and Gateway hosts against real Postgres with `Backend=Wolverine`. Admin is started **first** deliberately — recreating W1's leadership scenario, which is only dangerous if the durability schemas ever regress to being shared. Asserts:

- each service forms its own single-node agent cluster (`wolverine_conduit_gateway` / `wolverine_conduit_admin` schemas each hold exactly one node);
- the exclusive strict-ordered `wolverine-listener://postgresql/spend-update-events` and `.../image-generation-events` agents are assigned to the Gateway node with `started` set (queried from `wolverine_node_assignments`);
- the Admin node has **no** queue listener agents assigned;
- the Gateway logs `Started message listening at postgresql://…` for all five queues;
- neither host logs `InvalidAgentException` or `InvalidServiceLocationException`.

All 14 assertions verified green locally against throwaway Postgres/Redis containers (script header documents the local-run recipe). Migrations are applied via the existing `migrate` verb, which with the Wolverine env also provisions the bus schema.

## Also

- `phase2-parity-gate-runbook.md`: new "Standing CI guards (#961)" section noting these guards prove topology/codegen only — S2–S6 remain mandatory for cutover.

## Verification

- `dotnet build` full solution: clean.
- `dotnet test` (Messaging + WebApplicationFactory-based suites, 72 tests): pass — the entry-point change does not break test host interception.
- Both CI additions exercised end-to-end locally as described above; `ci.yml` YAML parse-checked.