### PR TITLE
feat(providers): Add Meta AI provider with Muse Spark 1.1 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,7 +396,8 @@ public enum ProviderType
     SambaNova = 10,     // Ultra-fast inference
     DeepInfra = 11,     // OpenAI-compatible LLM inference
     Cloudflare = 12,    // Serverless AI on Cloudflare's global network
-    OpenRouter = 13     // Multi-provider routing via OpenAI-compatible API
+    OpenRouter = 13,    // Multi-provider routing via OpenAI-compatible API
+    Meta = 14           // Meta Model API (Muse Spark models)
 }
 ```
 

--- a/SDKs/Node/Admin/src/models/providerConfiguration.ts
+++ b/SDKs/Node/Admin/src/models/providerConfiguration.ts
@@ -21,6 +21,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderType, string> = {
   [ProviderType.DeepInfra]: 'DeepInfra',
   [ProviderType.Cloudflare]: 'Cloudflare Workers AI',
   [ProviderType.OpenRouter]: 'OpenRouter',
+  [ProviderType.Meta]: 'Meta AI',
 };
 
 /** Provider categories for grouping in UI */
@@ -48,6 +49,7 @@ export const PROVIDER_CATEGORIES: Record<ProviderType, ProviderCategory[]> = {
   [ProviderType.DeepInfra]: [ProviderCategory.Chat, ProviderCategory.Image, ProviderCategory.Embedding],
   [ProviderType.Cloudflare]: [ProviderCategory.Chat, ProviderCategory.Embedding, ProviderCategory.Image],
   [ProviderType.OpenRouter]: [ProviderCategory.Chat],
+  [ProviderType.Meta]: [ProviderCategory.Chat],
 };
 
 /** Provider-specific configuration requirements */
@@ -174,6 +176,15 @@ export const PROVIDER_CONFIG_REQUIREMENTS: Record<ProviderType, ProviderConfigRe
     supportsCustomEndpoint: false,
     helpUrl: 'https://openrouter.ai/keys',
     helpText: 'Get your API key from openrouter.ai/keys - Routes to 100+ models from multiple providers',
+    supportedModelTypes: [ModelType.Chat]
+  },
+  [ProviderType.Meta]: {
+    requiresApiKey: true,
+    requiresEndpoint: false,
+    requiresOrganizationId: false,
+    supportsCustomEndpoint: true,
+    helpUrl: 'https://ai.developer.meta.com',
+    helpText: 'Get your API key from ai.developer.meta.com - Meta Model API with Muse Spark multimodal reasoning models',
     supportedModelTypes: [ModelType.Chat]
   },
 };

--- a/SDKs/Node/Admin/src/models/providerType.ts
+++ b/SDKs/Node/Admin/src/models/providerType.ts
@@ -40,5 +40,8 @@ export enum ProviderType {
   Cloudflare = 12,
 
   /** OpenRouter (multi-provider routing via OpenAI-compatible API) */
-  OpenRouter = 13
+  OpenRouter = 13,
+
+  /** Meta AI (Meta Model API, Muse Spark models) */
+  Meta = 14
 }

--- a/SDKs/Node/Admin/src/types/providers.ts
+++ b/SDKs/Node/Admin/src/types/providers.ts
@@ -108,6 +108,17 @@ export const PROVIDER_REGISTRY: Record<number, ProviderMetadata> = {
     supportsVariation: true,
     description: 'DeepInfra model hosting'
   },
+  [ProviderType.Meta]: {
+    value: ProviderType.Meta,
+    name: 'Meta',
+    label: 'Meta AI',
+    supportsSpeedScore: true,
+    supportsQualityScore: true,
+    supportsVariation: false,
+    defaultMaxInputTokens: 1048576,
+    defaultMaxOutputTokens: 131072,
+    description: 'Meta Model API (Muse Spark models)'
+  },
   [ProviderType.Ultravox]: {
     value: ProviderType.Ultravox,
     name: 'Ultravox',
@@ -220,7 +231,10 @@ export function normalizeProviderType(provider: string | number): ProviderType |
     'workers-ai': ProviderType.Cloudflare,
     'workersai': ProviderType.Cloudflare,
     'openrouter': ProviderType.OpenRouter,
-    'open-router': ProviderType.OpenRouter
+    'open-router': ProviderType.OpenRouter,
+    'meta': ProviderType.Meta,
+    'metaai': ProviderType.Meta,
+    'meta-ai': ProviderType.Meta
   };
   
   const lowerProvider = provider.toLowerCase().replace(/[\s_]/g, '');

--- a/SDKs/Node/Gateway/src/models/providerType.ts
+++ b/SDKs/Node/Gateway/src/models/providerType.ts
@@ -40,5 +40,8 @@ export enum ProviderType {
   Cloudflare = 12,
 
   /** OpenRouter (multi-provider routing via OpenAI-compatible API) */
-  OpenRouter = 13
+  OpenRouter = 13,
+
+  /** Meta AI (Meta Model API, Muse Spark models) */
+  Meta = 14
 }

--- a/Shared/ConduitLLM.Configuration/Enums/ProviderType.cs
+++ b/Shared/ConduitLLM.Configuration/Enums/ProviderType.cs
@@ -71,6 +71,11 @@ namespace ConduitLLM.Configuration
         /// <summary>
         /// OpenRouter (multi-provider routing via OpenAI-compatible API)
         /// </summary>
-        OpenRouter = 13
+        OpenRouter = 13,
+
+        /// <summary>
+        /// Meta AI (Meta Model API, Muse Spark models)
+        /// </summary>
+        Meta = 14
     }
 }

--- a/Shared/ConduitLLM.Core/Providers/Metadata/AllProviders.cs
+++ b/Shared/ConduitLLM.Core/Providers/Metadata/AllProviders.cs
@@ -254,4 +254,39 @@ namespace ConduitLLM.Core.Providers.Metadata
             });
         }
     }
+
+    /// <summary>
+    /// Provider metadata for Meta AI (Meta Model API).
+    /// </summary>
+    public class MetaProviderMetadata : BaseProviderMetadata
+    {
+        public override ProviderType ProviderType => ProviderType.Meta;
+        public override string DisplayName => "Meta AI";
+        public override string DefaultBaseUrl => "https://api.meta.ai/v1";
+
+        public MetaProviderMetadata()
+        {
+            // Meta Model API is OpenAI-compatible with multimodal input support
+            Capabilities.Features.Streaming = true;
+            Capabilities.Features.VisionInput = true;
+
+            // Chat parameters support
+            Capabilities.ChatParameters.Tools = true;
+            Capabilities.ChatParameters.ResponseFormat = true;
+
+            ConfigurationHints.DocumentationUrl = "https://ai.developer.meta.com/docs";
+            ConfigurationHints.Tips.Add(new ConfigurationTip
+            {
+                Title = "Massive Context Window",
+                Description = "Muse Spark models support a 1M-token context window with image, video, and PDF input",
+                Severity = TipSeverity.Info
+            });
+            ConfigurationHints.Tips.Add(new ConfigurationTip
+            {
+                Title = "Public Preview",
+                Description = "The Meta Model API is in public preview and currently US-only",
+                Severity = TipSeverity.Info
+            });
+        }
+    }
 }

--- a/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
@@ -9,6 +9,7 @@ using ConduitLLM.Providers.MiniMax;
 using ConduitLLM.Providers.OpenAI;
 using ConduitLLM.Providers.Replicate;
 using ConduitLLM.Providers.Cloudflare;
+using ConduitLLM.Providers.Meta;
 using ConduitLLM.Providers.OpenRouter;
 using ConduitLLM.Providers.SambaNova;
 
@@ -77,7 +78,8 @@ namespace ConduitLLM.Providers.Configuration
             [ProviderType.SambaNova] = CreateSambaNovaClient,
             [ProviderType.DeepInfra] = CreateDeepInfraClient,
             [ProviderType.Cloudflare] = CreateCloudflareClient,
-            [ProviderType.OpenRouter] = CreateOpenRouterClient
+            [ProviderType.OpenRouter] = CreateOpenRouterClient,
+            [ProviderType.Meta] = CreateMetaClient
         };
 
         /// <summary>
@@ -314,6 +316,22 @@ namespace ConduitLLM.Providers.Configuration
         {
             var logger = context.LoggerFactory.CreateLogger<OpenRouterClient>();
             return new OpenRouterClient(
+                provider,
+                keyCredential,
+                modelId,
+                logger,
+                context.HttpClientFactory,
+                context.DefaultModels);
+        }
+
+        private static ILLMClient CreateMetaClient(
+            Provider provider,
+            ProviderKeyCredential keyCredential,
+            string modelId,
+            ClientCreationContext context)
+        {
+            var logger = context.LoggerFactory.CreateLogger<MetaClient>();
+            return new MetaClient(
                 provider,
                 keyCredential,
                 modelId,

--- a/Shared/ConduitLLM.Providers/Providers/Meta/MetaClient.ErrorHandling.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Meta/MetaClient.ErrorHandling.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+using ConduitLLM.Core.Exceptions;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Meta
+{
+    /// <summary>
+    /// MetaClient partial class containing error handling methods.
+    /// </summary>
+    public partial class MetaClient
+    {
+        /// <summary>
+        /// Processes HTTP errors and converts them to appropriate exceptions.
+        /// </summary>
+        /// <param name="statusCode">The HTTP status code.</param>
+        /// <param name="responseContent">The response content.</param>
+        /// <param name="requestId">Optional request ID for tracking.</param>
+        /// <returns>An appropriate exception for the error.</returns>
+        private Exception ProcessHttpError(System.Net.HttpStatusCode statusCode, string responseContent, string? requestId = null)
+        {
+            Logger.LogError("Meta Model API error - Status: {StatusCode}, Content: {Content}, RequestId: {RequestId}",
+                statusCode, responseContent, requestId);
+
+            return statusCode switch
+            {
+                System.Net.HttpStatusCode.Unauthorized => new ConfigurationException(Constants.ErrorMessages.InvalidApiKey),
+                System.Net.HttpStatusCode.TooManyRequests => new LLMCommunicationException(Constants.ErrorMessages.RateLimitExceeded),
+                System.Net.HttpStatusCode.NotFound => new ModelUnavailableException(Constants.ErrorMessages.ModelNotFound),
+                System.Net.HttpStatusCode.PaymentRequired => new LLMCommunicationException(Constants.ErrorMessages.QuotaExceeded),
+                System.Net.HttpStatusCode.BadRequest => ParseBadRequestError(responseContent),
+                System.Net.HttpStatusCode.InternalServerError => new LLMCommunicationException($"Meta Model API internal error: {responseContent}"),
+                System.Net.HttpStatusCode.ServiceUnavailable => new LLMCommunicationException("Meta Model API is temporarily unavailable. Please try again later."),
+                _ => new LLMCommunicationException($"Meta Model API error ({statusCode}): {responseContent}")
+            };
+        }
+
+        /// <summary>
+        /// Parses bad request errors to provide more specific error information.
+        /// </summary>
+        /// <param name="responseContent">The response content containing error details.</param>
+        /// <returns>An appropriate exception for the bad request error.</returns>
+        private Exception ParseBadRequestError(string responseContent)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(responseContent);
+                if (document.RootElement.TryGetProperty("error", out var errorElement))
+                {
+                    if (errorElement.TryGetProperty("message", out var messageElement))
+                    {
+                        var errorMessage = messageElement.GetString();
+
+                        // Check for specific error patterns
+                        if (errorMessage?.Contains("model", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            return new ModelUnavailableException($"Model error: {errorMessage}");
+                        }
+
+                        if (errorMessage?.Contains("token", StringComparison.OrdinalIgnoreCase) == true)
+                        {
+                            return new ValidationException($"Token limit error: {errorMessage}");
+                        }
+
+                        return new ValidationException($"Request error: {errorMessage}");
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Fall through to generic error if JSON parsing fails
+            }
+
+            return new ValidationException($"Bad request: {responseContent}");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/Meta/MetaClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Meta/MetaClient.cs
@@ -1,0 +1,125 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Common.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Meta
+{
+    /// <summary>
+    /// Client for interacting with the Meta Model API (Meta AI).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This client interacts with Meta's Model API, which provides access to the Muse Spark
+    /// family of multimodal reasoning models from Meta Superintelligence Labs.
+    /// </para>
+    /// <para>
+    /// Key features:
+    /// - OpenAI-compatible API format (Chat Completions) for seamless integration
+    /// - Support for streaming and non-streaming responses
+    /// - 1M-token context window with multimodal input (image, video, PDF)
+    /// - Tool calling (including parallel tool calls) and structured output
+    /// </para>
+    /// <para>
+    /// Authentication is handled via Bearer token in the Authorization header.
+    /// The API key can be obtained from https://ai.developer.meta.com
+    /// </para>
+    /// </remarks>
+    public partial class MetaClient : ConduitLLM.Providers.OpenAICompatible.OpenAICompatibleClient
+    {
+        // API configuration constants
+        private static class Constants
+        {
+            public static class Urls
+            {
+                /// <summary>
+                /// Default base URL for the Meta Model API
+                /// </summary>
+                public const string DefaultBaseUrl = "https://api.meta.ai/v1";
+            }
+
+            public static class Headers
+            {
+                /// <summary>
+                /// Authorization header for API key authentication
+                /// </summary>
+                public const string Authorization = "Authorization";
+            }
+
+            public static class Endpoints
+            {
+                public const string ChatCompletions = "/chat/completions";
+                public const string Models = "/models";
+            }
+
+            public static class ErrorMessages
+            {
+                public const string MissingApiKey = "API key is missing for provider 'meta'";
+                public const string RateLimitExceeded = "Meta Model API rate limit exceeded. Please try again later or reduce your request frequency.";
+                public const string InvalidApiKey = "Invalid Meta Model API key. Please check your credentials.";
+                public const string ModelNotFound = "The specified model is not available. Please check the model name and try again.";
+                public const string QuotaExceeded = "API quota exceeded. Please check your usage limits or remaining credits.";
+            }
+        }
+
+        /// <summary>
+        /// Fallback models for Meta when the models endpoint is not available
+        /// </summary>
+        private static readonly List<ExtendedModelInfo> MetaModels = new()
+        {
+            // Muse Spark models
+            ExtendedModelInfo.Create("muse-spark-1.1", "meta", "Meta Muse Spark 1.1")
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the MetaClient class.
+        /// </summary>
+        /// <param name="provider">The provider entity containing configuration.</param>
+        /// <param name="keyCredential">Key credential containing API key and endpoint configuration.</param>
+        /// <param name="providerModelId">The specific model ID to use with this provider.</param>
+        /// <param name="logger">Logger for recording diagnostic information.</param>
+        /// <param name="httpClientFactory">Factory for creating HttpClient instances with proper configuration.</param>
+        /// <param name="defaultModels">Optional default model configuration for the provider.</param>
+        /// <param name="providerName">Optional provider name override. If not specified, defaults to "meta".</param>
+        /// <exception cref="ArgumentNullException">Thrown when any required parameter is null.</exception>
+        /// <exception cref="ConfigurationException">Thrown when API key is missing.</exception>
+        public MetaClient(
+            Provider provider,
+            ProviderKeyCredential keyCredential,
+            string providerModelId,
+            ILogger<MetaClient> logger,
+            IHttpClientFactory httpClientFactory,
+            ProviderDefaultModels? defaultModels = null,
+            string? providerName = null)
+            : base(
+                provider,
+                keyCredential,
+                providerModelId,
+                logger,
+                httpClientFactory,
+                providerName ?? "meta",
+                baseUrl: Constants.Urls.DefaultBaseUrl,
+                defaultModels: defaultModels)
+        {
+            if (string.IsNullOrWhiteSpace(keyCredential.ApiKey))
+            {
+                throw new ConfigurationException(Constants.ErrorMessages.MissingApiKey);
+            }
+        }
+
+        /// <summary>
+        /// Configures the HTTP client for Meta Model API requests.
+        /// </summary>
+        /// <param name="client">The HTTP client to configure.</param>
+        /// <param name="apiKey">The API key to configure authentication with.</param>
+        protected override void ConfigureHttpClient(HttpClient client, string apiKey)
+        {
+            base.ConfigureHttpClient(client, apiKey);
+
+            // Set User-Agent for better API analytics
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("ConduitLLM-MetaClient/1.0");
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/MetaClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/MetaClientTests.cs
@@ -1,0 +1,185 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Meta;
+
+using Moq;
+
+using Xunit.Abstractions;
+
+namespace ConduitLLM.Tests.Providers
+{
+    /// <summary>
+    /// Unit tests for the MetaClient class, covering the Meta Model API (Muse Spark models).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Providers")]
+    public class MetaClientTests : TestBase
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock;
+        private readonly HttpClient _httpClient;
+
+        public MetaClientTests(ITestOutputHelper output) : base(output)
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            _httpClient = new HttpClient(_httpMessageHandlerMock.Object)
+            {
+                BaseAddress = new Uri("https://api.meta.ai/v1/")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(_httpClient);
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_WithValidCredentials_InitializesCorrectly()
+        {
+            // Arrange
+            var provider = new Provider
+            {
+                Id = 1,
+                ProviderType = ProviderType.Meta
+            };
+
+            var keyCredential = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = 1,
+                ApiKey = "test-api-key"
+            };
+
+            var modelId = "muse-spark-1.1";
+            var logger = CreateLogger<MetaClient>();
+
+            // Act
+            var client = new MetaClient(
+                provider,
+                keyCredential,
+                modelId,
+                logger.Object,
+                _httpClientFactoryMock.Object);
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
+        [Fact]
+        public void Constructor_WithMissingApiKey_ThrowsConfigurationException()
+        {
+            // Arrange
+            var provider = new Provider
+            {
+                Id = 1,
+                ProviderType = ProviderType.Meta
+            };
+
+            var keyCredential = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = 1,
+                ApiKey = "" // Empty API key
+            };
+
+            var modelId = "muse-spark-1.1";
+            var logger = CreateLogger<MetaClient>();
+
+            // Act & Assert
+            var ex = Assert.Throws<ConfigurationException>(() =>
+                new MetaClient(
+                    provider,
+                    keyCredential,
+                    modelId,
+                    logger.Object,
+                    _httpClientFactoryMock.Object));
+
+            Assert.Contains("API key is missing", ex.Message);
+        }
+
+        [Fact]
+        public void Constructor_WithNullCredentials_ThrowsException()
+        {
+            // Arrange
+            var modelId = "muse-spark-1.1";
+            var logger = CreateLogger<MetaClient>();
+
+            // Act & Assert
+            Assert.ThrowsAny<Exception>(() =>
+                new MetaClient(
+                    null!,
+                    null!,
+                    modelId,
+                    logger.Object,
+                    _httpClientFactoryMock.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var provider = new Provider
+            {
+                Id = 1,
+                ProviderType = ProviderType.Meta
+            };
+
+            var keyCredential = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = 1,
+                ApiKey = "test-api-key"
+            };
+
+            var modelId = "muse-spark-1.1";
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new MetaClient(
+                    provider,
+                    keyCredential,
+                    modelId,
+                    null!,
+                    _httpClientFactoryMock.Object));
+        }
+
+        #endregion
+
+        #region Model Support Tests
+
+        [Theory]
+        [InlineData("muse-spark-1.1")]
+        [InlineData("muse-spark-1")]
+        public void SupportedModels_AreRecognized(string modelId)
+        {
+            // Arrange
+            var provider = new Provider
+            {
+                Id = 1,
+                ProviderType = ProviderType.Meta
+            };
+
+            var keyCredential = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = 1,
+                ApiKey = "test-api-key"
+            };
+
+            var logger = CreateLogger<MetaClient>();
+
+            // Act
+            var client = new MetaClient(
+                provider,
+                keyCredential,
+                modelId,
+                logger.Object,
+                _httpClientFactoryMock.Object);
+
+            // Assert
+            Assert.NotNull(client);
+        }
+
+        #endregion
+    }
+}

--- a/WebAdmin/src/constants/providers.ts
+++ b/WebAdmin/src/constants/providers.ts
@@ -16,6 +16,7 @@ export enum ProviderType {
   DeepInfra = 11,
   Cloudflare = 12,
   OpenRouter = 13,
+  Meta = 14,
 }
 
 /**
@@ -35,6 +36,7 @@ export const PROVIDER_TYPE_NAMES: Record<number, string> = {
   [ProviderType.DeepInfra]: 'DeepInfra',
   [ProviderType.Cloudflare]: 'Cloudflare Workers AI',
   [ProviderType.OpenRouter]: 'OpenRouter',
+  [ProviderType.Meta]: 'Meta AI',
 };
 
 /**

--- a/docs/development/llm-client-factory-guide.md
+++ b/docs/development/llm-client-factory-guide.md
@@ -67,6 +67,9 @@ The factory currently supports **9 active providers** (as of 2025-11-08):
 | `Cerebras` | `CerebrasClient` | High-performance inference | ✅ Active |
 | `SambaNova` | `SambaNovaClient` | Ultra-fast inference | ✅ Active |
 | `DeepInfra` | `DeepInfraClient` | OpenAI-compatible inference platform | ✅ Active |
+| `Cloudflare` | `CloudflareClient` | Cloudflare Workers AI serverless inference | ✅ Active |
+| `OpenRouter` | `OpenRouterClient` | Multi-provider routing | ✅ Active |
+| `Meta` | `MetaClient` | Meta Model API (Muse Spark models) | ✅ Active |
 
 **Obsolete Providers (removed):**
 - `Ultravox` (Audio functionality removed)

--- a/docs/model-pricing/meta-pricing.md
+++ b/docs/model-pricing/meta-pricing.md
@@ -1,0 +1,47 @@
+# Meta AI Model Pricing
+
+**Last Updated**: 2026-07-17
+**Source**: Meta Model API Documentation (https://ai.developer.meta.com/docs)
+
+## Overview
+
+Meta opened its Meta Model API to developers on July 9, 2026 (public preview, US-only at launch).
+The API is self-serve, OpenAI-compatible (Chat Completions and Responses formats), and new accounts
+receive $20 in free credits.
+
+## Pricing
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| Muse Spark 1.1 (`muse-spark-1.1`) | $1.25 | $4.25 |
+
+## Model Capabilities
+
+**Muse Spark 1.1** — multimodal reasoning model from Meta Superintelligence Labs:
+- 1,048,576-token (1M) context window; 131,072 max output tokens per response
+- Input modalities: text, image, video, PDF; output: text
+- Reasoning is always on and cannot be disabled; reasoning tokens are not returned as text but
+  bill as output tokens and count against `max_tokens`
+- Tool calling (including parallel tool calls) and structured output
+- Search grounding with citations
+- Optimized for agentic tool calling, multi-step workflows, coding, and document processing
+
+## API Access
+
+- Base URL: `https://api.meta.ai/v1`
+- Authentication: Bearer token (`Authorization: Bearer {MODEL_API_KEY}`)
+- Model listing: `GET /v1/models`
+- API keys: https://ai.developer.meta.com
+
+## Token Counting
+
+- The tokenizer is not publicly disclosed (no open-source package or published vocabulary).
+- Exact counts are available server-side: `POST /v1/responses/input_tokens` (OpenAI-format) or
+  `POST /v1/messages/count_tokens` (Anthropic-format) return the input-token count without
+  generating a response.
+- ConduitLLM uses the LLaMA3 tokenizer type as a client-side estimate.
+
+## Notes
+
+- Consumers get Muse Spark free in "Thinking" mode in the Meta AI app and on meta.ai; the pricing
+  above applies to API usage only.

