### PR TITLE
fix(core): pass video generation and auth capabilities through LLM client decorator chain

### DIFF
--- a/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
@@ -16,7 +16,7 @@ namespace ConduitLLM.Core.Decorators
     /// <summary>
     /// Decorator that sets provider key context and tracks errors for LLM operations
     /// </summary>
-    public class ContextAwareLLMClient : ILLMClient
+    public class ContextAwareLLMClient : ILLMClient, ILLMClientDecorator, IAuthenticationVerifiable
     {
         private readonly ILLMClient _innerClient;
         private readonly int _keyId;
@@ -36,6 +36,9 @@ namespace ConduitLLM.Core.Decorators
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _logger = serviceProvider.GetService<ILogger<ContextAwareLLMClient>>();
         }
+
+        /// <inheritdoc />
+        public ILLMClient InnerClient => _innerClient;
 
         public async Task<ChatCompletionResponse> CreateChatCompletionAsync(
             ChatCompletionRequest request,
@@ -183,24 +186,27 @@ namespace ConduitLLM.Core.Decorators
                 try
                 {
                     // CreateVideoAsync is not on ILLMClient — only specific providers implement it.
-                    // Use reflection to invoke it on the concrete client type.
-                    var innerClientType = _innerClient.GetType();
-                    var createVideoMethod = innerClientType.GetMethod("CreateVideoAsync",
+                    // The inner client may itself be a decorator (e.g. PromptCachingLLMClient)
+                    // that hides the provider's video capability, so unwrap the chain to the
+                    // innermost provider client before reflecting (issue #976).
+                    var providerClient = _innerClient.UnwrapInnermost();
+                    var providerClientType = providerClient.GetType();
+                    var createVideoMethod = providerClientType.GetMethod("CreateVideoAsync",
                         new[] { typeof(VideoGenerationRequest), typeof(string), typeof(CancellationToken) });
 
                     if (createVideoMethod == null)
                     {
                         throw new NotSupportedException(
-                            $"The underlying client {innerClientType.Name} does not support video generation");
+                            $"The underlying client {providerClientType.Name} does not support video generation");
                     }
 
                     var task = (Task<VideoGenerationResponse>?)createVideoMethod.Invoke(
-                        _innerClient, new object?[] { request, apiKey, cancellationToken });
+                        providerClient, new object?[] { request, apiKey, cancellationToken });
 
                     if (task == null)
                     {
                         throw new InvalidOperationException(
-                            $"CreateVideoAsync on {innerClientType.Name} returned null");
+                            $"CreateVideoAsync on {providerClientType.Name} returned null");
                     }
 
                     return await task;
@@ -227,6 +233,39 @@ namespace ConduitLLM.Core.Decorators
                     throw;
                 }
             }
+        }
+
+        /// <summary>
+        /// Verifies authentication by delegating to the inner client if it supports
+        /// <see cref="IAuthenticationVerifiable"/>.
+        /// </summary>
+        public Task<AuthenticationResult> VerifyAuthenticationAsync(
+            string? apiKey = null,
+            string? baseUrl = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (_innerClient is IAuthenticationVerifiable authVerifiable)
+            {
+                return authVerifiable.VerifyAuthenticationAsync(apiKey, baseUrl, cancellationToken);
+            }
+
+            return Task.FromResult(AuthenticationResult.Failure(
+                "Provider does not support authentication verification",
+                $"The {_innerClient.GetType().Name} client has not implemented authentication verification"));
+        }
+
+        /// <summary>
+        /// Gets the health check URL by delegating to the inner client if it supports
+        /// <see cref="IAuthenticationVerifiable"/>.
+        /// </summary>
+        public string GetHealthCheckUrl(string? baseUrl = null)
+        {
+            if (_innerClient is IAuthenticationVerifiable authVerifiable)
+            {
+                return authVerifiable.GetHealthCheckUrl(baseUrl);
+            }
+
+            return baseUrl ?? "https://api.provider.com/health";
         }
 
         private LLMCommunicationException? ExtractLLMCommunicationException(Exception ex)

