### PR TITLE
fix(providers): infinite HttpClient.Timeout + streaming idle-read watchdog

### DIFF
--- a/Shared/ConduitLLM.Core/Http/ConduitOperationClasses.cs
+++ b/Shared/ConduitLLM.Core/Http/ConduitOperationClasses.cs
@@ -1,0 +1,33 @@
+namespace ConduitLLM.Core.Http;
+
+/// <summary>
+/// Operation-class identifiers attached to provider HTTP requests (via
+/// <see cref="HttpRequestMessage.Options"/>) so the resilience pipeline in
+/// ConduitLLM.Providers can select per-class timeout budgets.
+/// </summary>
+/// <remarks>
+/// Lives in Core (not Providers) because Core utilities like <c>HttpClientHelper</c> tag
+/// requests, while the Providers pipeline reads the tag. The Providers-side
+/// <c>ConduitHttpOptions</c> exposes the strongly-typed options key built from
+/// <see cref="KeyName"/>.
+/// </remarks>
+public static class ConduitOperationClasses
+{
+    /// <summary>Name of the <see cref="HttpRequestOptionsKey{TValue}"/> carrying the class.</summary>
+    public const string KeyName = "Conduit.OperationClass";
+
+    /// <summary>Interactive chat/completions/embeddings.</summary>
+    public const string Chat = "chat";
+
+    /// <summary>Chat streaming (SSE).</summary>
+    public const string ChatStream = "chat-stream";
+
+    /// <summary>Image generation.</summary>
+    public const string Images = "images";
+
+    /// <summary>Authentication/key verification.</summary>
+    public const string Auth = "auth";
+
+    /// <summary>Video generation.</summary>
+    public const string Video = "video";
+}

