### PR TITLE
fix(admin): ModelCosts GET->PUT round-trip 500 (DbUpdateException) — Fixes #977

### DIFF
--- a/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
@@ -283,6 +283,10 @@ namespace ConduitLLM.Admin.Extensions
             entity.CostName = dto.CostName;
             entity.PricingModel = dto.PricingModel;
             entity.PricingConfiguration = dto.PricingConfiguration;
+            entity.ModelType = dto.ModelType;
+            entity.IsActive = dto.IsActive;
+            entity.Priority = dto.Priority;
+            entity.Description = dto.Description;
             entity.InputCostPerMillionTokens = dto.InputCostPerMillionTokens;
             entity.OutputCostPerMillionTokens = dto.OutputCostPerMillionTokens;
             entity.EmbeddingCostPerMillionTokens = dto.EmbeddingCostPerMillionTokens;

--- a/Services/ConduitLLM.Admin/Services/AdminModelCostService.cs
+++ b/Services/ConduitLLM.Admin/Services/AdminModelCostService.cs
@@ -302,16 +302,38 @@ namespace ConduitLLM.Admin.Services
                     }
                 }
 
-                // Track changes for event publishing
+                // Track changes for event publishing (compare before UpdateFrom mutates the entity)
                 var changedProperties = new List<string>();
                 if (existingModelCost.CostName != modelCost.CostName)
                     changedProperties.Add(nameof(modelCost.CostName));
+                if (existingModelCost.PricingModel != modelCost.PricingModel)
+                    changedProperties.Add(nameof(modelCost.PricingModel));
+                if (existingModelCost.PricingConfiguration != modelCost.PricingConfiguration)
+                    changedProperties.Add(nameof(modelCost.PricingConfiguration));
+                if (existingModelCost.ModelType != modelCost.ModelType)
+                    changedProperties.Add(nameof(modelCost.ModelType));
+                if (existingModelCost.IsActive != modelCost.IsActive)
+                    changedProperties.Add(nameof(modelCost.IsActive));
+                if (existingModelCost.Priority != modelCost.Priority)
+                    changedProperties.Add(nameof(modelCost.Priority));
+                if (existingModelCost.Description != modelCost.Description)
+                    changedProperties.Add(nameof(modelCost.Description));
                 if (existingModelCost.InputCostPerMillionTokens != modelCost.InputCostPerMillionTokens)
                     changedProperties.Add(nameof(modelCost.InputCostPerMillionTokens));
                 if (existingModelCost.OutputCostPerMillionTokens != modelCost.OutputCostPerMillionTokens)
                     changedProperties.Add(nameof(modelCost.OutputCostPerMillionTokens));
                 if (existingModelCost.EmbeddingCostPerMillionTokens != modelCost.EmbeddingCostPerMillionTokens)
                     changedProperties.Add(nameof(modelCost.EmbeddingCostPerMillionTokens));
+                if (existingModelCost.BatchProcessingMultiplier != modelCost.BatchProcessingMultiplier)
+                    changedProperties.Add(nameof(modelCost.BatchProcessingMultiplier));
+                if (existingModelCost.SupportsBatchProcessing != modelCost.SupportsBatchProcessing)
+                    changedProperties.Add(nameof(modelCost.SupportsBatchProcessing));
+                if (existingModelCost.CachedInputCostPerMillionTokens != modelCost.CachedInputCostPerMillionTokens)
+                    changedProperties.Add(nameof(modelCost.CachedInputCostPerMillionTokens));
+                if (existingModelCost.CachedInputWriteCostPerMillionTokens != modelCost.CachedInputWriteCostPerMillionTokens)
+                    changedProperties.Add(nameof(modelCost.CachedInputWriteCostPerMillionTokens));
+                if (existingModelCost.CostPerSearchUnit != modelCost.CostPerSearchUnit)
+                    changedProperties.Add(nameof(modelCost.CostPerSearchUnit));
 
                 // Update entity
                 existingModelCost.UpdateFrom(modelCost);
