### PR TITLE
feat(messaging): #930 staged cutover — default backend Wolverine, MassTransit rollback switch retained

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,8 @@ services:
   api:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      # Messaging backend switch (epic #909): MassTransit (default) or Wolverine
-      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-MassTransit}"
+      # Messaging backend switch (epic #909, cutover #930): Wolverine (default) or MassTransit (rollback)
+      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-Wolverine}"
       ConduitLLM__Messaging__Wolverine__AutoProvision: "true"
       # OpenTelemetry tracing configuration
       Telemetry__OtlpEndpoint: "http://jaeger:4317"
@@ -40,8 +40,8 @@ services:
   admin:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      # Messaging backend switch (epic #909): MassTransit (default) or Wolverine
-      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-MassTransit}"
+      # Messaging backend switch (epic #909, cutover #930): Wolverine (default) or MassTransit (rollback)
+      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-Wolverine}"
       ConduitLLM__Messaging__Wolverine__AutoProvision: "true"
       # OpenTelemetry tracing configuration
       Telemetry__OtlpEndpoint: "http://jaeger:4317"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,10 @@ services:
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
+      # Messaging backend cutover (#930): Wolverine on the Postgres transport is the
+      # default; set CONDUIT_MESSAGING_BACKEND=MassTransit for instant rollback
+      # (kept switchable for one release cycle — see phase2-parity-report.md S6).
+      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-Wolverine}"
       # Using new REDIS_URL format (old variables still work for backward compatibility)
       REDIS_URL: "redis://redis:6379"
       CONDUIT_REDIS_INSTANCE_NAME: "conduit:"
@@ -155,6 +159,9 @@ services:
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
+      # Messaging backend cutover (#930): Wolverine default; MassTransit rollback
+      # via CONDUIT_MESSAGING_BACKEND=MassTransit (one release cycle).
+      ConduitLLM__Messaging__Backend: "${CONDUIT_MESSAGING_BACKEND:-Wolverine}"
       # API-to-API authentication key for backend services
       CONDUIT_API_TO_API_BACKEND_AUTH_KEY: alpha
       # Redis cache configuration - using new REDIS_URL format


### PR DESCRIPTION
**Awaiting cutover sign-off** — merging this PR IS the #930 sign-off action; the sign-off line in `phase2-parity-report.md` can be filled with the merger's name/date.

Gate #929 **PASSED** (`docs/architecture/messaging-migration/phase2-parity-report.md`, merged in #975; W3/W4 fixes merged in #974):
- Spend: 10k events @17/s — exactly-once / zero-loss / ordered / money exact on both backends; latency parity (P50 433ms vs 428ms).
- Webhooks: 1,080/min ×10 min zero loss; identical deferral ladder.
- Crash: zero lost spend; Wolverine inbox/outbox recovery observed.
- Rollback drill: **9s time-to-rollback**, 6s client disruption, drain procedure documented (S6).

This PR flips the compose defaults (prod + dev) to `Backend=Wolverine` (Postgres transport). `CONDUIT_MESSAGING_BACKEND=MassTransit` remains the instant rollback switch, and the MassTransit backend + RabbitMQ apparatus stay fully in place for one release cycle; #932 removes them after the agreed soak.

Notes:
- `AutoProvision` defaults to `true` in code — first boot provisions the wolverine schemas; deployments preferring scripted provisioning set `ConduitLLM__Messaging__Wolverine__AutoProvision=false`.
- Static codegen (`TypeLoadMode.Static` via `codegen write`) remains an optional startup optimization; the CI build-ahead check (#961) already guards codegen validity.

Part of #909. Closes #930 when merged and soak begins.