--- a/Shared/ConduitLLM.Core/Utilities/HttpClientHelper.cs
+++ b/Shared/ConduitLLM.Core/Utilities/HttpClientHelper.cs
@@ -33,6 +33,9 @@ namespace ConduitLLM.Core.Utilities
         /// <param name="jsonOptions">Optional JSON serialization options.</param>
         /// <param name="logger">Optional logger for request/response logging.</param>
         /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <param name="operationClass">Optional operation class (see
+        /// <see cref="Http.ConduitOperationClasses"/>) so the resilience pipeline can select the
+        /// matching timeout budget (e.g. images vs chat).</param>
         /// <returns>The deserialized response object.</returns>
         /// <exception cref="LLMCommunicationException">Thrown when there is an error communicating with the API.</exception>
         public static async Task<TResponse> SendJsonRequestAsync<TRequest, TResponse>(
@@ -43,13 +46,18 @@ namespace ConduitLLM.Core.Utilities
             IDictionary<string, string>? headers = null,
             JsonSerializerOptions? jsonOptions = null,
             ILogger? logger = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            string? operationClass = null)
         {
             var options = jsonOptions ?? DefaultJsonOptions;
 
             try
             {
                 var request = CreateJsonRequest(method, endpoint, requestData, headers, options, logger);
+                if (operationClass != null)
+                {
+                    request.Options.Set(new HttpRequestOptionsKey<string>(Http.ConduitOperationClasses.KeyName), operationClass);
+                }
                 logger?.LogDebug("Sending {Method} request to {Endpoint}", method, endpoint);
 
                 using var response = await client.SendAsync(request, cancellationToken);
@@ -308,7 +316,13 @@ namespace ConduitLLM.Core.Utilities
             try
             {
                 var request = CreateJsonRequest(method, endpoint, requestData, headers, options, logger);
-                
+
+                // Tag as chat streaming so the resilience pipeline's per-attempt timeout acts as
+                // a time-to-first-token bound (the send completes at response headers)
+                request.Options.Set(
+                    new HttpRequestOptionsKey<string>(Http.ConduitOperationClasses.KeyName),
+                    Http.ConduitOperationClasses.ChatStream);
+
                 // Add Accept header for SSE if not already present
                 if (!request.Headers.Accept.Any(h => h.MediaType == "text/event-stream"))
                 {

--- a/Shared/ConduitLLM.Core/Utilities/StreamHelper.cs
+++ b/Shared/ConduitLLM.Core/Utilities/StreamHelper.cs
@@ -22,6 +22,15 @@ namespace ConduitLLM.Core.Utilities
         };
 
         /// <summary>
+        /// Idle-read watchdog applied when a caller does not pass an explicit timeout: if no
+        /// data arrives on a streaming response for this long, the stream is aborted with a
+        /// distinguishable <see cref="LLMCommunicationException"/> instead of hanging forever.
+        /// Initialized from <c>Conduit:ProviderHttp:Streaming:IdleReadTimeoutSeconds</c> when
+        /// the provider HTTP clients are registered.
+        /// </summary>
+        public static TimeSpan DefaultIdleReadTimeout { get; set; } = TimeSpan.FromSeconds(90);
+
+        /// <summary>
         /// Processes a server-sent event (SSE) stream from an HTTP response and yields deserialized objects.
         /// </summary>
         /// <typeparam name="T">The type to deserialize each data event into.</typeparam>
@@ -34,11 +43,13 @@ namespace ConduitLLM.Core.Utilities
             HttpResponseMessage response,
             ILogger? logger = null,
             JsonSerializerOptions? options = null,
+            TimeSpan? idleReadTimeout = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var jsonOptions = options ?? DefaultJsonOptions;
 
-            await foreach (var dataBuffer in ReadSseDataLinesAsync(response, logger, cancellationToken))
+            await foreach (var dataBuffer in ReadSseDataLinesAsync(
+                response, logger, idleReadTimeout ?? DefaultIdleReadTimeout, cancellationToken))
             {
                 T? data = default;
                 try
@@ -71,7 +82,8 @@ namespace ConduitLLM.Core.Utilities
 
             try
             {
-                await foreach (var dataBuffer in ReadSseDataLinesAsync(response, logger, cancellationToken))
+                await foreach (var dataBuffer in ReadSseDataLinesAsync(
+                    response, logger, DefaultIdleReadTimeout, cancellationToken))
                 {
                     try
                     {
@@ -110,6 +122,7 @@ namespace ConduitLLM.Core.Utilities
         private static async IAsyncEnumerable<string> ReadSseDataLinesAsync(
             HttpResponseMessage response,
             ILogger? logger,
+            TimeSpan idleReadTimeout,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             logger?.LogDebug("Beginning to process SSE stream");
@@ -118,6 +131,7 @@ namespace ConduitLLM.Core.Utilities
 
             var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
             using var reader = new StreamReader(stream, Encoding.UTF8);
+            using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             string? line;
             string dataBuffer = string.Empty;
@@ -125,7 +139,7 @@ namespace ConduitLLM.Core.Utilities
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                line = await reader.ReadLineAsync(cancellationToken);
+                line = await ReadLineWithIdleWatchdogAsync(reader, idleCts, idleReadTimeout, cancellationToken, logger);
                 if (line == null) break; // End of stream
                 lineCount++;
 
@@ -172,6 +186,38 @@ namespace ConduitLLM.Core.Utilities
         }
 
         /// <summary>
+        /// Reads one line from a streaming response, aborting with a distinguishable
+        /// <see cref="LLMCommunicationException"/> if no data arrives within the idle timeout.
+        /// Providers that stall mid-stream would otherwise hang the request forever now that
+        /// streaming clients no longer carry an HttpClient.Timeout.
+        /// </summary>
+        private static async Task<string?> ReadLineWithIdleWatchdogAsync(
+            StreamReader reader,
+            CancellationTokenSource idleCts,
+            TimeSpan idleReadTimeout,
+            CancellationToken callerToken,
+            ILogger? logger)
+        {
+            idleCts.CancelAfter(idleReadTimeout);
+            try
+            {
+                var line = await reader.ReadLineAsync(idleCts.Token);
+                // Disarm the watchdog while the caller processes the line
+                idleCts.CancelAfter(Timeout.InfiniteTimeSpan);
+                return line;
+            }
+            catch (OperationCanceledException ex) when (!callerToken.IsCancellationRequested)
+            {
+                logger?.LogWarning(
+                    "Streaming response idle timeout: no data received for {IdleTimeoutSeconds}s",
+                    idleReadTimeout.TotalSeconds);
+                throw new LLMCommunicationException(
+                    $"Streaming response idle timeout: no data received for {idleReadTimeout.TotalSeconds:F0}s",
+                    ex);
+            }
+        }
+
+        /// <summary>
         /// Processes a server-sent event (SSE) stream specially formatted for LLM chat completion responses.
         /// </summary>
         /// <param name="response">The HTTP response containing the SSE stream.</param>
@@ -186,7 +232,7 @@ namespace ConduitLLM.Core.Utilities
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await foreach (var chunk in ProcessSseStreamAsync<ChatCompletionChunk>(
-                response, logger, options, cancellationToken))
+                response, logger, options, cancellationToken: cancellationToken))
             {
                 yield return chunk;
             }
@@ -326,11 +372,13 @@ namespace ConduitLLM.Core.Utilities
                 logger?.LogDebug("Beginning to process custom stream with delimiter: {Delimiter}", delimiter);
                 var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
                 using var reader = new StreamReader(stream, Encoding.UTF8);
+                using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
                 string? line;
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    line = await reader.ReadLineAsync(cancellationToken);
+                    line = await ReadLineWithIdleWatchdogAsync(
+                        reader, idleCts, DefaultIdleReadTimeout, cancellationToken, logger);
                     if (line == null) break; // End of stream
                     if (string.IsNullOrEmpty(line))
                     {

--- a/Shared/ConduitLLM.Providers/BaseLLMClient.cs
+++ b/Shared/ConduitLLM.Providers/BaseLLMClient.cs
@@ -171,8 +171,11 @@ namespace ConduitLLM.Providers
             // Configure authentication
             ConfigureAuthentication(client, apiKey);
 
-            // Configure default timeout (can be overridden per-request)
-            client.Timeout = DefaultRequestTimeout;
+            // All timeout budgets live in the resilience pipeline (per-attempt + total, per
+            // operation class). HttpClient.Timeout must stay infinite: it would otherwise also
+            // cancel streaming response reads mid-stream (killing SSE streams that outlive it)
+            // and truncate pipeline budgets longer than itself.
+            client.Timeout = Timeout.InfiniteTimeSpan;
         }
         
         /// <summary>
@@ -214,8 +217,8 @@ namespace ConduitLLM.Providers
             // Configure authentication
             ConfigureAuthentication(client, apiKey);
 
-            // Use a shorter timeout for health checks
-            client.Timeout = AuthVerificationTimeout;
+            // Timeout budgets live in the resilience pipeline (auth class: fail fast, no retries)
+            client.Timeout = Timeout.InfiniteTimeSpan;
 
             // Do NOT set BaseAddress - we'll be using absolute URLs
             return client;

--- a/Shared/ConduitLLM.Providers/Extensions/HttpClientExtensions.cs
+++ b/Shared/ConduitLLM.Providers/Extensions/HttpClientExtensions.cs
@@ -63,6 +63,13 @@ public static class HttpClientExtensions
                 var options = context.ServiceProvider
                     .GetRequiredService<IOptionsMonitor<ProviderResilienceOptions>>().CurrentValue;
 
+                // Initialize the streaming idle watchdog from config. Set here (not at
+                // registration time) because options need a built ServiceProvider; every
+                // streaming response first passes through a named-client pipeline, so this runs
+                // before the first watchdog-guarded read.
+                ConduitLLM.Core.Utilities.StreamHelper.DefaultIdleReadTimeout =
+                    TimeSpan.FromSeconds(options.Streaming.IdleReadTimeoutSeconds);
+
                 var errorTracker = context.ServiceProvider.GetService<IProviderErrorTrackingService>();
                 var hook = errorTracker == null
                     ? null

--- a/Shared/ConduitLLM.Providers/Http/ConduitHttpOptions.cs
+++ b/Shared/ConduitLLM.Providers/Http/ConduitHttpOptions.cs
@@ -9,25 +9,28 @@ public static class ConduitHttpOptions
     /// <summary>
     /// Overrides the operation class for a single request. When absent, the pipeline uses the
     /// default class of the named client the request was sent through (*LLMClient → chat,
-    /// *AuthVerification → auth, *VideoClient → video).
+    /// *AuthVerification → auth, *VideoClient → video). Key name and class values are defined
+    /// in Core (<see cref="Core.Http.ConduitOperationClasses"/>) so Core utilities can tag
+    /// requests too.
     /// </summary>
-    public static readonly HttpRequestOptionsKey<string> OperationClass = new("Conduit.OperationClass");
+    public static readonly HttpRequestOptionsKey<string> OperationClass =
+        new(Core.Http.ConduitOperationClasses.KeyName);
 
     /// <summary>Interactive chat/completions/embeddings.</summary>
-    public const string Chat = "chat";
+    public const string Chat = Core.Http.ConduitOperationClasses.Chat;
 
     /// <summary>Chat streaming (SSE) — same budgets as chat; the attempt timeout bounds
     /// time-to-first-token because the HTTP call completes at response headers.</summary>
-    public const string ChatStream = "chat-stream";
+    public const string ChatStream = Core.Http.ConduitOperationClasses.ChatStream;
 
     /// <summary>Image generation.</summary>
-    public const string Images = "images";
+    public const string Images = Core.Http.ConduitOperationClasses.Images;
 
     /// <summary>Authentication/key verification.</summary>
-    public const string Auth = "auth";
+    public const string Auth = Core.Http.ConduitOperationClasses.Auth;
 
     /// <summary>Video generation.</summary>
-    public const string Video = "video";
+    public const string Video = Core.Http.ConduitOperationClasses.Video;
 
     /// <summary>
     /// Sets the operation class on a request.

--- a/Shared/ConduitLLM.Providers/Providers/Cloudflare/CloudflareClient.Images.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Cloudflare/CloudflareClient.Images.cs
@@ -108,6 +108,7 @@ namespace ConduitLLM.Providers.Cloudflare
             {
                 Content = httpContent
             };
+            httpRequest.Options.Set(Http.ConduitHttpOptions.OperationClass, Http.ConduitHttpOptions.Images);
 
             using var httpResponse = await client.SendAsync(httpRequest, HttpCompletionOption.ResponseContentRead, cancellationToken);
 

--- a/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Images.cs
+++ b/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Images.cs
@@ -50,6 +50,7 @@ namespace ConduitLLM.Providers.MiniMax
                 // Make direct HTTP call to debug
                 var httpRequest = new HttpRequestMessage(HttpMethod.Post, endpoint);
                 httpRequest.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+                httpRequest.Options.Set(Http.ConduitHttpOptions.OperationClass, Http.ConduitHttpOptions.Images);
                 
                 using var httpResponse = await httpClient.SendAsync(httpRequest, cancellationToken);
                 var rawContent = await httpResponse.Content.ReadAsStringAsync();

--- a/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Streaming.cs
+++ b/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Streaming.cs
@@ -82,7 +82,7 @@ namespace ConduitLLM.Providers.MiniMax
                 }
 
                 var streamEnum = Core.Utilities.StreamHelper.ProcessSseStreamAsync<MiniMaxStreamChunk>(
-                    response!, Logger, null, cancellationToken);
+                    response!, Logger, null, cancellationToken: cancellationToken);
 
                 await foreach (var chunk in streamEnum.WithCancellation(cancellationToken))
                 {

--- a/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Videos.cs
+++ b/Shared/ConduitLLM.Providers/Providers/MiniMax/MiniMaxClient.Videos.cs
@@ -415,11 +415,11 @@ namespace ConduitLLM.Providers.MiniMax
             client.DefaultRequestHeaders.Add("User-Agent", "ConduitLLM");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", effectiveApiKey);
 
-            // Use large file download timeout for video files
-            client.Timeout = LargeFileDownloadTimeout;
+            // Timeout budgets live in the resilience pipeline (video class: long attempts, no
+            // retries); HttpClient.Timeout stays infinite so it can't cut long downloads short
+            client.Timeout = Timeout.InfiniteTimeSpan;
 
-            Logger.LogInformation("Created video HTTP client with {Timeout} timeout via IHttpClientFactory",
-                LargeFileDownloadTimeout);
+            Logger.LogInformation("Created video HTTP client via IHttpClientFactory (video-class pipeline budgets)");
 
             return client;
         }

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Images.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Images.cs
@@ -103,7 +103,8 @@ namespace ConduitLLM.Providers.OpenAICompatible
                     CreateStandardHeaders(apiKey),
                     DefaultJsonOptions,
                     Logger,
-                    cancellationToken);
+                    cancellationToken,
+                    operationClass: Core.Http.ConduitOperationClasses.Images);
 
                 return new CoreModels.ImageGenerationResponse
                 {

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Streaming.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Streaming.cs
@@ -119,7 +119,7 @@ namespace ConduitLLM.Providers.OpenAICompatible
                     bool reportedUsage = false;
                     // Stream chunks progressively using StreamHelper - use JsonElement for raw passthrough
                     await foreach (var chunk in CoreUtils.StreamHelper.ProcessSseStreamAsync<System.Text.Json.JsonElement>(
-                        response, Logger, DefaultJsonOptions, cancellationToken))
+                        response, Logger, DefaultJsonOptions, cancellationToken: cancellationToken))
                     {
                         if (cancellationToken.IsCancellationRequested)
                         {

--- a/Tests/ConduitLLM.Tests/Core/Utilities/StreamHelperWatchdogTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Utilities/StreamHelperWatchdogTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Text;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Utilities;
+
+using Xunit.Abstractions;
+
+namespace ConduitLLM.Tests.Core.Utilities
+{
+    /// <summary>
+    /// Tests for the streaming idle-read watchdog: with HttpClient.Timeout now infinite for
+    /// provider clients, a provider that stalls mid-stream must be aborted by the watchdog
+    /// rather than hanging the request forever.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Core")]
+    public class StreamHelperWatchdogTests : TestBase
+    {
+        public StreamHelperWatchdogTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static HttpResponseMessage SseResponse(Stream stream) => new(HttpStatusCode.OK)
+        {
+            Content = new PullStreamContent(stream),
+        };
+
+        [Fact]
+        public async Task HealthyStream_YieldsAllChunks_WatchdogSilent()
+        {
+            var sse = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\ndata: [DONE]\n\n";
+            using var response = SseResponse(new MemoryStream(Encoding.UTF8.GetBytes(sse)));
+
+            var chunks = new List<System.Text.Json.JsonElement>();
+            await foreach (var chunk in StreamHelper.ProcessSseStreamAsync<System.Text.Json.JsonElement>(
+                response, idleReadTimeout: TimeSpan.FromSeconds(5)))
+            {
+                chunks.Add(chunk);
+            }
+
+            Assert.Equal(2, chunks.Count);
+        }
+
+        [Fact]
+        public async Task StalledStream_AbortedByWatchdog_WithDistinguishableError()
+        {
+            using var response = SseResponse(new StallingStream(
+                Encoding.UTF8.GetBytes("data: {\"n\":1}\n\n")));
+
+            var chunks = new List<System.Text.Json.JsonElement>();
+            var ex = await Assert.ThrowsAsync<LLMCommunicationException>(async () =>
+            {
+                await foreach (var chunk in StreamHelper.ProcessSseStreamAsync<System.Text.Json.JsonElement>(
+                    response, idleReadTimeout: TimeSpan.FromMilliseconds(300)))
+                {
+                    chunks.Add(chunk);
+                }
+            });
+
+            Assert.Single(chunks); // the chunk before the stall was delivered
+            Assert.Contains("idle timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task StalledStream_CallerCancellation_StillSurfacesAsCancellation()
+        {
+            using var response = SseResponse(new StallingStream(
+                Encoding.UTF8.GetBytes("data: {\"n\":1}\n\n")));
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+            // Watchdog is generous (10s); the caller's own cancellation must win and keep its
+            // OperationCanceledException identity (not be rewritten as an idle timeout).
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var _ in StreamHelper.ProcessSseStreamAsync<System.Text.Json.JsonElement>(
+                    response, idleReadTimeout: TimeSpan.FromSeconds(10), cancellationToken: cts.Token))
+                {
+                }
+            });
+        }
+
+        [Fact]
+        public async Task SlowButActiveStream_NotAborted_WhenChunksArriveWithinIdleWindow()
+        {
+            // Three chunks, each delayed 150ms — total stream time (450ms+) exceeds the idle
+            // window (300ms), but no single gap does. The watchdog must re-arm per read.
+            using var response = SseResponse(new DrippingStream(
+                Encoding.UTF8.GetBytes("data: {\"n\":1}\n\ndata: {\"n\":2}\n\ndata: {\"n\":3}\n\n"),
+                chunkSize: 16,
+                delayPerChunk: TimeSpan.FromMilliseconds(150)));
+
+            var chunks = new List<System.Text.Json.JsonElement>();
+            await foreach (var chunk in StreamHelper.ProcessSseStreamAsync<System.Text.Json.JsonElement>(
+                response, idleReadTimeout: TimeSpan.FromMilliseconds(300)))
+            {
+                chunks.Add(chunk);
+            }
+
+            Assert.Equal(3, chunks.Count);
+        }
+
+        /// <summary>HttpContent exposing a caller-supplied stream directly (no buffering).</summary>
+        private sealed class PullStreamContent : HttpContent
+        {
+            private readonly Stream _stream;
+
+            public PullStreamContent(Stream stream) => _stream = stream;
+
+            protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult(_stream);
+
+            protected override Task SerializeToStreamAsync(Stream stream, System.Net.TransportContext? context)
+                => _stream.CopyToAsync(stream);
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = -1;
+                return false;
+            }
+        }
+
+        /// <summary>Serves its payload, then stalls forever (until cancelled).</summary>
+        private sealed class StallingStream : Stream
+        {
+            private readonly byte[] _payload;
+            private int _position;
+
+            public StallingStream(byte[] payload) => _payload = payload;
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (_position < _payload.Length)
+                {
+                    var count = Math.Min(buffer.Length, _payload.Length - _position);
+                    _payload.AsMemory(_position, count).CopyTo(buffer);
+                    _position += count;
+                    return count;
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0; // unreachable
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+                => ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => _position; set => throw new NotSupportedException(); }
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        /// <summary>Serves its payload in small delayed chunks, then ends.</summary>
+        private sealed class DrippingStream : Stream
+        {
+            private readonly byte[] _payload;
+            private readonly int _chunkSize;
+            private readonly TimeSpan _delayPerChunk;
+            private int _position;
+
+            public DrippingStream(byte[] payload, int chunkSize, TimeSpan delayPerChunk)
+            {
+                _payload = payload;
+                _chunkSize = chunkSize;
+                _delayPerChunk = delayPerChunk;
+            }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (_position >= _payload.Length)
+                {
+                    return 0;
+                }
+
+                await Task.Delay(_delayPerChunk, cancellationToken);
+                var count = Math.Min(Math.Min(buffer.Length, _chunkSize), _payload.Length - _position);
+                _payload.AsMemory(_position, count).CopyTo(buffer);
+                _position += count;
+                return count;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+                => ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => _position; set => throw new NotSupportedException(); }
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/Http/ProviderHttpClientRegistrationTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Http/ProviderHttpClientRegistrationTests.cs
@@ -196,6 +196,54 @@ namespace ConduitLLM.Tests.Providers.Http
         }
 
         [Fact]
+        public async Task ProviderClients_UseInfiniteHttpClientTimeout()
+        {
+            // All timeout budgets live in the resilience pipeline; HttpClient.Timeout must be
+            // infinite or it cancels streaming response reads mid-stream (>120s SSE deaths).
+            var createdClients = new List<HttpClient>();
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+            var factoryMock = new Mock<IHttpClientFactory>();
+            factoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(() =>
+            {
+                var client = new HttpClient(handlerMock.Object) { BaseAddress = new Uri("http://localhost:59999/") };
+                createdClients.Add(client);
+                return client;
+            });
+
+            var creator = ClientCreatorRegistry.GetCreator(ProviderType.OpenAI);
+            var client = creator!(
+                new Provider { Id = 1, ProviderType = ProviderType.OpenAI, IsEnabled = true, BaseUrl = "http://localhost:59999" },
+                new ProviderKeyCredential { Id = 1, ProviderId = 1, ApiKey = "test-key", IsPrimary = true, IsEnabled = true },
+                "test-model",
+                new ClientCreationContext
+                {
+                    LoggerFactory = LoggerFactory.Create(_ => { }),
+                    HttpClientFactory = factoryMock.Object,
+                });
+
+            try
+            {
+                await client.CreateChatCompletionAsync(new ChatCompletionRequest
+                {
+                    Model = "test-model",
+                    Messages = new List<Message> { new Message { Role = MessageRole.User, Content = "hi" } },
+                });
+            }
+            catch
+            {
+                // canned 500 — irrelevant, the client was configured before the send
+            }
+
+            Assert.NotEmpty(createdClients);
+            Assert.All(createdClients, c => Assert.Equal(Timeout.InfiniteTimeSpan, c.Timeout));
+        }
+
+        [Fact]
         public async Task RegisteredClient_RetriesTransientErrors_AndSucceeds()
         {
             var attempts = 0;

--- a/docs/architecture/provider-http-resilience.md
+++ b/docs/architecture/provider-http-resilience.md
@@ -97,9 +97,18 @@ every retry; fatal-class errors (401/402/403) only on the final retry (avoiding 
 Key/provider attribution flows through `ProviderKeyContext` (AsyncLocal, set by
 `ContextAwareLLMClient`) into `IProviderErrorTrackingService`, which auto-disables failing keys.
 
-## Known limitation (until the streaming timeout fix lands)
+## Streaming lifetime and the idle-read watchdog
 
-`BaseLLMClient` still sets `HttpClient.Timeout = 120s`, which sits outside the pipeline and both
-truncates the images total budget (240s → 120s) and kills SSE streams that run longer than 120s.
-The follow-up PR moves all budgets into the pipeline (`HttpClient.Timeout = Infinite`) and adds
-the streaming idle-read watchdog.
+Provider clients set `HttpClient.Timeout = Timeout.InfiniteTimeSpan` — **all** budgets live in
+the pipeline. This is deliberate: `HttpClient.Timeout` also cancels streaming response reads
+mid-stream, which used to kill SSE streams older than 120 seconds regardless of health.
+
+With no wall-clock limit on stream lifetime, a provider that stalls mid-stream is instead caught
+by the **idle-read watchdog** (`StreamHelper`): if no data arrives for
+`Streaming:IdleReadTimeoutSeconds` (default 90s), the stream is aborted with a distinguishable
+`LLMCommunicationException` ("streaming response idle timeout"). The watchdog re-arms on every
+read — a healthy slow stream of any total length is never cut off; only silence is.
+
+Time-to-first-token remains bounded by the per-attempt timeout (the streaming send completes at
+response headers), and image generation requests are tagged with the `images` operation class at
+their call sites so they get the images budget rather than chat's.


### PR DESCRIPTION
## Summary

PR 3 of the provider-resilience overhaul (**stacked on #1041**, which stacks on #1040 — only the last commit is new here).

Fixes the confirmed streaming bug: `HttpClient.Timeout` cancels streaming response reads mid-flight, so the 120s client timeout was killing **healthy SSE streams older than 2 minutes** (reasoning models, long generations) with a cancellation error surfaced at `HttpClientHelper.cs` ("Streaming request timed out").

## Changes

- **`HttpClient.Timeout = Timeout.InfiniteTimeSpan`** for all provider clients (chat, auth verification, MiniMax video). All time budgets now live exclusively in the resilience pipeline — per-attempt (= time-to-first-token for streaming) and total, per operation class. Safe because PR 2 guarantees every client name BaseLLMClient can request has a pipeline attached (names come from the same helper as registration), pinned by the `ProviderClients_UseInfiniteHttpClientTimeout` regression test.
- **Idle-read watchdog** (`StreamHelper`): with no wall-clock limit on stream lifetime, a provider that stalls mid-stream is aborted after `Streaming:IdleReadTimeoutSeconds` (default 90s) of silence with a distinguishable `LLMCommunicationException`. The watchdog **re-arms per read** — a slow but active stream of any total length is never cut off. Caller cancellation keeps its `OperationCanceledException` identity. Initialized from `ProviderResilienceOptions` when the pipeline is built.
- **Operation-class tagging completed** now that budgets are real:
  - Image generation call sites (OpenAI-compatible family, MiniMax, Cloudflare) tag `images` → 180s attempt / 240s total instead of chat's 100/120. Without this, images would have *tightened* from today's effective 120s to 100s.
  - `SendStreamingRequestAsync` tags `chat-stream`.
  - Key + class values moved to Core (`ConduitOperationClasses`) so Core utilities can tag; Providers' `ConduitHttpOptions` aliases them (same strings).

## Behavior deltas

- SSE streams longer than 120s now survive (the headline fix).
- A provider stalling mid-stream errors after 90s of silence (previously: hung until the 120s wall clock, or forever if it had already passed).
- Image generation gains headroom: 120s → 240s total.

## Verification

- `dotnet test` — 2969 passed, 0 failed. New tests: stalled-stream abort with distinguishable error, per-read watchdog re-arm on slow streams, caller-cancellation identity preserved, healthy stream passthrough, infinite-client-timeout regression.
- Live check after merge: stream a >2.5-minute completion through the Gateway (`./scripts/dev/start-dev.ps1`) — survives; stall the upstream mid-stream — SSE error event at ~90s.