@@ -319,32 +341,42 @@ namespace ConduitLLM.Admin.Services
                 // Save changes
                 var result = await _modelCostRepository.UpdateAsync(existingModelCost);
 
-                // Update ModelProviderTypeAssociations if provided
+                // Update ModelProviderTypeAssociations only when the caller provided them.
+                // Null means "leave associations unchanged" (a GET→PUT round-trip does not carry
+                // association IDs); an explicit empty list clears all associations.
                 if (modelCost.ModelProviderTypeAssociationIds != null)
                 {
                     using var dbContext = await _dbContextFactory.CreateDbContextAsync();
-                    
+
                     // Clear existing associations for this cost
                     var existingAssociations = await dbContext.ModelProviderTypeAssociations
                         .Where(mpta => mpta.ModelCostId == modelCost.Id)
                         .ToListAsync();
-                    
+
                     foreach (var association in existingAssociations)
                     {
                         association.ModelCostId = null;
                     }
-                    
+
                     // Set new associations
                     var newAssociations = await dbContext.ModelProviderTypeAssociations
                         .Where(mpta => modelCost.ModelProviderTypeAssociationIds.Contains(mpta.Id))
                         .ToListAsync();
-                    
+
                     foreach (var association in newAssociations)
                     {
                         association.ModelCostId = modelCost.Id;
                     }
-                    
+
                     await dbContext.SaveChangesAsync();
+
+                    // Publish an event when the set of associated models changed so caches
+                    // keyed by model identifier are invalidated too
+                    if (!existingAssociations.Select(a => a.Id).OrderBy(id => id)
+                            .SequenceEqual(newAssociations.Select(a => a.Id).OrderBy(id => id)))
+                    {
+                        changedProperties.Add("ModelProviderTypeAssociations");
+                    }
                 }
 
                 if (result)

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Update.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Update.cs
@@ -38,8 +38,11 @@ namespace ConduitLLM.Configuration.DTOs
         /// </summary>
         /// <remarks>
         /// These are the IDs of ModelProviderTypeAssociation entities that should use this cost configuration.
+        /// Null (field absent from the request body) means "leave the existing associations unchanged" —
+        /// a GET→PUT round-trip does not carry association IDs and must not drop the cost→model links.
+        /// An explicit empty list clears all associations.
         /// </remarks>
-        public List<int> ModelProviderTypeAssociationIds { get; set; } = new List<int>();
+        public List<int>? ModelProviderTypeAssociationIds { get; set; }
 
         /// <summary>
         /// Model type for categorization

--- a/Shared/ConduitLLM.Configuration/Repositories/ModelCostRepository.cs
+++ b/Shared/ConduitLLM.Configuration/Repositories/ModelCostRepository.cs
@@ -56,6 +56,47 @@ namespace ConduitLLM.Configuration.Repositories
         }
 
         /// <inheritdoc/>