--- a/Shared/ConduitLLM.Core/Decorators/PerformanceTrackingLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/PerformanceTrackingLLMClient.cs
@@ -9,7 +9,7 @@ namespace ConduitLLM.Core.Decorators
     /// <summary>
     /// Decorator that adds performance tracking to LLM client operations.
     /// </summary>
-    public class PerformanceTrackingLLMClient : ILLMClient, IAuthenticationVerifiable
+    public class PerformanceTrackingLLMClient : ILLMClient, ILLMClientDecorator, IAuthenticationVerifiable
     {
         private readonly ILLMClient _innerClient;
         private readonly IPerformanceMetricsService _metricsService;
@@ -30,6 +30,9 @@ namespace ConduitLLM.Core.Decorators
             _providerName = providerName ?? throw new ArgumentNullException(nameof(providerName));
             _isEnabled = isEnabled;
         }
+
+        /// <inheritdoc />
+        public ILLMClient InnerClient => _innerClient;
 
 
         /// <summary>

--- a/Shared/ConduitLLM.Core/Decorators/PromptCachingLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/PromptCachingLLMClient.cs
@@ -13,7 +13,7 @@ namespace ConduitLLM.Core.Decorators;
 /// Decorator that automatically injects cache_control directives into chat completion
 /// requests when prompt caching auto-injection is enabled via GlobalSettings.
 /// </summary>
