### PR TITLE
feat(core): in-request key-level failover behind CONDUIT_FAILOVER_ENABLED

### DIFF
--- a/Services/ConduitLLM.Gateway/Controllers/ChatController.Streaming.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/ChatController.Streaming.cs
@@ -25,6 +25,8 @@ namespace ConduitLLM.Gateway.Controllers
             _logger.LogInformation("Handling non-streaming request.");
             var response = await _conduit.CreateChatCompletionAsync(request, null, virtualKeyId, cancellationToken);
 
+            SetFallbackHeaderIfFailoverOccurred();
+
             if (response.AgenticMetrics?.FunctionCalls != null && response.AgenticMetrics.FunctionCalls.Count > 0)
             {
                 StoreFunctionExecutionResults(response.AgenticMetrics);
@@ -32,6 +34,26 @@ namespace ConduitLLM.Gateway.Controllers
 
             GatewayOpsMetrics.RecordLlmOperation("chat_completion", request.Model, "success", operationStopwatch.Elapsed.TotalSeconds);
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Surfaces in-request failover to the API consumer as <c>X-Conduit-Fallback:
+        /// attempts=&lt;n&gt;</c> — attempt count only, never the serving provider (upstream
+        /// topology stays private; full detail goes to logs and the request log).
+        /// </summary>
+        private void SetFallbackHeaderIfFailoverOccurred()
+        {
+            var attribution = HttpContext.RequestServices
+                .GetService<ConduitLLM.Core.Services.IFailoverAttributionAccessor>();
+            if (attribution is { FailoverOccurred: true } && !HttpContext.Response.HasStarted)
+            {
+                HttpContext.Response.Headers["X-Conduit-Fallback"] = $"attempts={attribution.AttemptCount}";
+                _logger.LogInformation(
+                    "Request served after failover: {Attempts} attempts, serving key {KeyId} (provider {ProviderId})",
+                    attribution.AttemptCount,
+                    attribution.Current?.KeyCredentialId,
+                    attribution.Current?.ProviderId);
+            }
         }
 
         private void StoreFunctionExecutionResults(AgenticExecutionMetrics agenticMetrics)
@@ -93,6 +115,9 @@ namespace ConduitLLM.Gateway.Controllers
                     if (state.ChunkCount == 1)
                     {
                         _logger.LogInformation("First chunk received at {Time}ms", (DateTime.UtcNow - firstChunkTime).TotalMilliseconds);
+                        // Candidate selection is final once the first chunk exists, and headers
+                        // are still writable until the first body write below.
+                        SetFallbackHeaderIfFailoverOccurred();
                     }
 
                     AccumulateContent(chunk, state);

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.BillingAndMetrics.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.BillingAndMetrics.cs
@@ -32,6 +32,8 @@ namespace ConduitLLM.Gateway.Middleware
                     ? providerTypeObj?.ToString()
                     : null;
 
+                metadata = AppendFailoverMetadata(context, metadata);
+
                 var logRequest = new LogRequestDto
                 {
                     VirtualKeyId = virtualKeyId,
@@ -62,6 +64,55 @@ namespace ConduitLLM.Gateway.Middleware
             {
                 _logger.LogError(ex, "Failed to log request for VirtualKey {VirtualKeyId}", virtualKeyId);
                 // Don't throw - logging failure shouldn't break the request
+            }
+        }
+
+        /// <summary>
+        /// Records in-request failover details (attempts + serving key/provider) into the
+        /// RequestLog metadata JSON so operators can audit which candidate actually served.
+        /// Attribution overrides for cost (provider-level failover) ship separately.
+        /// </summary>
+        private string? AppendFailoverMetadata(HttpContext context, string? metadata)
+        {
+            try
+            {
+                var attribution = context.RequestServices
+                    .GetService<ConduitLLM.Core.Services.IFailoverAttributionAccessor>();
+                if (attribution is not { FailoverOccurred: true } || attribution.Current == null)
+                {
+                    return metadata;
+                }
+
+                var failover = new
+                {
+                    failover = new
+                    {
+                        attempts = attribution.AttemptCount,
+                        servingProviderId = attribution.Current.ProviderId,
+                        servingKeyCredentialId = attribution.Current.KeyCredentialId,
+                    },
+                };
+
+                if (string.IsNullOrEmpty(metadata))
+                {
+                    return System.Text.Json.JsonSerializer.Serialize(failover);
+                }
+
+                // Merge into existing metadata JSON object if possible; otherwise leave as-is.
+                var existing = System.Text.Json.Nodes.JsonNode.Parse(metadata);
+                if (existing is System.Text.Json.Nodes.JsonObject obj)
+                {
+                    obj["failover"] = System.Text.Json.Nodes.JsonNode.Parse(
+                        System.Text.Json.JsonSerializer.Serialize(failover.failover));
+                    return obj.ToJsonString();
+                }
+
+                return metadata;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to append failover metadata to request log");
+                return metadata;
             }
         }
 

--- a/Shared/ConduitLLM.Core/Configuration/FailoverOptions.cs
+++ b/Shared/ConduitLLM.Core/Configuration/FailoverOptions.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ConduitLLM.Core.Configuration;
+
+/// <summary>
+/// Configuration for in-request failover across provider keys (and, when
+/// <see cref="ProviderFailoverEnabled"/> is set, across providers).
+/// </summary>
+/// <remarks>
+/// Bound from the <c>Conduit:Failover</c> section. Both flags default to <b>off</b>: with
+/// <see cref="Enabled"/> false the client factory returns exactly the single-client chain it
+/// always has, byte for byte.
+/// </remarks>
+public class FailoverOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Conduit:Failover";
+
+    /// <summary>
+    /// Master switch for in-request key-level failover. Environment override:
+    /// <c>CONDUIT_FAILOVER_ENABLED</c> (mapped in configuration). Default off.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// Enables cross-provider failover (requires <see cref="Enabled"/> too). Shipped by the
+    /// provider-level failover PR; has no effect until candidates from multiple providers
+    /// exist. Default off.
+    /// </summary>
+    public bool ProviderFailoverEnabled { get; set; } = false;
+
+    /// <summary>Maximum keys attempted per provider (primary + alternates).</summary>
+    [Range(1, 10)]
+    public int MaxKeyAttemptsPerProvider { get; set; } = 2;
+
+    /// <summary>Hard cap on total attempts across all providers.</summary>
+    [Range(1, 10)]
+    public int MaxTotalAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Total wall-clock budget for the failover loop. A new attempt is not started once 60% of
+    /// this budget has elapsed (an attempt that cannot plausibly finish only adds latency).
+    /// For streaming, the budget governs only the pre-first-chunk phase — a healthy long
+    /// stream is never cut off by it.
+    /// </summary>
+    [Range(5, 600)]
+    public double TotalBudgetSeconds { get; set; } = 90;
+
+    /// <summary>
+    /// When false (default), image generation only fails over on auth-class errors
+    /// (401/402/403) — never on timeouts or 5xx, where the provider may have accepted the
+    /// generation job and a retry would double-generate and double-cost.
+    /// </summary>
+    public bool EnableFullMediaFailover { get; set; } = false;
+}

