### PR TITLE
fix(messaging): Wolverine listener parallelism + Postgres polling tuning (#929 gate findings W3/W4)

### DIFF
--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
@@ -18,9 +18,11 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
     /// <remarks>
     /// Mapping notes:
     /// <list type="bullet">
-    /// <item><c>SingleActiveConsumer</c> → <c>ListenWithStrictOrdering</c>: exactly one
-    /// node listens at a time with sequential handling — the cluster-wide equivalent of
-    /// RabbitMQ's <c>x-single-active-consumer</c> + <c>ConcurrentMessageLimit = 1</c>.</item>
+    /// <item><c>ConcurrentMessageLimit = 1</c> → <c>ListenWithStrictOrdering</c>: exactly
+    /// one node listens with sequential handling (spend-update-events).
+    /// <c>SingleActiveConsumer</c> alone → <c>ExclusiveNodeWithParallelism</c>: one node
+    /// listens (failover semantics of RabbitMQ's <c>x-single-active-consumer</c>) but
+    /// handles messages in parallel, matching MassTransit's concurrent processing.</item>
     /// <item><c>ConcurrentMessageLimit</c> → <c>MaximumParallelMessages</c>; null inherits
     /// Wolverine's default. <c>PrefetchCount</c> has no Postgres-transport analogue (the
     /// listener batches its own polling).</item>
@@ -37,6 +39,14 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
     public static class WolverineEndpointPolicy
     {
         /// <summary>
+        /// Parallelism for single-active-consumer endpoints whose descriptor leaves
+        /// <c>ConcurrentMessageLimit</c> null ("inherit the bus/config default") —
+        /// mirrors the <c>ConduitLLM:RabbitMQ</c> ConcurrentMessageLimit default (50)
+        /// that MassTransit applies to those same endpoints.
+        /// </summary>
+        private const int DefaultSingleActiveParallelism = 50;
+
+        /// <summary>
         /// Configures a listener for the policy's queue on this host and registers the
         /// policy's retry rules for the given event types. Call only on the host that
         /// consumes the queue; publishers need only the routing rules
@@ -49,11 +59,22 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         {
             var listener = options.ListenToPostgresqlQueue(policy.Name);
 
-            if (policy.SingleActiveConsumer || policy.ConcurrentMessageLimit == 1)
+            if (policy.ConcurrentMessageLimit == 1)
             {
                 // Cluster-wide single active listener + sequential handling: strict
-                // ordering across all nodes (spend-update-events / image-generation-events).
+                // ordering across all nodes (spend-update-events).
                 listener.ListenWithStrictOrdering();
+            }
+            else if (policy.SingleActiveConsumer)
+            {
+                // RabbitMQ x-single-active-consumer without ConcurrentMessageLimit=1 is
+                // one consumer *instance* with parallel handling (image-generation-events
+                // runs 50-concurrent on MassTransit via the ConduitLLM:RabbitMQ default) —
+                // exclusive node for failover semantics, but NOT sequential. Mapping SAC
+                // to ListenWithStrictOrdering serialized the queue and cut media
+                // throughput ~10x (#929 parity gate finding W3).
+                listener.ExclusiveNodeWithParallelism(
+                    policy.ConcurrentMessageLimit ?? DefaultSingleActiveParallelism);
             }
             else if (policy.ConcurrentMessageLimit is int limit)
             {

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs
@@ -24,8 +24,8 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
     /// listens (failover semantics of RabbitMQ's <c>x-single-active-consumer</c>) but
     /// handles messages in parallel, matching MassTransit's concurrent processing.</item>
     /// <item><c>ConcurrentMessageLimit</c> → <c>MaximumParallelMessages</c>; null inherits
-    /// Wolverine's default. <c>PrefetchCount</c> has no Postgres-transport analogue (the
-    /// listener batches its own polling).</item>
+    /// Wolverine's default. <c>PrefetchCount</c> → <c>MaximumMessagesToReceive</c> (the
+    /// per-poll receive batch), polled every 250ms instead of the 5s default.</item>
     /// <item><c>Retry</c> → failure rules scoped to the endpoint's message types (see
     /// <see cref="ComputeRetryCooldowns"/>); <c>DelayedRedeliveryIntervals</c> →
     /// scheduled retries after the inline attempts. Exhausted messages land in
@@ -47,6 +47,13 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         private const int DefaultSingleActiveParallelism = 50;
 
         /// <summary>
+        /// Per-poll receive batch for endpoints whose descriptor leaves
+        /// <c>PrefetchCount</c> null — mirrors the RabbitMQ prefetch the same endpoints
+        /// get from the <c>ConduitLLM:RabbitMQ</c> defaults.
+        /// </summary>
+        private const int DefaultReceiveBatchSize = 50;
+
+        /// <summary>
         /// Configures a listener for the policy's queue on this host and registers the
         /// policy's retry rules for the given event types. Call only on the host that
         /// consumes the queue; publishers need only the routing rules
@@ -58,6 +65,13 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         public static void ListenWithPolicy(this WolverineOptions options, EndpointPolicy policy, IReadOnlyList<Type> eventTypes)
         {
             var listener = options.ListenToPostgresqlQueue(policy.Name);
+
+            // The Postgres queue listener defaults to 20 messages per poll on the 5s
+            // ScheduledJobPollingTime cadence — a ~4 msg/s ceiling per queue (#929 parity
+            // gate finding W4). Poll aggressively and map PrefetchCount to the per-poll
+            // batch size, which IS its Postgres-transport analogue.
+            listener.PollingInterval(TimeSpan.FromMilliseconds(250));
+            listener.MaximumMessagesToReceive(policy.PrefetchCount ?? DefaultReceiveBatchSize);
 
             if (policy.ConcurrentMessageLimit == 1)
             {

--- a/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
+++ b/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
@@ -155,13 +155,19 @@ namespace ConduitLLM.Core.Messaging
             options.ListenWithPolicy(ConduitEndpointPolicies.VideoGeneration, VideoGenerationEvents);
             options.ListenWithPolicy(ConduitEndpointPolicies.ImageGeneration, ImageGenerationEvents);
 
-            options.ListenToPostgresqlQueue(GatewayEventsQueue);
+            // Default queue: same aggressive polling as the tuned endpoints — the
+            // listener's 20-per-5s poll default is a ~4 msg/s ceiling (#929 finding W4).
+            options.ListenToPostgresqlQueue(GatewayEventsQueue)
+                .PollingInterval(TimeSpan.FromMilliseconds(250))
+                .MaximumMessagesToReceive(50);
         }
 
         /// <summary>Admin-side listener: the shared cache events queue.</summary>
         public static void ListenAsConduitAdmin(this WolverineOptions options)
         {
-            options.ListenToPostgresqlQueue(AdminEventsQueue);
+            options.ListenToPostgresqlQueue(AdminEventsQueue)
+                .PollingInterval(TimeSpan.FromMilliseconds(250))
+                .MaximumMessagesToReceive(50);
         }
 
         private static void RouteAll(WolverineOptions options, IReadOnlyList<Type> eventTypes, string queueName)


### PR DESCRIPTION
Two Wolverine-side throughput defects found and fixed during the #929 parity-gate load runs (S2: 10k spend events @ 17 msg/s):

## W3 — SAC mistranslated to strict ordering
`WolverineEndpointPolicy` mapped `SingleActiveConsumer` → `ListenWithStrictOrdering()` (exclusive **and sequential**). On MassTransit, `x-single-active-consumer` means one consumer *instance* with concurrent handling — `image-generation-events` runs 50-concurrent via the `ConduitLLM:RabbitMQ` defaults. The mistranslation serialized media processing: task latency P50 **53s vs 428ms** baseline at 17/s. Strict ordering now applies only when `ConcurrentMessageLimit == 1` (spend-update-events); SAC alone maps to `ExclusiveNodeWithParallelism` (same failover semantics, parallel handling).

## W4 — Postgres queue polling left at idle defaults
The Postgres queue listener defaults to **20 messages per poll every 5s** (`ScheduledJobPollingTime`) — a ~4 msg/s ceiling per queue, far below the tuned production rates. Listeners now poll every 250ms and map the descriptor's `PrefetchCount` to `MaximumMessagesToReceive` (its Postgres analogue); the untuned `gateway_events`/`admin_events` queues get the same treatment.

## Verification
- 59/59 messaging tests green.
- Live parity re-run on the e909 gate environment (dev HEAD + these fixes, `Backend=Wolverine`): 17/s sustained, task latency P50 434ms vs 428ms MassTransit baseline, spend/image queues drain to ~0 during load. Full evidence lands in `phase2-parity-report.md` with the #929 gate PR.

Part of #909 / gate #929.