-public class PromptCachingLLMClient : ILLMClient
+public class PromptCachingLLMClient : ILLMClient, ILLMClientDecorator, IAuthenticationVerifiable
 {
     private readonly ILLMClient _innerClient;
     private readonly IGlobalSettingsCacheService _settingsService;
@@ -33,6 +33,9 @@ public class PromptCachingLLMClient : ILLMClient
         _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
+
+    /// <inheritdoc />
+    public ILLMClient InnerClient => _innerClient;
 
     /// <inheritdoc />
     public async Task<ChatCompletionResponse> CreateChatCompletionAsync(
@@ -73,6 +76,39 @@ public class PromptCachingLLMClient : ILLMClient
     /// <inheritdoc />
     public Task<ProviderCapabilities> GetCapabilitiesAsync(string? modelId = null)
         => _innerClient.GetCapabilitiesAsync(modelId);
+
+    /// <summary>
+    /// Verifies authentication by delegating to the inner client if it supports
+    /// <see cref="IAuthenticationVerifiable"/>.
+    /// </summary>
+    public Task<AuthenticationResult> VerifyAuthenticationAsync(
+        string? apiKey = null,
+        string? baseUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (_innerClient is IAuthenticationVerifiable authVerifiable)
+        {
+            return authVerifiable.VerifyAuthenticationAsync(apiKey, baseUrl, cancellationToken);
+        }
+
+        return Task.FromResult(AuthenticationResult.Failure(
+            "Provider does not support authentication verification",
+            $"The {_innerClient.GetType().Name} client has not implemented authentication verification"));
+    }
+
+    /// <summary>
+    /// Gets the health check URL by delegating to the inner client if it supports
+    /// <see cref="IAuthenticationVerifiable"/>.
+    /// </summary>
+    public string GetHealthCheckUrl(string? baseUrl = null)
+    {
+        if (_innerClient is IAuthenticationVerifiable authVerifiable)
+        {
+            return authVerifiable.GetHealthCheckUrl(baseUrl);
+        }
+
+        return baseUrl ?? "https://api.provider.com/health";
+    }
 
     private async Task TryInjectCacheControlAsync(ChatCompletionRequest request)
     {

--- a/Shared/ConduitLLM.Core/Interfaces/ILLMClientDecorator.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ILLMClientDecorator.cs
@@ -1,0 +1,42 @@
+namespace ConduitLLM.Core.Interfaces
+{
+    /// <summary>
+    /// Implemented by <see cref="ILLMClient"/> decorators so callers can traverse a decorator
+    /// chain and reach capabilities exposed only by the innermost provider client.
+    /// </summary>
+    /// <remarks>
+    /// Some capabilities (e.g. video generation, provider-specific progress callbacks) are not
+    /// part of <see cref="ILLMClient"/> and are discovered via reflection on the concrete client.
+    /// Without this interface a decorator hides those members, silently dropping the capability
+    /// even though the wrapped provider client supports it (see issue #976).
+    /// </remarks>
+    public interface ILLMClientDecorator
+    {
+        /// <summary>
+        /// Gets the client wrapped by this decorator. May itself be another decorator.
+        /// </summary>
+        ILLMClient InnerClient { get; }
+    }
+
+    /// <summary>
+    /// Helpers for working with <see cref="ILLMClientDecorator"/> chains.
+    /// </summary>
+    public static class LLMClientDecoratorExtensions
+    {
+        /// <summary>
+        /// Unwraps a decorator chain and returns the innermost (non-decorator) client.
+        /// Returns the client itself when it is not a decorator.
+        /// </summary>
+        /// <param name="client">The potentially decorated client.</param>
+        /// <returns>The innermost client in the chain.</returns>
+        public static ILLMClient UnwrapInnermost(this ILLMClient client)
+        {
+            while (client is ILLMClientDecorator decorator)
+            {
+                client = decorator.InnerClient;
+            }
+
+            return client;
+        }
+    }
+}

--- a/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
+++ b/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
@@ -94,49 +94,55 @@ namespace ConduitLLM.Core.Services
                 throw new NotSupportedException($"No provider available for model {modelInfo.ModelAlias}");
             }
 
-            // Check if client supports video generation using reflection
-            var clientType = client.GetType();
-            
-            // Handle decorators by getting inner client
-            object clientToCheck = client;
-            if (clientType.FullName?.Contains("Decorator") == true || 
-                clientType.FullName?.Contains("PerformanceTracking") == true)
+            // Video generation is not part of ILLMClient — only specific provider clients
+            // implement CreateVideoAsync. Unwrap the decorator chain to the innermost provider
+            // client to check the capability; decorators would otherwise hide it (issue #976).
+            var innermostClient = client.UnwrapInnermost();
+            var innermostType = innermostClient.GetType();
+
+            var supportsVideo = innermostType.GetMethods()
+                .Any(m => m.Name == "CreateVideoAsync" && m.GetParameters().Length == 3);
+
+            if (!supportsVideo)
             {
-                var innerClientField = clientType.GetField("_innerClient",
-                    BindingFlags.NonPublic | BindingFlags.Instance);
-                if (innerClientField != null)
-                {
-                    var innerClient = innerClientField.GetValue(client);
-                    if (innerClient != null)
-                    {
-                        clientToCheck = innerClient;
-                        clientType = innerClient.GetType();
-                    }
-                }
+                throw new NotSupportedException($"Provider for model {modelInfo.ModelAlias} does not support video generation");
             }
 
-            // Find CreateVideoAsync method
-            var createVideoMethod = clientType.GetMethods()
-                .FirstOrDefault(m => m.Name == "CreateVideoAsync" && m.GetParameters().Length == 3);
+            // Set up progress callback if the provider client is MiniMax
+            if (innermostType.Name == "MiniMaxClient")
+            {
+                SetupMiniMaxProgressCallback(innermostClient, request.Model, cancellationToken);
+            }
+
+            // Invoke through the outermost client in the chain that exposes CreateVideoAsync so
+            // decorators (e.g. ContextAwareLLMClient's key context and error tracking) still run.
+            object invocationTarget = innermostClient;
+            MethodInfo? createVideoMethod = null;
+            for (ILLMClient? current = client; current != null;
+                 current = (current as ILLMClientDecorator)?.InnerClient)
+            {
+                var method = current.GetType().GetMethods()
+                    .FirstOrDefault(m => m.Name == "CreateVideoAsync" && m.GetParameters().Length == 3);
+                if (method != null)
+                {
+                    invocationTarget = current;
+                    createVideoMethod = method;
+                    break;
+                }
+            }
 
             if (createVideoMethod == null)
             {
                 throw new NotSupportedException($"Provider for model {modelInfo.ModelAlias} does not support video generation");
             }
 
-            // Set up progress callback if the client is MiniMax
-            if (clientType.Name == "MiniMaxClient")
-            {
-                SetupMiniMaxProgressCallback(clientToCheck, request.Model, cancellationToken);
-            }
-
             // Invoke video generation
-            var task = createVideoMethod.Invoke(clientToCheck, new object?[] { request, null, cancellationToken }) 
+            var task = createVideoMethod.Invoke(invocationTarget, new object?[] { request, null, cancellationToken })
                 as Task<VideoGenerationResponse>;
-            
+
             if (task == null)
             {
-                throw new InvalidOperationException($"CreateVideoAsync method on {clientType.Name} did not return expected Task<VideoGenerationResponse>");
+                throw new InvalidOperationException($"CreateVideoAsync method on {invocationTarget.GetType().Name} did not return expected Task<VideoGenerationResponse>");
             }
 
             return await task;

--- a/Tests/ConduitLLM.Tests/Core/Decorators/ContextAwareLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Decorators/ContextAwareLLMClientTests.cs
@@ -1,0 +1,226 @@
+using ConduitLLM.Core.Decorators;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ConduitLLM.Tests.Core.Decorators;
+
+/// <summary>
+/// Regression tests for issue #976: optional capabilities (video generation, auth
+/// verification) must survive being wrapped in a decorator chain instead of being
+/// silently dropped by an intermediate decorator.
+/// </summary>
+public class ContextAwareLLMClientTests
+{
+    private readonly Mock<IServiceProvider> _serviceProvider = new();
+
+    /// <summary>
+    /// Fake provider client that supports video generation (like MiniMaxClient) and
+    /// authentication verification.
+    /// </summary>
+    private sealed class FakeVideoCapableProviderClient : ILLMClient, IAuthenticationVerifiable
+    {
+        private readonly VideoGenerationResponse _videoResponse;
+
+        public VideoGenerationRequest? ReceivedVideoRequest { get; private set; }
+
+        public FakeVideoCapableProviderClient(VideoGenerationResponse videoResponse)
+        {
+            _videoResponse = videoResponse;
+        }
+
+        // Discovered via reflection by ContextAwareLLMClient / VideoGenerationOrchestrator.
+        public Task<VideoGenerationResponse> CreateVideoAsync(
+            VideoGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedVideoRequest = request;
+            return Task.FromResult(_videoResponse);
+        }
+
+        public Task<ChatCompletionResponse> CreateChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public IAsyncEnumerable<ChatCompletionChunk> StreamChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<List<string>> ListModelsAsync(
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<string>());
+
+        public Task<EmbeddingResponse> CreateEmbeddingAsync(
+            EmbeddingRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ImageGenerationResponse> CreateImageAsync(
+            ImageGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<ProviderCapabilities> GetCapabilitiesAsync(string? modelId = null)
+            => Task.FromResult(new ProviderCapabilities());
+
+        public Task<AuthenticationResult> VerifyAuthenticationAsync(
+            string? apiKey = null,
+            string? baseUrl = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(AuthenticationResult.Success("provider auth ok"));
+
+        public string GetHealthCheckUrl(string? baseUrl = null)
+            => "https://provider.example.com/health";
+    }
+
+    private static VideoGenerationRequest CreateVideoRequest()
+        => new()
+        {
+            Prompt = "A cat surfing a wave",
+            Model = "video-01"
+        };
+
+    private static VideoGenerationResponse CreateVideoResponse()
+        => new()
+        {
+            Data = new List<VideoData>
+            {
+                new() { Url = "https://example.com/video.mp4" }
+            }
+        };
+
+    private PromptCachingLLMClient WrapInPromptCaching(ILLMClient inner)
+    {
+        var settingsService = new Mock<ConduitLLM.Configuration.Interfaces.IGlobalSettingsCacheService>();
+        var logger = new Mock<ILogger<PromptCachingLLMClient>>();
+        return new PromptCachingLLMClient(inner, settingsService.Object, logger.Object);
+    }
+
+    private ContextAwareLLMClient WrapInContextAware(ILLMClient inner)
+        => new(inner, keyId: 0, providerId: 0, _serviceProvider.Object);
+
+    private static PerformanceTrackingLLMClient WrapInPerformanceTracking(ILLMClient inner)
+    {
+        var metricsService = new Mock<IPerformanceMetricsService>();
+        var logger = new Mock<ILogger<PerformanceTrackingLLMClient>>();
+        return new PerformanceTrackingLLMClient(
+            inner, metricsService.Object, logger.Object, "testprovider", true);
+    }
+
+    [Fact]
+    public async Task CreateVideoAsync_InnerClientIsPromptCachingDecorator_ReturnsProviderResponse()
+    {
+        // Arrange — chain mirrors DatabaseAwareLLMClientFactory: Context(Caching(provider))
+        var expectedResponse = CreateVideoResponse();
+        var providerClient = new FakeVideoCapableProviderClient(expectedResponse);
+        var sut = WrapInContextAware(WrapInPromptCaching(providerClient));
+
+        // Act
+        var result = await sut.CreateVideoAsync(CreateVideoRequest());
+
+        // Assert
+        result.Should().BeSameAs(expectedResponse);
+    }
+
+    [Fact]
+    public async Task CreateVideoAsync_InnerClientIsPromptCachingDecorator_ForwardsRequestToProvider()
+    {
+        // Arrange
+        var providerClient = new FakeVideoCapableProviderClient(CreateVideoResponse());
+        var sut = WrapInContextAware(WrapInPromptCaching(providerClient));
+        var request = CreateVideoRequest();
+
+        // Act
+        await sut.CreateVideoAsync(request);
+
+        // Assert
+        providerClient.ReceivedVideoRequest.Should().BeSameAs(request);
+    }
+
+    [Fact]
+    public async Task CreateVideoAsync_ProviderDirectlyWrapped_ReturnsProviderResponse()
+    {
+        // Arrange — no intermediate decorator (chain without prompt caching)
+        var expectedResponse = CreateVideoResponse();
+        var providerClient = new FakeVideoCapableProviderClient(expectedResponse);
+        var sut = WrapInContextAware(providerClient);
+
+        // Act
+        var result = await sut.CreateVideoAsync(CreateVideoRequest());
+
+        // Assert
+        result.Should().BeSameAs(expectedResponse);
+    }
+
+    [Fact]
+    public async Task CreateVideoAsync_InnermostClientLacksVideoSupport_ThrowsNotSupportedException()
+    {
+        // Arrange — innermost client has no CreateVideoAsync method
+        var providerClient = new Mock<ILLMClient>();
+        var sut = WrapInContextAware(WrapInPromptCaching(providerClient.Object));
+
+        // Act
+        var act = () => sut.CreateVideoAsync(CreateVideoRequest());
+
+        // Assert
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*does not support video generation*");
+    }
+
+    [Fact]
+    public void UnwrapInnermost_FullDecoratorChain_ReturnsProviderClient()
+    {
+        // Arrange — full factory chain: Perf(Context(Caching(provider)))
+        var providerClient = new FakeVideoCapableProviderClient(CreateVideoResponse());
+        ILLMClient chain = WrapInPerformanceTracking(
+            WrapInContextAware(WrapInPromptCaching(providerClient)));
+
+        // Act
+        var innermost = chain.UnwrapInnermost();
+
+        // Assert
+        innermost.Should().BeSameAs(providerClient);
+    }
+
+    [Fact]
+    public async Task VerifyAuthenticationAsync_FullDecoratorChain_DelegatesToProviderClient()
+    {
+        // Arrange — Perf(Context(Caching(provider))); previously Context/Caching dropped
+        // IAuthenticationVerifiable so the chain reported "not supported"
+        var providerClient = new FakeVideoCapableProviderClient(CreateVideoResponse());
+        var chain = WrapInPerformanceTracking(
+            WrapInContextAware(WrapInPromptCaching(providerClient)));
+
+        // Act
+        var result = await chain.VerifyAuthenticationAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHealthCheckUrl_FullDecoratorChain_DelegatesToProviderClient()
+    {
+        // Arrange
+        var providerClient = new FakeVideoCapableProviderClient(CreateVideoResponse());
+        var chain = WrapInPerformanceTracking(
+            WrapInContextAware(WrapInPromptCaching(providerClient)));
+
+        // Act
+        var url = chain.GetHealthCheckUrl();
+
+        // Assert
+        url.Should().Be("https://provider.example.com/health");
+    }
+}


### PR DESCRIPTION
Fixes #976

## Problem

Every async video generation task failed with:

```
System.NotSupportedException: The underlying client PromptCachingLLMClient does not support video generation
   at ConduitLLM.Core.Decorators.ContextAwareLLMClient.CreateVideoAsync(...)
   at ConduitLLM.Core.Services.VideoGenerationOrchestrator.ExecuteGenerationAsync(...)
```

`CreateVideoAsync` is not part of `ILLMClient` — it is discovered by reflection on the concrete client type. The factory builds the chain `PerformanceTracking -> ContextAware -> PromptCaching -> provider`, and `ContextAwareLLMClient.CreateVideoAsync` reflected only on its **immediate** inner client. Once `PromptCachingLLMClient` was inserted below it, the provider's (e.g. MiniMaxClient) video capability became invisible and the chain threw even though the innermost client fully supports video.

`VideoGenerationOrchestrator` had the same one-level-deep flaw via a private `_innerClient` field hack, which additionally:
- silently dropped the MiniMax progress callback (`SetVideoProgressCallback` was looked up on `ContextAwareLLMClient`, never found), and
- would throw `NotSupportedException` itself whenever the performance-tracking decorator is absent (one unwrap lands on `PromptCachingLLMClient`).

A second silently dropped capability: `IAuthenticationVerifiable` was forwarded only by `PerformanceTrackingLLMClient`, but its inner client (`ContextAwareLLMClient`) didn't implement the interface, so `VerifyAuthenticationAsync` / `GetHealthCheckUrl` reported "not supported" for any decorated client.

## Fix

- New `ILLMClientDecorator` interface (`InnerClient` property) + `UnwrapInnermost()` extension in `ConduitLLM.Core.Interfaces`, implemented by all three decorators — capability checks now traverse chains of any depth instead of guessing at private fields.
- `ContextAwareLLMClient.CreateVideoAsync` unwraps to the innermost provider client before reflecting, while still wrapping the call in provider-key context + error tracking.
- `VideoGenerationOrchestrator` checks video support on the innermost client, wires the MiniMax progress callback to the innermost client, and invokes through the outermost chain member exposing `CreateVideoAsync` so decorators still participate.
- `ContextAwareLLMClient` and `PromptCachingLLMClient` now implement `IAuthenticationVerifiable` with the same delegate-if-supported pattern `PerformanceTrackingLLMClient` already used.

## Tests

New `Tests/ConduitLLM.Tests/Core/Decorators/ContextAwareLLMClientTests.cs` (7 tests): decorated video chain succeeds through `PromptCachingLLMClient` + `ContextAwareLLMClient`, request forwarding, direct-wrap case, `NotSupportedException` when the innermost client lacks video, full-chain `UnwrapInnermost`, and auth-verification/health-URL passthrough through the full chain.

`dotnet build` (full solution): 0 errors. `dotnet test` for `ConduitLLM.Tests.Core.Decorators` + `VideoGenerationOrchestratorTests`: 31/31 passed.

## Notes

- Found during the #929 parity gate.
- Live end-to-end verification deferred until the #930 soak concludes (environment intentionally frozen).