--- a/scripts/db/providers/meta-models.json
+++ b/scripts/db/providers/meta-models.json
@@ -1,0 +1,21 @@
+{
+  "models": {
+    "muse-spark-1.1": {
+      "name": "muse-spark-1.1",
+      "family": "Muse Spark",
+      "series": "Muse Spark Series",
+      "owner": "meta",
+      "maxInputTokens": 1048576,
+      "maxOutputTokens": 131072,
+      "tokenizerType": "LLaMA3",
+      "supportsChat": true,
+      "supportsStreaming": true,
+      "supportsVision": true,
+      "supportsFunctionCalling": true,
+      "supportsEmbeddings": false,
+      "inputPricePerMillion": 1.25,
+      "outputPricePerMillion": 4.25,
+      "notes": "Multimodal reasoning model from Meta Superintelligence Labs, optimized for agentic tool calling and multi-step workflows. 1M-token context, 128K output; text, image, video, and PDF input. Supports parallel tool calling, structured output, and search grounding. Reasoning is always on and bills as output tokens against max_tokens. Tokenizer is undisclosed (server-side counting via POST /v1/responses/input_tokens); LLaMA3 tokenizerType is a client-side estimate. Released July 2026 on the Meta Model API (public preview, US-only)."
+    }
+  }
+}

