### PR TITLE
fix(billing): parse PricingConfiguration case-insensitively in CostCalculationService

### DIFF
--- a/Shared/ConduitLLM.Core/Services/CostCalculationService.PricingModels.cs
+++ b/Shared/ConduitLLM.Core/Services/CostCalculationService.PricingModels.cs
@@ -13,6 +13,16 @@ namespace ConduitLLM.Core.Services;
 /// </summary>
 public partial class CostCalculationService
 {
+    /// <summary>
+    /// Serializer options for parsing <see cref="ModelCost.PricingConfiguration"/> JSON.
+    /// Case-insensitive because documented configs and the WebAdmin UI produce camelCase
+    /// property names (e.g. "baseRate") while the config POCOs use PascalCase.
+    /// </summary>
+    private static readonly JsonSerializerOptions PricingConfigJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private Task<decimal> CalculatePerVideoCostAsync(string modelId, ModelCost modelCost, Usage usage)
     {
         if (!usage.VideoDurationSeconds.HasValue || string.IsNullOrEmpty(usage.VideoResolution))
@@ -27,7 +37,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<PerVideoPricingConfig>(modelCost.PricingConfiguration);
+                config = JsonSerializer.Deserialize<PerVideoPricingConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
             }
             catch (Exception ex)
             {
@@ -73,7 +83,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<PerSecondVideoPricingConfig>(modelCost.PricingConfiguration);
+                config = JsonSerializer.Deserialize<PerSecondVideoPricingConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
             }
             catch (Exception ex)
             {
@@ -113,7 +123,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<InferenceStepsPricingConfig>(modelCost.PricingConfiguration);
+                config = JsonSerializer.Deserialize<InferenceStepsPricingConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
             }
             catch (Exception ex)
             {
@@ -152,7 +162,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<TieredTokensPricingConfig>(modelCost.PricingConfiguration);
+                config = JsonSerializer.Deserialize<TieredTokensPricingConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
             }
             catch (Exception ex)
             {
@@ -212,7 +222,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<PerImagePricingConfig>(modelCost.PricingConfiguration);
+                config = JsonSerializer.Deserialize<PerImagePricingConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
             }
             catch (Exception ex)
             {
@@ -281,10 +291,7 @@ public partial class CostCalculationService
         {
             try
             {
-                config = JsonSerializer.Deserialize<PricingRulesConfig>(modelCost.PricingConfiguration, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
+                config = JsonSerializer.Deserialize<PricingRulesConfig>(modelCost.PricingConfiguration, PricingConfigJsonOptions);
                 _logger.LogDebug("Parsed pricing rules configuration directly for model {ModelId}", modelId);
             }
             catch (Exception ex)

--- a/Tests/ConduitLLM.Tests/Core/Services/PolymorphicPricingTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/PolymorphicPricingTests.cs
@@ -338,6 +338,96 @@ namespace ConduitLLM.Tests.Core.Services
         }
 
         [Fact]
+        public async Task CalculateCost_PerImage_CamelCaseJson_ReturnsNonZeroCost()
+        {
+            // Regression test: documented/WebAdmin-produced PricingConfiguration is camelCase
+            // (e.g. {"baseRate":0.05}). Case-sensitive parsing silently yielded BaseRate=0
+            // and billed $0.00 for media generation.
+            // Arrange
+            var modelId = "minimax/image-01";
+            var usage = new Usage
+            {
+                ImageCount = 2
+            };
+
+            var modelCost = new ModelCost
+            {
+                CostName = modelId,
+                PricingModel = PricingModel.PerImage,
+                PricingConfiguration = "{\"baseRate\":0.05}"
+            };
+
+            _mockModelCostService.Setup(x => x.GetCostForModelAsync(modelId, default))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var cost = await _service.CalculateCostAsync(modelId, usage);
+
+            // Assert
+            Assert.Equal(0.10m, cost); // 2 images * 0.05 base rate
+        }
+
+        [Fact]
+        public async Task CalculateCost_PerImage_CamelCaseJsonWithMultipliers_AppliesMultipliers()
+        {
+            // Arrange
+            var modelId = "replicate/flux-pro";
+            var usage = new Usage
+            {
+                ImageCount = 1,
+                ImageQuality = "hd",
+                ImageResolution = "1792x1024"
+            };
+
+            var modelCost = new ModelCost
+            {
+                CostName = modelId,
+                PricingModel = PricingModel.PerImage,
+                PricingConfiguration =
+                    "{\"baseRate\":0.04,\"qualityMultipliers\":{\"hd\":2.0},\"resolutionMultipliers\":{\"1792x1024\":1.5}}"
+            };
+
+            _mockModelCostService.Setup(x => x.GetCostForModelAsync(modelId, default))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var cost = await _service.CalculateCostAsync(modelId, usage);
+
+            // Assert
+            Assert.Equal(0.12m, cost); // 1 image * 0.04 base * 2.0 quality * 1.5 resolution
+        }
+
+        [Fact]
+        public async Task CalculateCost_PerSecondVideo_CamelCaseJson_ReturnsNonZeroCost()
+        {
+            // Regression test: camelCase config must not deserialize BaseRate=0 (silent $0 billing).
+            // Arrange
+            var modelId = "replicate/minimax-video";
+            var usage = new Usage
+            {
+                VideoDurationSeconds = 10,
+                VideoResolution = "1080p"
+            };
+
+            var modelCost = new ModelCost
+            {
+                CostName = modelId,
+                PricingModel = PricingModel.PerSecondVideo,
+                PricingConfiguration =
+                    "{\"baseRate\":0.09,\"resolutionMultipliers\":{\"720p\":1.0,\"1080p\":1.5}}"
+            };
+
+            _mockModelCostService.Setup(x => x.GetCostForModelAsync(modelId, default))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var cost = await _service.CalculateCostAsync(modelId, usage);
+
+            // Assert
+            Assert.Equal(1.35m, cost); // 10 seconds * 0.09 * 1.5
+        }
+
+        [Fact]
         public async Task CalculateCost_Standard_WithBatchProcessing()
         {
             // Arrange


### PR DESCRIPTION
Fixes #971

## Problem

The polymorphic pricing deserializers in `CostCalculationService.PricingModels.cs` parsed `ModelCost.PricingConfiguration` with **default (case-sensitive)** `JsonSerializer` options for five of six pricing models — PerVideo, PerSecondVideo, InferenceSteps, TieredTokens, PerImage — while only RulesBased passed `PropertyNameCaseInsensitive = true` (via inline options allocated per call).

The documented format (`docs/model-pricing/*.md`), the WebAdmin pricing UI (`PricingModelSelector.tsx`), and the DTO doc comments all specify **camelCase** (`{"baseRate": 0.05}`), and the POCOs in `PricingConfigurations.cs` are PascalCase with no `[JsonPropertyName]` attributes. Result: camelCase configs deserialized with all defaults — `BaseRate = 0` — and media generation billed **$0.00 silently**. Verified live on dev HEAD:

```
Image generation cost calculated: ... BaseRate=$0.0000 ... PricingConfiguration={"baseRate":0.05}
```

## Fix

- Single `static readonly JsonSerializerOptions PricingConfigJsonOptions { PropertyNameCaseInsensitive = true }` shared by **all six** `Deserialize` calls in `CostCalculationService.PricingModels.cs` (RulesBased included — its inline per-call options allocation is removed).
- This matches the behavior of `RedisModelCostCache` (Gateway parsed-config cache path), `CachedPricingRulesService`, `PricingRulesValidator`, and `PricingController`, which already parse the same JSON case-insensitively — the direct path and the cache path now agree.

## Other sites audited (no change needed)

- `Services/ConduitLLM.Gateway/Services/RedisModelCostCache.Helpers.cs` — uses `JsonOptions` from `RedisCacheServiceBase`, which defaults to `PropertyNameCaseInsensitive = true`.
- `Shared/ConduitLLM.Functions/Services/FunctionCostCalculationService.*` — deserializes `TieredPricingConfig` / `ExaHybridPricingConfig` / `TavilySearchPricingConfig` with default options, but those POCOs carry explicit camelCase `[JsonPropertyName]` attributes, so camelCase JSON binds correctly.
- `PricingController`, `CachedPricingRulesService`, `PricingRulesValidator` — already case-insensitive.

## Tests

Added camelCase regression tests to `PolymorphicPricingTests` (existing tests round-trip via `JsonSerializer.Serialize`, i.e. PascalCase, so they never caught this):

- `CalculateCost_PerImage_CamelCaseJson_ReturnsNonZeroCost`
- `CalculateCost_PerImage_CamelCaseJsonWithMultipliers_AppliesMultipliers`
- `CalculateCost_PerSecondVideo_CamelCaseJson_ReturnsNonZeroCost`

`dotnet test --filter FullyQualifiedName~CostCalculation`: **65/65 passed** (includes 14/14 PolymorphicPricingTests). `ConduitLLM.Core` builds clean, 0 warnings.

## Related

- Same class as the #955 media-$0-billing issues; related to #768.
- Found during #929 parity-gate load testing.