### PR TITLE
test(gateway): fix the 17 permanently-failing controller tests blocking dev CI

### DIFF
--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetModelParametersTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetModelParametersTests.cs
@@ -156,14 +156,9 @@ namespace ConduitLLM.Tests.Http.Controllers.Discovery
             MockDbContextFactory.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Database error"));
 
-            // Act
-            var result = await Controller.GetModelParameters("gpt-4");
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await Controller.GetModelParameters("gpt-4");
+            await act.Should().ThrowAsync<Exception>().WithMessage("Database error");
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/GetModels/GetModelsErrorHandlingTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/GetModels/GetModelsErrorHandlingTests.cs
@@ -24,15 +24,9 @@ namespace ConduitLLM.Tests.Http.Controllers.Discovery.GetModels
             MockDbContextFactory.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Database connection failed"));
 
-            // Act
-            var result = await Controller.GetModels();
-
-            // Assert - GatewayControllerBase returns OpenAIErrorResponse via ExceptionToResponseMapper
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await Controller.GetModels();
+            await act.Should().ThrowAsync<Exception>().WithMessage("Database connection failed");
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.CheckAndOwnership.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.CheckAndOwnership.cs
@@ -114,14 +114,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockFileRetrievalService.Setup(x => x.FileExistsAsync(fileId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Existence check error"));
 
-            // Act
-            var result = await _controller.CheckFileExists(fileId);
-
-            // Assert — GatewayControllerBase returns ObjectResult with OpenAIErrorResponse for unhandled exceptions
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(500);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            errorResponse.Error.Should().NotBeNull();
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.CheckFileExists(fileId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Existence check error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.DownloadFile.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.DownloadFile.cs
@@ -221,15 +221,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockFileRetrievalService.Setup(x => x.RetrieveFileAsync(fileId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Service error"));
 
-            // Act
-            var result = await _controller.DownloadFile(fileId);
-
-            // Assert — GatewayControllerBase returns OpenAIErrorResponse for unhandled exceptions
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(500);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            errorResponse.Error.Should().NotBeNull();
-            errorResponse.Error!.Type.Should().Be("server_error");
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.DownloadFile(fileId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Service error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.MetadataAndUrl.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/DownloadsControllerTests.MetadataAndUrl.cs
@@ -130,15 +130,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockFileRetrievalService.Setup(x => x.GetFileMetadataAsync(fileId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Metadata service error"));
 
-            // Act
-            var result = await _controller.GetFileMetadata(fileId);
-
-            // Assert — GatewayControllerBase returns OpenAIErrorResponse for unhandled exceptions
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(500);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            errorResponse.Error.Should().NotBeNull();
-            errorResponse.Error!.Type.Should().Be("server_error");
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetFileMetadata(fileId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Metadata service error");
         }
 
         #endregion
@@ -380,15 +374,9 @@ namespace ConduitLLM.Tests.Http.Controllers
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("URL generation error"));
 
-            // Act
-            var result = await _controller.GenerateDownloadUrl(request);
-
-            // Assert — GatewayControllerBase returns OpenAIErrorResponse for unhandled exceptions
-            var statusCodeResult = result.Should().BeOfType<ObjectResult>().Subject;
-            statusCodeResult.StatusCode.Should().Be(500);
-            var errorResponse = statusCodeResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            errorResponse.Error.Should().NotBeNull();
-            errorResponse.Error!.Type.Should().Be("server_error");
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GenerateDownloadUrl(request);
+            await act.Should().ThrowAsync<Exception>().WithMessage("URL generation error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.CheckMediaExists.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.CheckMediaExists.cs
@@ -105,14 +105,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockStorageService.Setup(x => x.ExistsAsync(storageKey))
                 .ThrowsAsync(new Exception("Storage error"));
 
-            // Act
-            var result = await _controller.CheckMediaExists(storageKey);
-
-            // Assert - GatewayControllerBase returns OpenAIErrorResponse via ExceptionToResponseMapper
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.CheckMediaExists(storageKey);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Storage error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.GetMedia.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.GetMedia.cs
@@ -212,14 +212,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockStorageService.Setup(x => x.GetInfoAsync(storageKey))
                 .ThrowsAsync(new Exception("Storage error"));
 
-            // Act
-            var result = await _controller.GetMedia(storageKey);
-
-            // Assert - GatewayControllerBase returns OpenAIErrorResponse via ExceptionToResponseMapper
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetMedia(storageKey);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Storage error");
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.GetMediaInfo.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.GetMediaInfo.cs
@@ -69,14 +69,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockStorageService.Setup(x => x.GetInfoAsync(storageKey))
                 .ThrowsAsync(new Exception("Storage error"));
 
-            // Act
-            var result = await _controller.GetMediaInfo(storageKey);
-
-            // Assert - GatewayControllerBase returns OpenAIErrorResponse via ExceptionToResponseMapper
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetMediaInfo(storageKey);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Storage error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.VideoRange.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/MediaControllerTests.VideoRange.cs
@@ -192,12 +192,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             };
             _controller.Request.Headers["Range"] = "bytes=0-999";
 
-            // Act
-            var result = await _controller.GetMedia(storageKey);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetMedia(storageKey);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Storage error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/TasksControllerTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/TasksControllerTests.cs
@@ -114,16 +114,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockTaskService.Setup(x => x.GetTaskStatusAsync(taskId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Service error"));
 
-            // Act
-            var result = await _controller.GetTaskStatus(taskId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetTaskStatus(taskId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Service error");
         }
 
         #endregion
@@ -172,16 +165,9 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockTaskService.Setup(x => x.CancelTaskAsync(taskId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Service error"));
 
-            // Act
-            var result = await _controller.CancelTask(taskId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.CancelTask(taskId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Service error");
         }
 
         #endregion
@@ -303,15 +289,9 @@ namespace ConduitLLM.Tests.Http.Controllers
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Service error"));
 
-            // Act
-            var result = await _controller.PollTask(taskId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.PollTask(taskId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Service error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.GenerateVideo.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.GenerateVideo.cs
@@ -38,6 +38,16 @@ namespace ConduitLLM.Tests.Http.Controllers
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(taskId);
 
+            // The event is published fire-and-forget on the thread pool
+            // (PublishEventFireAndForget); signal completion so the Verify below
+            // doesn't race the publish under parallel test load.
+            var published = new TaskCompletionSource();
+            _mockEventBus.Setup(x => x.PublishAsync(
+                    It.IsAny<VideoGenerationRequested>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => published.TrySetResult())
+                .Returns(Task.CompletedTask);
+
             _controller.ControllerContext = CreateControllerContext();
             _controller.ControllerContext.HttpContext.Items["VirtualKey"] = virtualKey;
             _controller.ControllerContext.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
@@ -48,6 +58,7 @@ namespace ConduitLLM.Tests.Http.Controllers
 
             // Act
             var result = await _controller.GenerateVideoAsync(request);
+            await published.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             // Assert
             var acceptedResult = result.Should().BeOfType<AcceptedResult>().Subject;
@@ -225,14 +236,9 @@ namespace ConduitLLM.Tests.Http.Controllers
                     new System.Security.Claims.Claim("VirtualKeyId", "123")
                 }, "Test"));
 
-            // Act
-            var result = await _controller.GenerateVideoAsync(request);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("server_error", errorResponse.Error.Type);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GenerateVideoAsync(request);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Internal error");
         }
 
         #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.TaskCancel.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.TaskCancel.cs
@@ -39,6 +39,16 @@ namespace ConduitLLM.Tests.Http.Controllers
             _mockTaskService.Setup(x => x.CancelTaskAsync(taskId, It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
+            // The event is published fire-and-forget on the thread pool
+            // (PublishEventFireAndForget); signal completion so the Verify below
+            // doesn't race the publish under parallel test load.
+            var published = new TaskCompletionSource();
+            _mockEventBus.Setup(x => x.PublishAsync(
+                    It.IsAny<VideoGenerationCancelled>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => published.TrySetResult())
+                .Returns(Task.CompletedTask);
+
             _controller.ControllerContext = CreateControllerContext();
             _controller.ControllerContext.HttpContext.Items["VirtualKey"] = virtualKey;
             _controller.ControllerContext.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
@@ -49,6 +59,7 @@ namespace ConduitLLM.Tests.Http.Controllers
 
             // Act
             var result = await _controller.CancelTask(taskId);
+            await published.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             // Assert
             result.Should().BeOfType<NoContentResult>();

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.TaskStatus.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/VideosControllerTests.TaskStatus.cs
@@ -128,14 +128,9 @@ namespace ConduitLLM.Tests.Http.Controllers
                     new System.Security.Claims.Claim("VirtualKeyId", "123")
                 }, "Test"));
 
-            // Act
-            var result = await _controller.GetTaskStatus(taskId);
-
-            // Assert
-            var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-            Assert.Equal(500, objectResult.StatusCode);
-            var errorResponse = objectResult.Value.Should().BeOfType<OpenAIErrorResponse>().Subject;
-            Assert.Equal("An unexpected error occurred", errorResponse.Error.Message);
+            // Act + Assert — error mapping is owned by OpenAIErrorMiddleware; the action propagates.
+            var act = async () => await _controller.GetTaskStatus(taskId);
+            await act.Should().ThrowAsync<Exception>().WithMessage("Database error");
         }
 
         #endregion


### PR DESCRIPTION
## Problem

Dev CI's Validate job has been red on every push since late June, blamed on a "flaky exception→500 test family." Digging in showed two distinct defects, neither actually order-dependent flakiness in the family itself:

1. **15 deterministically broken tests** (Discovery, Downloads, Media, Tasks, Videos controllers). Since b134bb98 (Tier 1a #902), Gateway exception mapping is owned by the global `OpenAIErrorMiddleware` — controller actions propagate raw exceptions. These tests still asserted `ObjectResult(500)` from the action, so they fail every run, including in isolation. They escaped the Tier 1a verification because its filter (`~ConduitLLM.Tests.Gateway`) never matched their namespace (`ConduitLLM.Tests.Http.Controllers.*` — the folder says Gateway, the namespace doesn't).
2. **2 genuinely racy tests** (`GenerateVideoAsync_WithValidRequest_ShouldReturnAccepted`, `CancelTask_WithPendingTask_ShouldReturnNoContent`). They `Verify(PublishAsync)` immediately after the action, but `PublishEventFireAndForget` publishes inside `Task.Run` — under parallel full-suite load the Verify wins the race ("expected 1 invocation, was 0"). This pair is why the failing set appeared to shift between runs.

## Fix (test-only, no production code)

- The 15 stale tests now follow the Admin Tier 1a precedent: `act.Should().ThrowAsync<Exception>()` with a comment that mapping is owned by `OpenAIErrorMiddleware`. The 500 mapping itself is covered by `OpenAIErrorMiddlewareTests` and `ExceptionToResponseMapperTests`.
- The 2 racy tests signal a `TaskCompletionSource` from the mocked publish and `await published.Task.WaitAsync(10s)` before verifying — deterministic under any thread-pool load.

## Verification

- 3 consecutive full `ConduitLLM.Tests` runs: **2906 passed / 0 failed** (first clean full-suite runs on dev-based code)
- Exact CI command (`dotnet test --filter "FullyQualifiedName!~IntegrationTests&Category!=TimingSensitive"`): green

## Why this matters for #909/#961

The #961 Wolverine codegen-check step sits after ".NET Build & Test" in the Validate job, so it has **never executed on dev** — these failures always killed the job first. With this merged, Validate should go green end-to-end and the codegen guard goes live. (Codegen itself was verified clean locally on dev HEAD with the CI env: gateway 40 generated types, admin 4.)