--- a/scripts/db/providers/provider-config.json
+++ b/scripts/db/providers/provider-config.json
@@ -22,5 +22,11 @@
     "websiteUrl": "https://openrouter.ai",
     "modelCardUrl": "https://openrouter.ai/models",
     "supportsAudio": false
+  },
+  "meta": {
+    "providerType": 14,
+    "websiteUrl": "https://ai.meta.com",
+    "modelCardUrl": "https://ai.developer.meta.com/docs/getting-started/models",
+    "supportsAudio": false
   }
 }


### PR DESCRIPTION
## Summary

Adds **Meta AI** (Meta Model API) as a new provider (`ProviderType.Meta = 14`) with support for **Muse Spark 1.1** (`muse-spark-1.1`), Meta's multimodal reasoning model released July 9, 2026.

The Meta Model API is OpenAI-compatible (base URL `https://api.meta.ai/v1`, Bearer auth), so the client is a thin `OpenAICompatibleClient` subclass following the Cerebras/SambaNova pattern.

> **Rebased on dev**: Cloudflare (12) and OpenRouter (13) landed on dev after this branch was cut, so Meta is now **14** across all enum mirrors. The branch is also adapted to dev's factory refactor — Meta registers via `ClientCreatorRegistry` instead of the removed switch statement in `DatabaseAwareLLMClientFactory`.