--- a/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
@@ -268,43 +268,8 @@ namespace ConduitLLM.Core.Decorators
             return baseUrl ?? "https://api.provider.com/health";
         }
 
-        private LLMCommunicationException? ExtractLLMCommunicationException(Exception ex)
-        {
-            // Check if it's already an LLMCommunicationException with a StatusCode
-            if (ex is LLMCommunicationException llmEx && llmEx.StatusCode.HasValue)
-                return llmEx;
-            
-            // If it's an LLMCommunicationException without StatusCode, check its inner exceptions
-            if (ex is LLMCommunicationException outerLlmEx && outerLlmEx.InnerException != null)
-            {
-                var innerWithStatus = ExtractLLMCommunicationException(outerLlmEx.InnerException);
-                if (innerWithStatus != null)
-                    return innerWithStatus;
-            }
-            
-            // Check inner exceptions recursively for any LLMCommunicationException with StatusCode
-            var current = ex.InnerException;
-            while (current != null)
-            {
-                if (current is LLMCommunicationException innerLlmEx && innerLlmEx.StatusCode.HasValue)
-                    return innerLlmEx;
-                current = current.InnerException;
-            }
-            
-            // If we only found exceptions without StatusCode, return the first one we found
-            if (ex is LLMCommunicationException firstLlmEx)
-                return firstLlmEx;
-                
-            current = ex.InnerException;
-            while (current != null)
-            {
-                if (current is LLMCommunicationException innerLlmEx)
-                    return innerLlmEx;
-                current = current.InnerException;
-            }
-            
-            return null;
-        }
+        private static LLMCommunicationException? ExtractLLMCommunicationException(Exception ex)
+            => FailoverErrorClassifier.ExtractLLMCommunicationException(ex);
 
         private async Task TrackErrorAsync(LLMCommunicationException ex)
         {

--- a/Shared/ConduitLLM.Core/Decorators/FailoverLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/FailoverLLMClient.cs
@@ -1,0 +1,294 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+
+using ConduitLLM.Core.Configuration;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Core.Decorators
+{
+    /// <summary>
+    /// Outermost decorator that retries a failed provider call against an ordered list of
+    /// candidate (provider, key) chains before surfacing an error to the caller.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>Each candidate is a fully decorated client chain bound to its own key, so per-key
+    /// error tracking and auto-disable fire per attempt exactly as without failover; this
+    /// decorator itself tracks nothing.</item>
+    /// <item>Advancement is decided by <see cref="FailoverErrorClassifier"/>: key-scoped errors
+    /// move to the next key; provider-scoped errors move to the next provider (or, within one
+    /// provider, a sibling key on a different endpoint); user errors and cancellations abort
+    /// with the original exception.</item>
+    /// <item>Streaming: failover is only possible before the first chunk — once a chunk has
+    /// been yielded the HTTP response is committed downstream and errors propagate as today.</item>
+    /// <item>An explicit caller-supplied <c>apiKey</c> (BYOK) bypasses failover entirely.</item>
+    /// <item>Image generation only fails over on auth-class errors unless
+    /// <see cref="FailoverOptions.EnableFullMediaFailover"/> is set (double-generation risk).
+    /// Video generation is not routed through this decorator at all (the video orchestrator
+    /// walks the chain for <c>CreateVideoAsync</c>, which this class deliberately does not
+    /// expose).</item>
+    /// </list>
+    /// </remarks>
+    public class FailoverLLMClient : ILLMClient, ILLMClientDecorator, IAuthenticationVerifiable
+    {
+        private readonly IReadOnlyList<FailoverCandidate> _candidates;
+        private readonly FailoverOptions _options;
+        private readonly IFailoverAttributionAccessor? _attribution;
+        private readonly ILogger<FailoverLLMClient>? _logger;
+
+        public FailoverLLMClient(
+            IReadOnlyList<FailoverCandidate> candidates,
+            FailoverOptions options,
+            IFailoverAttributionAccessor? attribution,
+            ILogger<FailoverLLMClient>? logger)
+        {
+            if (candidates == null || candidates.Count == 0)
+            {
+                throw new ArgumentException("At least one failover candidate is required", nameof(candidates));
+            }
+
+            _candidates = candidates;
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _attribution = attribution;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public ILLMClient InnerClient => _candidates[0].GetClient();
+
+        public Task<ChatCompletionResponse> CreateChatCompletionAsync(
+            ChatCompletionRequest request, string? apiKey = null, CancellationToken cancellationToken = default)
+            => ExecuteWithFailoverAsync(
+                (client, ct) => client.CreateChatCompletionAsync(request, apiKey, ct),
+                mediaRestricted: false, apiKey, cancellationToken);
+
+        public Task<EmbeddingResponse> CreateEmbeddingAsync(
+            EmbeddingRequest request, string? apiKey = null, CancellationToken cancellationToken = default)
+            => ExecuteWithFailoverAsync(
+                (client, ct) => client.CreateEmbeddingAsync(request, apiKey, ct),
+                mediaRestricted: false, apiKey, cancellationToken);
+
+        public Task<List<string>> ListModelsAsync(
+            string? apiKey = null, CancellationToken cancellationToken = default)
+            => ExecuteWithFailoverAsync(
+                (client, ct) => client.ListModelsAsync(apiKey, ct),
+                mediaRestricted: false, apiKey, cancellationToken);
+
+        public Task<ImageGenerationResponse> CreateImageAsync(
+            ImageGenerationRequest request, string? apiKey = null, CancellationToken cancellationToken = default)
+            => ExecuteWithFailoverAsync(
+                (client, ct) => client.CreateImageAsync(request, apiKey, ct),
+                mediaRestricted: !_options.EnableFullMediaFailover, apiKey, cancellationToken);
+
+        public Task<ProviderCapabilities> GetCapabilitiesAsync(string? modelId = null)
+        {
+            // Metadata lookup — no failover semantics needed.
+            RecordAttempt(_candidates[0]);
+            return _candidates[0].GetClient().GetCapabilitiesAsync(modelId);
+        }
+
+        public async IAsyncEnumerable<ChatCompletionChunk> StreamChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var index = 0;
+            Exception? lastError = null;
+
+            while (index >= 0 && index < _candidates.Count)
+            {
+                var candidate = _candidates[index];
+                RecordAttempt(candidate);
+
+                var enumerator = candidate.GetClient()
+                    .StreamChatCompletionAsync(request, apiKey, cancellationToken)
+                    .GetAsyncEnumerator(cancellationToken);
+
+                bool hasFirst;
+                try
+                {
+                    hasFirst = await enumerator.MoveNextAsync();
+                }
+                catch (Exception ex)
+                {
+                    await enumerator.DisposeAsync();
+                    lastError = ex;
+                    index = AdvanceOrThrow(ex, index, stopwatch, mediaRestricted: false, apiKey);
+                    continue;
+                }
+
+                // First chunk obtained — the response is committed; stream through and let any
+                // later error propagate unchanged.
+                try
+                {
+                    while (hasFirst)
+                    {
+                        yield return enumerator.Current;
+                        hasFirst = await enumerator.MoveNextAsync();
+                    }
+                }
+                finally
+                {
+                    await enumerator.DisposeAsync();
+                }
+
+                yield break;
+            }
+
+            // Unreachable: AdvanceOrThrow rethrows when no candidate remains. Defensive only.
+            ExceptionDispatchInfo.Capture(lastError!).Throw();
+        }
+
+        /// <summary>
+        /// Verifies authentication for the first candidate (auth verification targets one
+        /// specific key by design).
+        /// </summary>
+        public Task<AuthenticationResult> VerifyAuthenticationAsync(
+            string? apiKey = null, string? baseUrl = null, CancellationToken cancellationToken = default)
+        {
+            if (_candidates[0].GetClient() is IAuthenticationVerifiable verifiable)
+            {
+                return verifiable.VerifyAuthenticationAsync(apiKey, baseUrl, cancellationToken);
+            }
+
+            return Task.FromResult(AuthenticationResult.Failure(
+                "Provider does not support authentication verification",
+                $"The {_candidates[0].GetClient().GetType().Name} client has not implemented authentication verification"));
+        }
+
+        /// <inheritdoc cref="IAuthenticationVerifiable.GetHealthCheckUrl" />
+        public string GetHealthCheckUrl(string? baseUrl = null)
+        {
+            if (_candidates[0].GetClient() is IAuthenticationVerifiable verifiable)
+            {
+                return verifiable.GetHealthCheckUrl(baseUrl);
+            }
+
+            return baseUrl ?? "https://api.provider.com/health";
+        }
+
+        private async Task<T> ExecuteWithFailoverAsync<T>(
+            Func<ILLMClient, CancellationToken, Task<T>> operation,
+            bool mediaRestricted,
+            string? apiKey,
+            CancellationToken cancellationToken)
+        {
+            // BYOK: rotating server-side keys under a caller-supplied key would be wrong.
+            if (apiKey != null)
+            {
+                RecordAttempt(_candidates[0]);
+                return await operation(_candidates[0].GetClient(), cancellationToken);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var index = 0;
+
+            while (true)
+            {
+                var candidate = _candidates[index];
+                RecordAttempt(candidate);
+
+                try
+                {
+                    return await operation(candidate.GetClient(), cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    index = AdvanceOrThrow(ex, index, stopwatch, mediaRestricted, apiKey);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decides the next candidate index for a failed attempt, or rethrows the original
+        /// exception (stack preserved) when failover must stop.
+        /// </summary>
+        private int AdvanceOrThrow(
+            Exception ex, int currentIndex, Stopwatch stopwatch, bool mediaRestricted, string? apiKey)
+        {
+            var action = FailoverErrorClassifier.Classify(ex);
+
+            if (apiKey != null
+                || action == FailoverAction.Abort
+                || (mediaRestricted && !FailoverErrorClassifier.IsAuthClassError(ex)))
+            {
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+
+            // A new attempt that cannot plausibly finish within the budget only adds latency.
+            var budget = TimeSpan.FromSeconds(_options.TotalBudgetSeconds);
+            if (stopwatch.Elapsed > 0.6 * budget)
+            {
+                _logger?.LogWarning(
+                    "Failover stopped after {Elapsed:F1}s (budget {Budget}s): not starting attempt {NextAttempt}",
+                    stopwatch.Elapsed.TotalSeconds, _options.TotalBudgetSeconds, currentIndex + 2);
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+
+            var next = NextIndex(currentIndex, action);
+            if (next < 0)
+            {
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+
+            _logger?.LogWarning(
+                ex,
+                "Failover attempt {Attempt}: {Action} after error on key {KeyId} (provider {ProviderId}) — advancing to key {NextKeyId} (provider {NextProviderId})",
+                currentIndex + 1,
+                action,
+                _candidates[currentIndex].KeyCredentialId,
+                _candidates[currentIndex].ProviderId,
+                _candidates[next].KeyCredentialId,
+                _candidates[next].ProviderId);
+
+            return next;
+        }
+
+        private int NextIndex(int currentIndex, FailoverAction action)
+        {
+            var current = _candidates[currentIndex];
+
+            for (var j = currentIndex + 1; j < _candidates.Count; j++)
+            {
+                var next = _candidates[j];
+                switch (action)
+                {
+                    case FailoverAction.NextKey:
+                        return j;
+
+                    case FailoverAction.NextProvider:
+                        // A different provider always qualifies; within the same provider, a
+                        // sibling key only helps if it points at a different endpoint.
+                        if (next.ProviderId != current.ProviderId ||
+                            !string.Equals(next.BaseUrl, current.BaseUrl, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return j;
+                        }
+                        continue;
+
+                    default:
+                        return -1;
+                }
+            }
+
+            return -1;
+        }
+
+        private void RecordAttempt(FailoverCandidate candidate)
+        {
+            _attribution?.RecordAttempt(new FailoverAttribution(
+                candidate.ProviderId,
+                candidate.ProviderType,
+                candidate.KeyCredentialId,
+                candidate.ProviderModelId,
+                candidate.MappingId,
+                candidate.ModelCostId));
+        }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/FailoverCandidate.cs
+++ b/Shared/ConduitLLM.Core/Models/FailoverCandidate.cs
@@ -1,0 +1,48 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Core.Interfaces;
+
+namespace ConduitLLM.Core.Models;
+
+/// <summary>
+/// One (provider, key) pair the failover decorator can attempt, with a lazily built client
+/// chain. Each candidate builds the FULL existing decorator chain (base provider client →
+/// prompt caching → context-aware error tracking bound to this key → performance tracking),
+/// so per-key attribution and auto-disable behave exactly as they do without failover.
+/// </summary>
+public sealed record FailoverCandidate
+{
+    /// <summary>Canonical provider ID (never ProviderType) of this candidate.</summary>
+    public required int ProviderId { get; init; }
+
+    /// <summary>Provider type, carried for attribution/metrics.</summary>
+    public required ProviderType ProviderType { get; init; }
+
+    /// <summary>Key credential this candidate's chain is bound to.</summary>
+    public required int KeyCredentialId { get; init; }
+
+    /// <summary>External account group of the key (quota is typically shared per group), used
+    /// to order candidates so rate-limit/balance failures hop accounts. 0 = ungrouped.</summary>
+    public short ProviderAccountGroup { get; init; }
+
+    /// <summary>The provider-native model id this candidate's client was constructed with.</summary>
+    public required string ProviderModelId { get; init; }
+
+    /// <summary>Effective base URL of this candidate (key override or provider default) —
+    /// used to decide whether infrastructure errors are worth retrying on a sibling key.</summary>
+    public string? BaseUrl { get; init; }
+
+    /// <summary>Model mapping this candidate came from (provider-level failover attribution).</summary>
+    public int? MappingId { get; init; }
+
+    /// <summary>Cost configuration of this candidate's mapping (billing attribution when a
+    /// non-primary candidate serves the request).</summary>
+    public int? ModelCostId { get; init; }
+
+    /// <summary>Builds (and memoizes) the full client chain for this candidate.</summary>
+    public required Func<ILLMClient> ClientFactory { get; init; }
+
+    private ILLMClient? _client;
+
+    /// <summary>Gets the memoized client chain, building it on first use.</summary>
+    public ILLMClient GetClient() => _client ??= ClientFactory();
+}

--- a/Shared/ConduitLLM.Core/Services/FailoverAttributionAccessor.cs
+++ b/Shared/ConduitLLM.Core/Services/FailoverAttributionAccessor.cs
@@ -1,0 +1,56 @@
+using ConduitLLM.Configuration;
+
+namespace ConduitLLM.Core.Services;
+
+/// <summary>
+/// Attribution snapshot for the candidate that produced the response (or the final failure).
+/// </summary>
+public sealed record FailoverAttribution(
+    int ProviderId,
+    ProviderType ProviderType,
+    int KeyCredentialId,
+    string ProviderModelId,
+    int? MappingId,
+    int? ModelCostId);
+
+/// <summary>
+/// Request-scoped bridge between the failover decorator and gateway middleware: the decorator
+/// records the candidate before each attempt (last write wins = the serving candidate), and
+/// usage/billing middleware plus controllers read it to attribute the request correctly and to
+/// surface the <c>X-Conduit-Fallback</c> header.
+/// </summary>
+/// <remarks>
+/// This is deliberately a scoped service and NOT an AsyncLocal: values set inside the
+/// controller's async flow do not propagate upward to middleware, while a scoped instance is
+/// shared by the (scoped) client factory and everything else in the request scope.
+/// </remarks>
+public interface IFailoverAttributionAccessor
+{
+    /// <summary>The most recently attempted candidate (the serving one once a response exists).</summary>
+    FailoverAttribution? Current { get; }
+
+    /// <summary>Number of candidates attempted so far in this request.</summary>
+    int AttemptCount { get; }
+
+    /// <summary>True when more than one candidate was attempted.</summary>
+    bool FailoverOccurred { get; }
+
+    /// <summary>Records the candidate about to be attempted.</summary>
+    void RecordAttempt(FailoverAttribution attribution);
+}
+
+/// <inheritdoc />
+public sealed class FailoverAttributionAccessor : IFailoverAttributionAccessor
+{
+    public FailoverAttribution? Current { get; private set; }
+
+    public int AttemptCount { get; private set; }
+
+    public bool FailoverOccurred => AttemptCount > 1;
+
+    public void RecordAttempt(FailoverAttribution attribution)
+    {
+        Current = attribution;
+        AttemptCount++;
+    }
+}

--- a/Shared/ConduitLLM.Core/Services/FailoverErrorClassifier.cs
+++ b/Shared/ConduitLLM.Core/Services/FailoverErrorClassifier.cs
@@ -1,0 +1,121 @@
+using System.Net;
+
+using ConduitLLM.Core.Exceptions;
+
+namespace ConduitLLM.Core.Services;
+
+/// <summary>What the failover loop should do after a failed attempt.</summary>
+public enum FailoverAction
+{
+    /// <summary>Rethrow — retrying the identical request cannot succeed (user error,
+    /// cancellation, or an unrecognizable failure).</summary>
+    Abort,
+
+    /// <summary>Key-scoped problem (bad key, exhausted balance/quota) — try the next enabled
+    /// key of the same provider.</summary>
+    NextKey,
+
+    /// <summary>Provider-scoped problem (model missing, infrastructure down) — every key of
+    /// this provider will fail the same way; move to the next provider (or, key-level-only
+    /// mode: a sibling key with a different endpoint).</summary>
+    NextProvider,
+}
+
+/// <summary>
+/// Maps a failed attempt's exception to a <see cref="FailoverAction"/>. Classification mirrors
+/// <c>ContextAwareLLMClient</c>'s error tracking so failover and key auto-disable always agree
+/// about what an error means.
+/// </summary>
+public static class FailoverErrorClassifier
+{
+    public static FailoverAction Classify(Exception ex)
+    {
+        // Caller gone or budget expired — never mask a cancellation with another attempt.
+        if (ex is OperationCanceledException)
+        {
+            return FailoverAction.Abort;
+        }
+
+        var llmEx = ExtractLLMCommunicationException(ex);
+        if (llmEx == null)
+        {
+            // Validation errors, configuration errors, unknown exceptions: conservative abort.
+            return FailoverAction.Abort;
+        }
+
+        return llmEx.StatusCode switch
+        {
+            HttpStatusCode.Unauthorized => FailoverAction.NextKey,        // 401 invalid key
+            HttpStatusCode.PaymentRequired => FailoverAction.NextKey,     // 402 balance (per account)
+            HttpStatusCode.Forbidden => FailoverAction.NextKey,           // 403 key/account scoped
+            HttpStatusCode.TooManyRequests => FailoverAction.NextKey,     // 429 after the HTTP-layer
+                                                                          // retry budget; ordering
+                                                                          // prefers other account groups
+            HttpStatusCode.NotFound => FailoverAction.NextProvider,       // 404 model — same for every key
+            HttpStatusCode.BadRequest => FailoverAction.Abort,            // user error
+            HttpStatusCode.RequestTimeout => FailoverAction.NextProvider,
+            >= HttpStatusCode.InternalServerError => FailoverAction.NextProvider,
+            // No status code: network failure, open circuit, or processing error — treat as
+            // provider infrastructure.
+            null => FailoverAction.NextProvider,
+            _ => FailoverAction.Abort,
+        };
+    }
+
+    /// <summary>
+    /// True when an action is allowed for media generation under the restricted policy:
+    /// only auth-class errors (401/402/403) may fail over — a timeout or 5xx may mean the
+    /// provider accepted the generation job, and retrying would double-generate.
+    /// </summary>
+    public static bool IsAuthClassError(Exception ex)
+    {
+        var status = ExtractLLMCommunicationException(ex)?.StatusCode;
+        return status is HttpStatusCode.Unauthorized
+            or HttpStatusCode.PaymentRequired
+            or HttpStatusCode.Forbidden;
+    }
+
+    /// <summary>
+    /// Walks an exception (and its inner chain) for the most specific
+    /// <see cref="LLMCommunicationException"/>: first one carrying a status code, else the
+    /// first one found at all. Shared by failover classification and
+    /// <c>ContextAwareLLMClient</c> error tracking.
+    /// </summary>
+    public static LLMCommunicationException? ExtractLLMCommunicationException(Exception ex)
+    {
+        // Check if it's already an LLMCommunicationException with a StatusCode
+        if (ex is LLMCommunicationException llmEx && llmEx.StatusCode.HasValue)
+            return llmEx;
+
+        // If it's an LLMCommunicationException without StatusCode, check its inner exceptions
+        if (ex is LLMCommunicationException outerLlmEx && outerLlmEx.InnerException != null)
+        {
+            var innerWithStatus = ExtractLLMCommunicationException(outerLlmEx.InnerException);
+            if (innerWithStatus != null)
+                return innerWithStatus;
+        }
+
+        // Check inner exceptions recursively for any LLMCommunicationException with StatusCode
+        var current = ex.InnerException;
+        while (current != null)
+        {
+            if (current is LLMCommunicationException innerLlmEx && innerLlmEx.StatusCode.HasValue)
+                return innerLlmEx;
+            current = current.InnerException;
+        }
+
+        // If we only found exceptions without StatusCode, return the first one we found
+        if (ex is LLMCommunicationException firstLlmEx)
+            return firstLlmEx;
+
+        current = ex.InnerException;
+        while (current != null)
+        {
+            if (current is LLMCommunicationException innerLlmEx)
+                return innerLlmEx;
+            current = current.InnerException;
+        }
+
+        return null;
+    }
+}

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -4,11 +4,15 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Decorators;
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Providers.Configuration;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using FailoverOptions = ConduitLLM.Core.Configuration.FailoverOptions;
 
 namespace ConduitLLM.Providers
 {
@@ -84,8 +88,114 @@ namespace ConduitLLM.Providers
                 throw new ServiceUnavailableException($"Provider for model '{modelName}' is not available.", "Provider");
             }
 
+            // In-request key failover: wrap an ordered candidate list when enabled and more
+            // than one key is available. Flag off or a single key → today's chain, unchanged.
+            var failoverOptions = _serviceProvider.GetService<IOptions<FailoverOptions>>()?.Value;
+            if (failoverOptions?.Enabled == true)
+            {
+                var failoverClient = await TryCreateFailoverClientAsync(provider, mapping, failoverOptions);
+                if (failoverClient != null)
+                {
+                    return failoverClient;
+                }
+            }
+
             var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
             return CreateClientForProvider(provider, primaryKey, mapping.ProviderModelId);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="FailoverLLMClient"/> over the provider's enabled keys, or null
+        /// when only one key exists (single-key requests keep the plain chain).
+        /// </summary>
+        private async Task<ILLMClient?> TryCreateFailoverClientAsync(
+            Provider provider,
+            ModelProviderMapping mapping,
+            FailoverOptions failoverOptions)
+        {
+            if (!provider.IsEnabled)
+            {
+                throw new ServiceUnavailableException(
+                    $"Provider '{provider.ProviderName}' is currently disabled.", provider.ProviderName);
+            }
+
+            var keys = OrderKeysForFailover(
+                await _credentialService.GetKeyCredentialsByProviderIdAsync(provider.Id),
+                failoverOptions.MaxKeyAttemptsPerProvider);
+
+            if (keys.Count == 0)
+            {
+                throw new ConfigurationException($"No API key configured for provider '{provider.ProviderName}'.");
+            }
+
+            if (keys.Count == 1)
+            {
+                return null; // nothing to fail over to — use the plain chain
+            }
+
+            var candidates = keys.Select(key => new FailoverCandidate
+            {
+                ProviderId = provider.Id,
+                ProviderType = provider.ProviderType,
+                KeyCredentialId = key.Id,
+                ProviderAccountGroup = key.ProviderAccountGroup,
+                ProviderModelId = mapping.ProviderModelId,
+                BaseUrl = key.BaseUrl ?? provider.BaseUrl,
+                MappingId = mapping.Id,
+                ModelCostId = mapping.ModelProviderTypeAssociation?.ModelCostId,
+                ClientFactory = () => CreateClientForProvider(provider, key, mapping.ProviderModelId),
+            }).ToList();
+
+            _logger.LogDebug(
+                "Failover enabled for provider {ProviderId}: {CandidateCount} key candidates (keys: {KeyIds})",
+                provider.Id, candidates.Count, string.Join(",", candidates.Select(c => c.KeyCredentialId)));
+
+            return new FailoverLLMClient(
+                candidates,
+                failoverOptions,
+                _serviceProvider.GetService<IFailoverAttributionAccessor>(),
+                _loggerFactory.CreateLogger<FailoverLLMClient>());
+        }
+
+        /// <summary>
+        /// Orders enabled keys for failover: the primary key first (preserving today's
+        /// selection for attempt #1), then remaining keys round-robin across
+        /// ProviderAccountGroup values starting with groups different from the primary's —
+        /// quota and balance are shared per external account, so 429/402 failures should hop
+        /// accounts rather than retry a sibling key of the same account.
+        /// </summary>
+        internal static List<ProviderKeyCredential> OrderKeysForFailover(
+            IEnumerable<ProviderKeyCredential> keyCredentials, int maxKeys)
+        {
+            var enabled = keyCredentials.Where(k => k.IsEnabled).OrderBy(k => k.Id).ToList();
+            if (enabled.Count == 0)
+            {
+                return new List<ProviderKeyCredential>();
+            }
+
+            var primary = enabled.FirstOrDefault(k => k.IsPrimary) ?? enabled[0];
+            var ordered = new List<ProviderKeyCredential> { primary };
+
+            var groupQueues = enabled
+                .Where(k => k.Id != primary.Id)
+                .GroupBy(k => k.ProviderAccountGroup)
+                .OrderBy(g => g.Key == primary.ProviderAccountGroup ? 1 : 0) // other accounts first
+                .ThenBy(g => g.Key)
+                .Select(g => new Queue<ProviderKeyCredential>(g))
+                .ToList();
+
+            while (ordered.Count < maxKeys && groupQueues.Any(q => q.Count > 0))
+            {
+                foreach (var queue in groupQueues)
+                {
+                    if (queue.Count > 0 && ordered.Count < maxKeys)
+                    {
+                        ordered.Add(queue.Dequeue());
+                    }
+                }
+            }
+
+            return ordered;
         }
 
         /// <inheritdoc />

--- a/Shared/ConduitLLM.Providers/Extensions/ServiceCollectionExtensions.cs
+++ b/Shared/ConduitLLM.Providers/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
+using ConduitLLM.Core.Configuration;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,6 +29,25 @@ namespace ConduitLLM.Providers.Extensions
             // Every host that creates provider clients needs the named HttpClients with the
             // resilience pipeline — registering here (idempotently) means no host can forget
             services.AddLLMProviderHttpClients();
+
+            // In-request failover (default off; enable via CONDUIT_FAILOVER_ENABLED or
+            // Conduit:Failover:Enabled). The attribution accessor is request-scoped so gateway
+            // middleware can read which candidate actually served the request.
+            services.AddOptions<FailoverOptions>()
+                .BindConfiguration(FailoverOptions.SectionName)
+                .ValidateDataAnnotations();
+            services.PostConfigure<FailoverOptions>(options =>
+            {
+                if (bool.TryParse(Environment.GetEnvironmentVariable("CONDUIT_FAILOVER_ENABLED"), out var enabled))
+                {
+                    options.Enabled = enabled;
+                }
+                if (bool.TryParse(Environment.GetEnvironmentVariable("CONDUIT_PROVIDER_FAILOVER_ENABLED"), out var providerEnabled))
+                {
+                    options.ProviderFailoverEnabled = providerEnabled;
+                }
+            });
+            services.AddScoped<IFailoverAttributionAccessor, FailoverAttributionAccessor>();
 
             // OBSOLETE: External model discovery is no longer used. 
             // The ProviderModelsController now returns models from the local database.

--- a/Tests/ConduitLLM.Tests/Core/Decorators/FailoverLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Decorators/FailoverLLMClientTests.cs
@@ -1,0 +1,389 @@
+using System.Net;
+
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Configuration;
+using ConduitLLM.Core.Decorators;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+using ConduitLLM.Providers;
+
+using Moq;
+
+using Xunit.Abstractions;
+
+namespace ConduitLLM.Tests.Core.Decorators
+{
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Core")]
+    public class FailoverLLMClientTests : TestBase
+    {
+        private readonly FailoverOptions _options = new() { Enabled = true };
+        private readonly FailoverAttributionAccessor _attribution = new();
+
+        public FailoverLLMClientTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static LLMCommunicationException Error(HttpStatusCode status)
+            => new($"error {(int)status}", status, null);
+
+        private static ChatCompletionRequest Request() => new()
+        {
+            Model = "test-model",
+            Messages = new List<Message> { new() { Role = MessageRole.User, Content = "hi" } },
+        };
+
+        private static ChatCompletionResponse Response(string id) => new()
+        {
+            Id = id,
+            Object = "chat.completion",
+            Created = 1,
+            Model = "test-model",
+            Choices = new List<Choice>(),
+        };
+
+        private FailoverCandidate Candidate(int keyId, ILLMClient client, int providerId = 1, string? baseUrl = "http://a", short accountGroup = 0)
+            => new()
+            {
+                ProviderId = providerId,
+                ProviderType = ProviderType.OpenAI,
+                KeyCredentialId = keyId,
+                ProviderAccountGroup = accountGroup,
+                ProviderModelId = "test-model",
+                BaseUrl = baseUrl,
+                ClientFactory = () => client,
+            };
+
+        private static Mock<ILLMClient> ClientReturning(ChatCompletionResponse response)
+        {
+            var mock = new Mock<ILLMClient>();
+            mock.Setup(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+            return mock;
+        }
+
+        private static Mock<ILLMClient> ClientThrowing(Exception ex)
+        {
+            var mock = new Mock<ILLMClient>();
+            mock.Setup(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(ex);
+            mock.Setup(c => c.CreateImageAsync(It.IsAny<ImageGenerationRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(ex);
+            return mock;
+        }
+
+        [Fact]
+        public async Task InvalidKeyOnPrimary_FailsOverToSecondKey()
+        {
+            var failing = ClientThrowing(Error(HttpStatusCode.Unauthorized));
+            var succeeding = ClientReturning(Response("from-key-2"));
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, failing.Object), Candidate(2, succeeding.Object) },
+                _options, _attribution, null);
+
+            var response = await sut.CreateChatCompletionAsync(Request());
+
+            Assert.Equal("from-key-2", response.Id);
+            Assert.Equal(2, _attribution.AttemptCount);
+            Assert.True(_attribution.FailoverOccurred);
+            Assert.Equal(2, _attribution.Current!.KeyCredentialId);
+            failing.Verify(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task BadRequest_DoesNotFailover_RethrowsOriginal()
+        {
+            var original = Error(HttpStatusCode.BadRequest);
+            var failing = ClientThrowing(original);
+            var second = ClientReturning(Response("never"));
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, failing.Object), Candidate(2, second.Object) },
+                _options, _attribution, null);
+
+            var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+                () => sut.CreateChatCompletionAsync(Request()));
+
+            Assert.Same(original, thrown);
+            Assert.Equal(1, _attribution.AttemptCount);
+            second.Verify(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AllCandidatesFail_LastExceptionRethrown()
+        {
+            var first = ClientThrowing(Error(HttpStatusCode.Unauthorized));
+            var lastError = Error(HttpStatusCode.PaymentRequired);
+            var second = ClientThrowing(lastError);
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, first.Object), Candidate(2, second.Object) },
+                _options, _attribution, null);
+
+            var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+                () => sut.CreateChatCompletionAsync(Request()));
+
+            Assert.Same(lastError, thrown);
+            Assert.Equal(2, _attribution.AttemptCount);
+        }
+
+        [Fact]
+        public async Task ServerError_SameEndpointSiblingKey_Aborts()
+        {
+            // 500 is provider-infrastructure-scoped: a sibling key on the SAME BaseUrl cannot
+            // help, so key-level failover must abort rather than burn an attempt.
+            var original = Error(HttpStatusCode.InternalServerError);
+            var failing = ClientThrowing(original);
+            var second = ClientReturning(Response("never"));
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failing.Object, baseUrl: "http://same"),
+                    Candidate(2, second.Object, baseUrl: "http://same"),
+                },
+                _options, _attribution, null);
+
+            var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+                () => sut.CreateChatCompletionAsync(Request()));
+
+            Assert.Same(original, thrown);
+            second.Verify(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ServerError_DifferentEndpointSiblingKey_FailsOver()
+        {
+            var failing = ClientThrowing(Error(HttpStatusCode.InternalServerError));
+            var second = ClientReturning(Response("other-endpoint"));
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failing.Object, baseUrl: "http://a"),
+                    Candidate(2, second.Object, baseUrl: "http://b"),
+                },
+                _options, _attribution, null);
+
+            var response = await sut.CreateChatCompletionAsync(Request());
+
+            Assert.Equal("other-endpoint", response.Id);
+        }
+
+        [Fact]
+        public async Task ByokApiKey_BypassesFailover()
+        {
+            var failing = ClientThrowing(Error(HttpStatusCode.Unauthorized));
+            var second = ClientReturning(Response("never"));
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, failing.Object), Candidate(2, second.Object) },
+                _options, _attribution, null);
+
+            await Assert.ThrowsAsync<LLMCommunicationException>(
+                () => sut.CreateChatCompletionAsync(Request(), apiKey: "caller-supplied"));
+
+            Assert.Equal(1, _attribution.AttemptCount);
+            second.Verify(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CallerCancellation_Aborts_WithoutFurtherAttempts()
+        {
+            var failing = new Mock<ILLMClient>();
+            failing.Setup(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new OperationCanceledException());
+            var second = ClientReturning(Response("never"));
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, failing.Object), Candidate(2, second.Object) },
+                _options, _attribution, null);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => sut.CreateChatCompletionAsync(Request()));
+
+            second.Verify(c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Images_ServerError_DoesNotFailover_DoubleGenerationRisk()
+        {
+            var original = Error(HttpStatusCode.InternalServerError);
+            var failing = ClientThrowing(original);
+            var second = new Mock<ILLMClient>();
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failing.Object, baseUrl: "http://a"),
+                    Candidate(2, second.Object, baseUrl: "http://b"),
+                },
+                _options, _attribution, null);
+
+            var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+                () => sut.CreateImageAsync(new ImageGenerationRequest { Prompt = "p", Model = "m" }));
+
+            Assert.Same(original, thrown);
+            second.Verify(c => c.CreateImageAsync(It.IsAny<ImageGenerationRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Images_AuthError_DoesFailover()
+        {
+            var failing = ClientThrowing(Error(HttpStatusCode.Unauthorized));
+            var second = new Mock<ILLMClient>();
+            second.Setup(c => c.CreateImageAsync(It.IsAny<ImageGenerationRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ImageGenerationResponse { Created = 1, Data = new List<ImageData>() });
+
+            var sut = new FailoverLLMClient(
+                new[] { Candidate(1, failing.Object), Candidate(2, second.Object) },
+                _options, _attribution, null);
+
+            var response = await sut.CreateImageAsync(new ImageGenerationRequest { Prompt = "p", Model = "m" });
+
+            Assert.NotNull(response);
+            Assert.Equal(2, _attribution.Current!.KeyCredentialId);
+        }
+
+        [Fact]
+        public async Task Streaming_ErrorBeforeFirstChunk_FailsOverToFreshStream()
+        {
+            var failing = new Mock<ILLMClient>();
+            failing.Setup(c => c.StreamChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .Returns(ThrowingStream(Error(HttpStatusCode.ServiceUnavailable)));
+            var second = new Mock<ILLMClient>();
+            second.Setup(c => c.StreamChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .Returns(ChunkStream("a", "b", "c"));
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failing.Object, providerId: 1, baseUrl: "http://a"),
+                    Candidate(2, second.Object, providerId: 1, baseUrl: "http://b"),
+                },
+                _options, _attribution, null);
+
+            var chunks = new List<string>();
+            await foreach (var chunk in sut.StreamChatCompletionAsync(Request()))
+            {
+                chunks.Add(chunk.Id!);
+            }
+
+            Assert.Equal(new[] { "a", "b", "c" }, chunks);
+            Assert.True(_attribution.FailoverOccurred);
+        }
+
+        [Fact]
+        public async Task Streaming_ErrorAfterFirstChunk_Propagates_NoFailover()
+        {
+            var midStreamError = Error(HttpStatusCode.ServiceUnavailable);
+            var failing = new Mock<ILLMClient>();
+            failing.Setup(c => c.StreamChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .Returns(StreamThenThrow("first", midStreamError));
+            var second = new Mock<ILLMClient>();
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failing.Object, baseUrl: "http://a"),
+                    Candidate(2, second.Object, baseUrl: "http://b"),
+                },
+                _options, _attribution, null);
+
+            var chunks = new List<string>();
+            var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(async () =>
+            {
+                await foreach (var chunk in sut.StreamChatCompletionAsync(Request()))
+                {
+                    chunks.Add(chunk.Id!);
+                }
+            });
+
+            Assert.Same(midStreamError, thrown);
+            Assert.Equal(new[] { "first" }, chunks);
+            second.Verify(c => c.StreamChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public void OrderKeysForFailover_PrimaryFirst_ThenOtherAccountGroups()
+        {
+            var keys = new[]
+            {
+                new ProviderKeyCredential { Id = 1, IsEnabled = true, IsPrimary = false, ProviderAccountGroup = 0 },
+                new ProviderKeyCredential { Id = 2, IsEnabled = true, IsPrimary = true, ProviderAccountGroup = 0 },
+                new ProviderKeyCredential { Id = 3, IsEnabled = true, IsPrimary = false, ProviderAccountGroup = 1 },
+                new ProviderKeyCredential { Id = 4, IsEnabled = false, IsPrimary = false, ProviderAccountGroup = 1 },
+            };
+
+            var ordered = DatabaseAwareLLMClientFactory.OrderKeysForFailover(keys, maxKeys: 3);
+
+            // Primary (key 2) first; then key 3 (different account group than primary's group 0)
+            // before key 1 (same group as primary); disabled key 4 excluded.
+            Assert.Equal(new[] { 2, 3, 1 }, ordered.Select(k => k.Id));
+        }
+
+        [Fact]
+        public void OrderKeysForFailover_RespectsMaxKeys()
+        {
+            var keys = Enumerable.Range(1, 5)
+                .Select(i => new ProviderKeyCredential { Id = i, IsEnabled = true, IsPrimary = i == 1, ProviderAccountGroup = (short)i })
+                .ToArray();
+
+            var ordered = DatabaseAwareLLMClientFactory.OrderKeysForFailover(keys, maxKeys: 2);
+
+            Assert.Equal(2, ordered.Count);
+            Assert.Equal(1, ordered[0].Id);
+        }
+
+        [Fact]
+        public void PromptCacheInjection_Idempotent_AcrossFailoverRedispatch()
+        {
+            // Failover re-dispatches the SAME request object through a second candidate chain,
+            // which runs PromptCachingLLMClient's injection again. The mutation must be
+            // idempotent or the second attempt would send a different payload.
+            var request = Request();
+            var config = new PromptCachingConfig
+            {
+                AutoInjectEnabled = true,
+                InjectionPoints = new List<CacheInjectionPoint> { new() { Role = "user", Index = -1 } },
+            };
+
+            PromptCacheInjectionService.InjectCacheControl(request, config);
+            var afterFirst = System.Text.Json.JsonSerializer.Serialize(request.Messages);
+
+            PromptCacheInjectionService.InjectCacheControl(request, config);
+            var afterSecond = System.Text.Json.JsonSerializer.Serialize(request.Messages);
+
+            Assert.Equal(afterFirst, afterSecond);
+        }
+
+        private static async IAsyncEnumerable<ChatCompletionChunk> ThrowingStream(Exception ex)
+        {
+            await Task.Yield();
+            throw ex;
+#pragma warning disable CS0162
+            yield break;
+#pragma warning restore CS0162
+        }
+
+        private static async IAsyncEnumerable<ChatCompletionChunk> ChunkStream(params string[] ids)
+        {
+            foreach (var id in ids)
+            {
+                await Task.Yield();
+                yield return new ChatCompletionChunk { Id = id, Model = "test-model" };
+            }
+        }
+
+        private static async IAsyncEnumerable<ChatCompletionChunk> StreamThenThrow(string firstId, Exception ex)
+        {
+            await Task.Yield();
+            yield return new ChatCompletionChunk { Id = firstId, Model = "test-model" };
+            throw ex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 4 of the provider-resilience overhaul (**stacked on #1042** — only the last commit is new). Adds in-request **key-level failover**: when a provider call fails with a key-scoped error, the request is retried with the next enabled `ProviderKeyCredential` before the user ever sees an error. **Default OFF** (`CONDUIT_FAILOVER_ENABLED` / `Conduit:Failover:Enabled`); flag off = today''s single-client chain, byte for byte.

## Design

**`FailoverLLMClient`** — new outermost decorator over an ordered candidate list. Each candidate lazily builds the *full* existing chain (prompt caching → context-aware tracking bound to its own key → perf tracking), so per-key error tracking and auto-disable fire per attempt exactly as without failover; the failover layer itself tracks nothing. All six `Conduit.cs` call sites (chat, streaming, agentic ×2, embeddings, images) get failover with zero `Conduit.cs` changes.

**Classification** (`FailoverErrorClassifier`, shares exception-unwrapping with `ContextAwareLLMClient`):
| Error | Action |
|---|---|
| 401 / 402 / 403 / 429 (post-HTTP-retry-budget) | next key |
| 404 model, 5xx, timeout, network, open circuit | provider-scoped → within one provider only a sibling key on a **different BaseUrl** qualifies, else abort |
| 400 / validation / cancellation / unknown | abort — original exception rethrown, stack preserved |

**Candidate ordering** — primary key first (attempt #1 identical to today), then remaining keys round-robin across `ProviderAccountGroup` starting with groups *different* from the primary''s: quota and balance are shared per external account, so 429/402 hops accounts. This finally gives the dormant account-group field its documented behavior.

**Streaming** — failover only before the first chunk (HTTP 200 commits at the first SSE write); mid-stream errors propagate unchanged. **BYOK** bypasses failover. **Video** is excluded by construction — the decorator doesn''t expose `CreateVideoAsync`, so the video orchestrator''s chain-walk goes straight through. **Images** fail over on auth-class errors only (double-generation risk), unless `EnableFullMediaFailover`.

**Budgets** — `MaxKeyAttemptsPerProvider=2`, `MaxTotalAttempts=3`, `TotalBudgetSeconds=90` (no new attempt past 60% of budget; streaming budget applies pre-first-chunk only).

**Observability** — `X-Conduit-Fallback: attempts=<n>` response header (attempt count only — no upstream topology; set at first chunk for streaming, verified headers still writable), failover summary in RequestLog metadata JSON, structured warnings per advancement.

## Billing

**Zero impact**: all key candidates share the same provider, mapping, and ModelCostId. Attribution overrides land with provider-level failover. Prompt-cache request mutation verified **idempotent across re-dispatch** (pinned by test) — the second candidate sends an identical payload.

## Tests (14 new)

401→next-key success + attribution; 400 aborts with original exception; all-fail rethrows last; 500 aborts on same-endpoint sibling but fails over to different-endpoint sibling; BYOK single-attempt; cancellation aborts; images 500-no/401-yes; streaming pre-first-chunk failover + post-first-chunk propagation; account-group ordering; max-keys cap; prompt-cache idempotency.

Full suite: 2983 passed, 0 failed. Existing `ProviderFailoverIntegrationTests` (which assert fail-through) remain valid — flag defaults off.

## Rollout

Merge inert → enable `CONDUIT_FAILOVER_ENABLED=true` in staging → watch failover log lines + provider error dashboards → flip default in a later release.