+        /// <remarks>
+        /// Overrides the graph-traversing <c>DbSet.Update()</c> in the base class and marks only
+        /// the root <see cref="ModelCost"/> entity as modified. Entities returned by
+        /// <c>GetByIdAsync</c>/<c>GetByCostNameAsync</c> carry the included
+        /// ModelProviderTypeAssociations → Model graph, and <c>Model.Series</c> is a phantom
+        /// <c>new ModelSeries()</c> (Id = 0, with a phantom <c>ModelAuthor</c>) because the
+        /// query does not include it. A graph-wide Update() attached those phantoms as Added,
+        /// inserting empty ModelSeries/ModelAuthor rows and failing with unique-constraint
+        /// violations on subsequent saves (issue #977). Association changes are managed
+        /// explicitly by the Admin service, not through this method.
+        /// </remarks>
+        public override async Task<bool> UpdateAsync(ModelCost entity, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(entity);
+
+            try
+            {
+                await using var context = await DbContextFactory.CreateDbContextAsync(cancellationToken);
+
+                OnBeforeUpdate(entity);
+
+                // Attach only the root entity — never the detached navigation graph.
+                context.Entry(entity).State = EntityState.Modified;
+                int rowsAffected = await context.SaveChangesAsync(cancellationToken);
+
+                return rowsAffected > 0;
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                Logger.LogWarning(ex, "Concurrency conflict updating {EntityType} with ID {Id} — another process modified this entity",
+                    EntityTypeName, entity.Id);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error updating {EntityType} with ID {Id}", EntityTypeName, entity.Id);
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<ModelCost?> GetByCostNameAsync(string costName, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(costName))

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceRoundTripTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceRoundTripTests.cs
@@ -1,0 +1,269 @@
+using ConduitLLM.Admin.Services;
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Repositories;
+using ConduitLLM.Core.Events;
+using ConduitLLM.Tests.TestInfrastructure;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Admin.Services
+{
+    /// <summary>
+    /// Regression tests for issue #977: GET /api/modelcosts/{id} followed by PUT with the
+    /// unmodified response body returned 500 (DbUpdateException).
+    /// <para>
+    /// Root cause: <see cref="ModelCostRepository"/> loads ModelCost with the
+    /// ModelProviderTypeAssociations → Model graph included, and <c>Model.Series</c> is
+    /// initialized to a phantom <c>new ModelSeries()</c> (Id = 0) whose <c>Author</c> is a
+    /// phantom <c>new ModelAuthor()</c> (Id = 0). The graph-traversing <c>DbSet.Update()</c>
+    /// in the repository base attached those phantom entities as Added, inserting empty
+    /// ModelSeries/ModelAuthor rows and — once an empty-named author existed — failing every
+    /// subsequent save with a unique-constraint violation (IX_ModelAuthor_Name_Unique).
+    /// </para>
+    /// These tests run against SQLite (real relational constraints) via
+    /// <see cref="RepositoryTestBase"/> so the failure shape matches production PostgreSQL.
+    /// </summary>
+    public class AdminModelCostServiceRoundTripTests : RepositoryTestBase
+    {
+        private readonly Mock<IEventBus> _mockEventBus;
+        private readonly AdminModelCostService _service;
+
+        public AdminModelCostServiceRoundTripTests()
+        {
+            var factory = CreateDbContextFactory();
+            var costRepository = new ModelCostRepository(factory, Mock.Of<ILogger<ModelCostRepository>>());
+            _mockEventBus = new Mock<IEventBus>();
+
+            _service = new AdminModelCostService(
+                costRepository,
+                Mock.Of<IRequestLogRepository>(),
+                factory,
+                Mock.Of<ILogger<AdminModelCostService>>(),
+                _mockEventBus.Object);
+        }
+
+        #region Setup helpers
+
+        private sealed record SeededGraph(int CostId, int ModelId, int SeriesId, int AuthorId, int AssociationId);
+
+        /// <summary>
+        /// Seeds a ModelCost linked (via ModelIdentifiers.ModelCostId) to a model alias,
+        /// mirroring the live "mock-image" repro from the #929 parity gate.
+        /// </summary>
+        private SeededGraph SeedCostWithAssociatedModel()
+        {
+            using var context = CreateContext();
+
+            var author = new ModelAuthor { Name = "MockCo" };
+            var series = new ModelSeries { Author = author, Name = "Mock Series", Parameters = "{}" };
+            var model = new Model { Name = "mock-image", Series = series };
+            var cost = new ModelCost
+            {
+                CostName = "mock-image-cost",
+                ModelType = "image",
+                PricingModel = PricingModel.Standard,
+                PricingConfiguration = "{\"baseRate\":0.1}",
+                InputCostPerMillionTokens = 1.5m,
+                OutputCostPerMillionTokens = 2.5m,
+                IsActive = true
+            };
+            var association = new ModelProviderTypeAssociation
+            {
+                Model = model,
+                Identifier = "mock-image",
+                Provider = ProviderType.OpenAI,
+                ModelCost = cost,
+                IsEnabled = true
+            };
+
+            context.AddRange(author, series, model, cost, association);
+            context.SaveChanges();
+
+            return new SeededGraph(cost.Id, model.Id, series.Id, author.Id, association.Id);
+        }
+
+        /// <summary>
+        /// Builds the UpdateModelCostDto exactly as an unmodified GET→PUT round-trip would:
+        /// the GET body carries associatedModelAliases (strings), not association IDs, so
+        /// ModelProviderTypeAssociationIds stays at its deserialization default.
+        /// </summary>
+        private static UpdateModelCostDto ToRoundTripUpdateDto(ModelCostDto dto)
+        {
+            return new UpdateModelCostDto
+            {
+                Id = dto.Id,
+                CostName = dto.CostName,
+                PricingModel = dto.PricingModel,
+                PricingConfiguration = dto.PricingConfiguration,
+                ModelType = dto.ModelType,
+                Priority = dto.Priority,
+                Description = dto.Description,
+                IsActive = dto.IsActive,
+                InputCostPerMillionTokens = dto.InputCostPerMillionTokens,
+                OutputCostPerMillionTokens = dto.OutputCostPerMillionTokens,
+                EmbeddingCostPerMillionTokens = dto.EmbeddingCostPerMillionTokens,
+                BatchProcessingMultiplier = dto.BatchProcessingMultiplier,
+                SupportsBatchProcessing = dto.SupportsBatchProcessing,
+                CachedInputCostPerMillionTokens = dto.CachedInputCostPerMillionTokens,
+                CachedInputWriteCostPerMillionTokens = dto.CachedInputWriteCostPerMillionTokens,
+                CostPerSearchUnit = dto.CostPerSearchUnit
+                // ModelProviderTypeAssociationIds intentionally not set — absent in a GET→PUT body
+            };
+        }
+
+        #endregion
+
+        [Fact]
+        public async Task UpdateModelCostAsync_RepeatedGetPutRoundTripWithAssociatedModel_Succeeds()
+        {
+            // Arrange — an empty-named ModelAuthor mirrors the corrupted live state left behind
+            // by an earlier buggy save (the phantom graph attach inserted Name = "" authors).
+            // With the bug present, the graph attach tries to insert another "" author and the
+            // save fails with a unique-constraint DbUpdateException — the live 500 on PUT.
+            using (var context = CreateContext())
+            {
+                context.ModelAuthors.Add(new ModelAuthor { Name = "" });
+                context.SaveChanges();
+            }
+            var seeded = SeedCostWithAssociatedModel();
+
+            // Act — repeated unmodified GET→PUT round-trips must keep succeeding
+            for (var i = 0; i < 2; i++)
+            {
+                var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+                getDto.Should().NotBeNull();
+
+                var result = await _service.UpdateModelCostAsync(ToRoundTripUpdateDto(getDto!));
+
+                // Assert
+                result.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task UpdateModelCostAsync_RoundTripWithAssociatedModel_DoesNotInsertPhantomSeriesOrAuthor()
+        {
+            // Arrange
+            var seeded = SeedCostWithAssociatedModel();
+            var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+
+            // Act
+            var result = await _service.UpdateModelCostAsync(ToRoundTripUpdateDto(getDto!));
+
+            // Assert
+            result.Should().BeTrue();
+            using var context = CreateContext();
+            context.ModelAuthors.Count().Should().Be(1, "the update must not insert phantom ModelAuthor rows");
+            context.ModelSeries.Count().Should().Be(1, "the update must not insert phantom ModelSeries rows");
+            var model = await context.Models.AsNoTracking().SingleAsync(m => m.Id == seeded.ModelId);
+            model.ModelSeriesId.Should().Be(seeded.SeriesId, "the update must not re-point the model at a phantom series");
+        }
+
+        [Fact]
+        public async Task UpdateModelCostAsync_AssociationIdsAbsentFromDto_PreservesAssociatedModelAliases()
+        {
+            // Arrange
+            var seeded = SeedCostWithAssociatedModel();
+            var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            getDto!.AssociatedModelAliases.Should().BeEquivalentTo(new[] { "mock-image" });
+
+            // Act
+            await _service.UpdateModelCostAsync(ToRoundTripUpdateDto(getDto));
+
+            // Assert — an unmodified round-trip must not silently drop the cost→model links
+            var afterDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            afterDto!.AssociatedModelAliases.Should().BeEquivalentTo(new[] { "mock-image" });
+        }
+
+        [Fact]
+        public async Task UpdateModelCostAsync_ChangedUpdatableFields_PersistsAllFields()
+        {
+            // Arrange
+            var seeded = SeedCostWithAssociatedModel();
+            var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            var updateDto = ToRoundTripUpdateDto(getDto!);
+            updateDto.PricingConfiguration = "{\"baseRate\":0.25}";
+            updateDto.ModelType = "video";
+            updateDto.Description = "updated description";
+            updateDto.Priority = 7;
+            updateDto.IsActive = false;
+            updateDto.InputCostPerMillionTokens = 9.75m;
+
+            // Act
+            var result = await _service.UpdateModelCostAsync(updateDto);
+
+            // Assert
+            result.Should().BeTrue();
+            var afterDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            afterDto!.PricingConfiguration.Should().Be("{\"baseRate\":0.25}");
+            afterDto.ModelType.Should().Be("video");
+            afterDto.Description.Should().Be("updated description");
+            afterDto.Priority.Should().Be(7);
+            afterDto.IsActive.Should().BeFalse();
+            afterDto.InputCostPerMillionTokens.Should().Be(9.75m);
+        }
+
+        [Fact]
+        public async Task UpdateModelCostAsync_OnlyPricingConfigurationChanged_PublishesModelCostChangedEvent()
+        {
+            // Arrange
+            var seeded = SeedCostWithAssociatedModel();
+            var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            var updateDto = ToRoundTripUpdateDto(getDto!);
+            updateDto.PricingConfiguration = "{\"baseRate\":0.5}";
+
+            // Act
+            await _service.UpdateModelCostAsync(updateDto);
+
+            // Assert — cache invalidation depends on this event
+            _mockEventBus.Verify(
+                x => x.PublishAsync(
+                    It.Is<ModelCostChanged>(e =>
+                        e.ModelCostId == seeded.CostId &&
+                        e.ChangeType == "Updated" &&
+                        e.ChangedProperties.Contains("PricingConfiguration")),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateModelCostAsync_EmptyAssociationIdsProvided_ClearsAssociationsAndPublishesEvent()
+        {
+            // Arrange
+            var seeded = SeedCostWithAssociatedModel();
+            var getDto = await _service.GetModelCostByIdAsync(seeded.CostId);
+            var updateDto = ToRoundTripUpdateDto(getDto!);
+            updateDto.ModelProviderTypeAssociationIds = new List<int>();
+
+            // Act
+            var result = await _service.UpdateModelCostAsync(updateDto);
+
+            // Assert — explicit empty list still means "clear all associations"
+            result.Should().BeTrue();
+            using (var context = CreateContext())
+            {
+                var association = await context.ModelProviderTypeAssociations
+                    .AsNoTracking()
+                    .SingleAsync(a => a.Id == seeded.AssociationId);
+                association.ModelCostId.Should().BeNull();
+            }
+
+            _mockEventBus.Verify(
+                x => x.PublishAsync(
+                    It.Is<ModelCostChanged>(e =>
+                        e.ModelCostId == seeded.CostId &&
+                        e.ChangeType == "Updated"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Found during the #929 parity gate: `GET /api/modelcosts/{id}` followed by `PUT` with the **unmodified** response body returned `500 {"error":"An error occurred while saving the entity changes..."}` (EF Core `DbUpdateException`). This blocked all cost edits via the Admin API and, with them, the documented `ModelCostChanged` cache-invalidation flow.

## Root cause

`ModelCostRepository.GetByIdAsync`/`GetByCostNameAsync` load the `ModelCost → ModelProviderTypeAssociations → Model` graph (no-tracking). `Model.Series` is initialized to a **phantom** `new ModelSeries()` (Id = 0) whose `Author` is a phantom `new ModelAuthor()` (Id = 0, Name = "") — the query never includes Series, so the initializer instances survive on the detached entities.

`RepositoryBase.UpdateAsync` then called the graph-traversing `DbSet.Update(entity)` on a fresh context, which attached the phantom Series/Author as **Added**. Each save inserted empty `ModelSeries`/`ModelAuthor` rows and re-pointed `Model.ModelSeriesId` at the phantom series; once an empty-named author existed, every subsequent save violated `IX_ModelAuthor_Name_Unique` → `DbUpdateException` → 500. Reproduced exactly in the new SQLite-backed regression test:

```
Microsoft.EntityFrameworkCore.DbUpdateException : An error occurred while saving the entity changes. See the inner exception for details.
---- Microsoft.Data.Sqlite.SqliteException : SQLite Error 19: 'UNIQUE constraint failed: ModelAuthors.Name'.
```

Three secondary round-trip bugs were fixed alongside:
- The round-trip PUT body carries `associatedModelAliases` (strings), not `modelProviderTypeAssociationIds`; the DTO's non-null empty-list default made the service **silently clear all cost→model links** (`ModelIdentifiers.ModelCostId`) on every round-trip.
- `UpdateFrom` silently dropped `ModelType`, `IsActive`, `Priority`, `Description`.
- `ModelCostChanged` was only published when name/token costs changed — updating `PricingConfiguration`, `PricingModel`, activity flags, or the associations never invalidated the two-layer (in-process + Redis) ModelCost cache.

## Changes

- **`ModelCostRepository.UpdateAsync` (override)** — marks only the root `ModelCost` as `Modified` instead of attaching the detached navigation graph. Also covers the CSV/JSON import path, which updates entities loaded with the same includes. Association changes remain managed explicitly by the Admin service.
- **`UpdateModelCostDto.ModelProviderTypeAssociationIds`** → `List<int>?` (default null): null/absent = leave associations unchanged; explicit empty list still clears them.
- **`RepositoryExtensions.UpdateFrom`** — now maps `ModelType`, `IsActive`, `Priority`, `Description`.
- **`AdminModelCostService.UpdateModelCostAsync`** — changed-property tracking covers all updatable fields plus association-set changes, so `ModelCostChanged` fires (same `PublishEventAsync` pattern as before) whenever anything observable changed.

## Tests

New `AdminModelCostServiceRoundTripTests` (SQLite via `RepositoryTestBase`, real `ModelCostRepository` + real service — real relational constraints, matching the production failure shape):
- `UpdateModelCostAsync_RepeatedGetPutRoundTripWithAssociatedModel_Succeeds` (fails pre-fix with the exact live DbUpdateException)
- `UpdateModelCostAsync_RoundTripWithAssociatedModel_DoesNotInsertPhantomSeriesOrAuthor`
- `UpdateModelCostAsync_AssociationIdsAbsentFromDto_PreservesAssociatedModelAliases`
- `UpdateModelCostAsync_ChangedUpdatableFields_PersistsAllFields`
- `UpdateModelCostAsync_OnlyPricingConfigurationChanged_PublishesModelCostChangedEvent`
- `UpdateModelCostAsync_EmptyAssociationIdsProvided_ClearsAssociationsAndPublishesEvent`

Results: 6/6 new tests green; all ModelCost-related tests green (83) and full `ConduitLLM.Tests.Admin` namespace green (557). Full solution `dotnet build` clean.

## Notes

- Live GET→PUT round-trip verification against the running stack is deferred until the #930 soak concludes (24h soak in progress; no containers were touched).
- Deployments that hit this bug may carry corrupted rows: empty-named `ModelAuthors`/`ModelSeries` and `Models` re-pointed at phantom series. This PR stops the bleeding; a one-time data cleanup can be scoped separately if the soak DB shows affected rows.

Fixes #977