## Changes

**Backend (.NET)**
- `ProviderType.Meta = 14` in `Shared/ConduitLLM.Configuration/Enums/ProviderType.cs`
- New `MetaClient` + error-handling partial under `Shared/ConduitLLM.Providers/Providers/Meta/`
- Registration in `Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs` (using + creator delegate)
- `MetaProviderMetadata` in `AllProviders.cs` (auto-registered via reflection)
- **No EF migration needed** — `ProviderType` is stored as a plain integer with no constraint

**SDKs / WebAdmin**
- `Meta = 14` in Admin + Gateway Node SDK enums
- `PROVIDER_REGISTRY` entry, name aliases, and the three exhaustive `Record<ProviderType, …>` maps in `providerConfiguration.ts`
- WebAdmin constants mirror (`ProviderType` enum + `PROVIDER_TYPE_NAMES`); dropdowns pick up the new provider automatically via the SDK registry

**Seeding / Docs**
- `scripts/db/providers/meta-models.json` + `provider-config.json` entry (providerType 14) — muse-spark-1.1 at 1,048,576 input / 131,072 output tokens, \$1.25/\$4.25 per M tokens, vision + tool calling + streaming
- `docs/model-pricing/meta-pricing.md`, client-factory guide provider table (also backfilled missing Cloudflare/OpenRouter/DeepInfra rows), CLAUDE.md enum listing

## Model spec notes

- Max output (131,072) comes from Meta's own docs (OpenCode config example) — it is not derivable from the 1M context window
- Tokenizer is undisclosed by Meta; `LLaMA3` tokenizerType is a client-side estimate. Exact counts available via `POST /v1/responses/input_tokens`
- Reasoning is always on and bills as output tokens against `max_tokens`

## Verification (after rebase onto dev)

- `dotnet build` — 0 errors
- `dotnet test` (MetaClientTests + ProviderRegistryTests + BaseProviderMetadataTests) — 37/37 passed
- Common + Admin + Gateway Node SDKs — `npm run build` clean
- WebAdmin — `npm run lint` and `npm run type-check` clean
- End-to-end chat completion against the live API not yet exercised (requires a Meta API key in the dev stack)