### PR TITLE
feat(config): provider-level failover via ModelProviderMapping.Priority

### DIFF
--- a/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
@@ -81,12 +81,15 @@ public class ModelProviderMappingController : AdminControllerBase
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreateMapping([FromBody] ModelProviderMappingDto mappingDto)
     {
-        // Check if a mapping with the same model alias already exists
+        // An alias may map to multiple providers (failover chain), but only once per provider
         var existingMappings = await _mappingService.GetAllMappingsAsync();
-        var existingMapping = existingMappings.FirstOrDefault(m => m.ModelAlias.Equals(mappingDto.ModelAlias, StringComparison.OrdinalIgnoreCase));
+        var existingMapping = existingMappings.FirstOrDefault(m =>
+            m.ModelAlias.Equals(mappingDto.ModelAlias, StringComparison.OrdinalIgnoreCase) &&
+            m.ProviderId == mappingDto.ProviderId);
         if (existingMapping != null)
         {
-            return Conflict(new ErrorResponseDto($"A mapping for model alias '{mappingDto.ModelAlias}' already exists"));
+            return Conflict(new ErrorResponseDto(
+                $"A mapping for model alias '{mappingDto.ModelAlias}' and this provider already exists"));
         }
 
         var mapping = mappingDto.ToEntity();

--- a/Services/ConduitLLM.Admin/Services/AdminModelProviderMappingService.cs
+++ b/Services/ConduitLLM.Admin/Services/AdminModelProviderMappingService.cs
@@ -91,11 +91,14 @@ public class AdminModelProviderMappingService : EventPublishingServiceBase, IAdm
                 return false;
             }
 
-            // Check if a mapping with the same model ID already exists
-            var existingMapping = await _mappingRepository.GetByModelNameAsync(mapping.ModelAlias);
-            if (existingMapping != null)
+            // An alias may map to multiple providers (failover chain) but only once per
+            // provider — matches the DB unique constraint on (ModelAlias, ProviderId)
+            var siblingMappings = await _mappingRepository.GetAllByModelAliasAsync(mapping.ModelAlias);
+            if (siblingMappings.Any(m => m.ProviderId == mapping.ProviderId))
             {
-                _logger.LogWarning("A mapping for model ID already exists: {ModelId}", LoggingSanitizer.S(mapping.ModelAlias));
+                _logger.LogWarning(
+                    "A mapping already exists for alias {ModelAlias} and provider {ProviderId}",
+                    LoggingSanitizer.S(mapping.ModelAlias), mapping.ProviderId);
                 return false;
             }
 
@@ -161,7 +164,8 @@ public class AdminModelProviderMappingService : EventPublishingServiceBase, IAdm
             existingMapping.ProviderId = mapping.ProviderId;
             existingMapping.ModelProviderTypeAssociationId = mapping.ModelProviderTypeAssociationId;
             existingMapping.IsEnabled = mapping.IsEnabled;
-            
+            existingMapping.Priority = mapping.Priority;
+
             existingMapping.UpdatedAt = DateTime.UtcNow;
 
             // Update the mapping

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
@@ -76,6 +76,14 @@ namespace ConduitLLM.Gateway.Middleware
 
                 await _next(context);
 
+                // If in-request failover served this request from a non-primary candidate, the
+                // provider attribution pinned pre-request by the controller (ProviderId,
+                // ProviderType, ModelCostId in HttpContext.Items) points at the PRIMARY
+                // mapping. Overwrite it from the failover accessor BEFORE any cost calculation
+                // or request logging reads it — otherwise fallback traffic is billed at the
+                // wrong provider's cost and logged against the wrong provider.
+                ApplyFailoverAttributionOverride(context);
+
                 // After the controller has run, check if this is a streaming response
                 // by checking the Content-Type that was set by the controller
                 if (context.Response.ContentType?.Contains("text/event-stream") == true)
@@ -107,6 +115,54 @@ namespace ConduitLLM.Gateway.Middleware
             finally
             {
                 context.Response.Body = originalBodyStream;
+            }
+        }
+
+        /// <summary>
+        /// Rewrites the provider attribution in HttpContext.Items with the candidate that
+        /// actually served the request when in-request failover advanced past the primary.
+        /// Runs once, before every cost/logging consumer of these keys. Emits a billing audit
+        /// trail via the failover metadata appended to the request log.
+        /// </summary>
+        private void ApplyFailoverAttributionOverride(HttpContext context)
+        {
+            try
+            {
+                var attribution = context.RequestServices
+                    .GetService<ConduitLLM.Core.Services.IFailoverAttributionAccessor>();
+                if (attribution is not { FailoverOccurred: true } || attribution.Current == null)
+                {
+                    return;
+                }
+
+                var serving = attribution.Current;
+
+                var previousProviderId = context.Items.TryGetValue("ProviderId", out var prev) ? prev : null;
+                context.Items["ProviderId"] = serving.ProviderId;
+                context.Items["ProviderType"] = serving.ProviderType;
+
+                if (serving.ModelCostId.HasValue)
+                {
+                    context.Items[HttpContextKeys.ModelCostId] = serving.ModelCostId.Value;
+                }
+                else
+                {
+                    // The serving mapping has no cost config: remove the primary's ModelCostId
+                    // so cost falls back to the model-name path (which resolves against the
+                    // serving provider's echoed model id) instead of the wrong provider's rate.
+                    context.Items.Remove(HttpContextKeys.ModelCostId);
+                }
+
+                _logger.LogInformation(
+                    "Failover attribution override: request served by provider {ServingProviderId} " +
+                    "(key {KeyId}, mapping {MappingId}, modelCost {ModelCostId}) after {Attempts} attempts " +
+                    "(primary provider was {PrimaryProviderId})",
+                    serving.ProviderId, serving.KeyCredentialId, serving.MappingId, serving.ModelCostId,
+                    attribution.AttemptCount, previousProviderId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to apply failover attribution override");
             }
         }
 

--- a/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
+++ b/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
@@ -315,6 +315,11 @@ public static class CacheKeys
         /// <returns>Full cache key like "model:mapping:gpt-4"</returns>
         public static string ByAlias(string modelAlias) => $"model:mapping:{modelAlias}";
 
+        /// <summary>Builds a cache key for ALL enabled mappings of an alias (failover order)</summary>
+        /// <param name="modelAlias">The model alias</param>
+        /// <returns>Full cache key like "model:mapping:all-by-alias:gpt-4"</returns>
+        public static string AllByAlias(string modelAlias) => $"model:mapping:all-by-alias:{modelAlias}";
+
         /// <summary>Builds a cache key for mapping by ID</summary>
         /// <param name="id">The mapping ID</param>
         /// <returns>Full cache key like "model:mapping:id:123"</returns>

--- a/Shared/ConduitLLM.Configuration/Data/EntityConfigurationExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Data/EntityConfigurationExtensions.cs
@@ -19,7 +19,10 @@ namespace ConduitLLM.Configuration.Data
             {
                 entity.HasKey(e => e.Id);
                 entity.HasIndex(e => new { e.ModelAlias, e.ProviderId }).IsUnique();
-                    
+
+                // Provider-level failover walks enabled mappings per alias in priority order
+                entity.HasIndex(e => new { e.ModelAlias, e.IsEnabled, e.Priority });
+
                 // Configure relationship with Provider
                 entity.HasOne(e => e.Provider)
                     .WithMany()

--- a/Shared/ConduitLLM.Configuration/Entities/ModelProviderMapping.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ModelProviderMapping.cs
@@ -56,6 +56,13 @@ namespace ConduitLLM.Configuration.Entities
         public bool IsEnabled { get; set; } = true;
 
         /// <summary>
+        /// Routing priority among mappings sharing the same ModelAlias — lower values are
+        /// preferred (0 = primary). Provider-level failover walks enabled mappings in
+        /// ascending priority order.
+        /// </summary>
+        public int Priority { get; set; } = 0;
+
+        /// <summary>
         /// The UTC timestamp when this mapping was created.
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
@@ -35,7 +35,7 @@ namespace ConduitLLM.Configuration.Extensions
                 ProviderId = mapping.ProviderId,
                 Provider = mapping.Provider?.ToReferenceDto(),
                 ModelProviderTypeAssociationId = mapping.ModelProviderTypeAssociationId,
-                Priority = 0, // Entity doesn't have Priority
+                Priority = mapping.Priority,
                 IsEnabled = mapping.IsEnabled,
                 CreatedAt = mapping.CreatedAt,
                 UpdatedAt = mapping.UpdatedAt,
@@ -65,8 +65,9 @@ namespace ConduitLLM.Configuration.Extensions
             mapping.ProviderId = dto.ProviderId;
             mapping.ModelProviderTypeAssociationId = dto.ModelProviderTypeAssociationId;
             mapping.IsEnabled = dto.IsEnabled;
+            mapping.Priority = dto.Priority;
             mapping.UpdatedAt = System.DateTime.UtcNow;
-            // Note: Priority and Notes are DTO-only properties
+            // Note: Notes is a DTO-only property
         }
 
         /// <summary>

--- a/Shared/ConduitLLM.Configuration/Interfaces/IModelProviderMappingRepository.cs
+++ b/Shared/ConduitLLM.Configuration/Interfaces/IModelProviderMappingRepository.cs
@@ -33,6 +33,15 @@ namespace ConduitLLM.Configuration.Interfaces
         Task<Entities.ModelProviderMapping?> GetByModelNameAsync(string modelName, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Gets all ENABLED mappings for a model alias, ordered by ascending Priority then Id
+        /// (the provider-level failover candidate order).
+        /// </summary>
+        /// <param name="modelAlias">The model alias</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Enabled mappings in failover order (may be empty)</returns>
+        Task<List<Entities.ModelProviderMapping>> GetAllByModelAliasAsync(string modelAlias, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets all model provider mappings for a specific provider
         /// </summary>
         /// <param name="providerType">The provider type</param>

--- a/Shared/ConduitLLM.Configuration/Interfaces/IModelProviderMappingService.cs
+++ b/Shared/ConduitLLM.Configuration/Interfaces/IModelProviderMappingService.cs
@@ -13,6 +13,12 @@ namespace ConduitLLM.Configuration.Interfaces
         Task<Entities.ModelProviderMapping?> GetMappingByModelAliasAsync(string modelAlias);
 
         /// <summary>
+        /// Gets all ENABLED mappings for a model alias in failover order (ascending Priority,
+        /// then Id). Empty list when the alias is unknown.
+        /// </summary>
+        Task<List<Entities.ModelProviderMapping>> GetMappingsByModelAliasAsync(string modelAlias);
+
+        /// <summary>
         /// Validates and creates a new model provider mapping
         /// </summary>
         /// <param name="mapping">The mapping to create</param>

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719022625_AddPriorityToModelProviderMapping.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719022625_AddPriorityToModelProviderMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719022625_AddPriorityToModelProviderMapping")]
+    partial class AddPriorityToModelProviderMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719022625_AddPriorityToModelProviderMapping.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719022625_AddPriorityToModelProviderMapping.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriorityToModelProviderMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Priority",
+                table: "ModelProviderMappings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ModelProviderMappings_ModelAlias_IsEnabled_Priority",
+                table: "ModelProviderMappings",
+                columns: new[] { "ModelAlias", "IsEnabled", "Priority" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ModelProviderMappings_ModelAlias_IsEnabled_Priority",
+                table: "ModelProviderMappings");
+
+            migrationBuilder.DropColumn(
+                name: "Priority",
+                table: "ModelProviderMappings");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/ModelProviderMappingService.cs
+++ b/Shared/ConduitLLM.Configuration/ModelProviderMappingService.cs
@@ -131,6 +131,25 @@ namespace ConduitLLM.Configuration
             }
         }
 
+        public async Task<List<Entities.ModelProviderMapping>> GetMappingsByModelAliasAsync(string modelAlias)
+        {
+            if (string.IsNullOrEmpty(modelAlias))
+            {
+                throw new ArgumentException("Model alias cannot be null or empty", nameof(modelAlias));
+            }
+
+            try
+            {
+                _logger.LogDebug("Getting all mappings by model alias: {ModelAlias}", LoggingSanitizer.S(modelAlias));
+                return await _repository.GetAllByModelAliasAsync(modelAlias);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting mappings for model alias {ModelAlias}", LoggingSanitizer.S(modelAlias));
+                throw;
+            }
+        }
+
         public async Task UpdateMappingAsync(Entities.ModelProviderMapping mapping)
         {
             if (mapping == null)
@@ -142,8 +161,11 @@ namespace ConduitLLM.Configuration
             {
                 _logger.LogInformation("Updating mapping: {ModelAlias}", LoggingSanitizer.S(mapping.ModelAlias));
 
-                // Get the existing entity
-                var existingEntity = await _repository.GetByModelNameAsync(mapping.ModelAlias);
+                // Look up by Id when available — an alias can map to multiple providers now,
+                // so an alias lookup could grab a sibling mapping
+                var existingEntity = mapping.Id > 0
+                    ? await _repository.GetByIdAsync(mapping.Id)
+                    : await _repository.GetByModelNameAsync(mapping.ModelAlias);
                 if (existingEntity == null)
                 {
                     _logger.LogWarning("Mapping not found for model alias {ModelAlias}", LoggingSanitizer.S(mapping.ModelAlias));
@@ -175,6 +197,7 @@ namespace ConduitLLM.Configuration
                 existingEntity.ProviderModelId = mapping.ProviderModelId;
                 existingEntity.ProviderId = credential.Id;
                 existingEntity.IsEnabled = mapping.IsEnabled;
+                existingEntity.Priority = mapping.Priority;
                 existingEntity.ModelProviderTypeAssociationId = mapping.ModelProviderTypeAssociationId;
 
                 await _repository.UpdateAsync(existingEntity);
@@ -215,25 +238,68 @@ namespace ConduitLLM.Configuration
                     return (false, "ProviderId is required for model provider mapping", null);
                 }
 
-                // Check if a mapping with the same alias already exists
-                var existingMapping = await GetMappingByModelAliasAsync(mapping.ModelAlias);
-                if (existingMapping != null)
+                // Duplicate check matches the DB unique constraint: an alias may map to
+                // multiple providers (failover chain), but only once per provider
+                var siblingMappings = await GetMappingsByModelAliasAsync(mapping.ModelAlias);
+                if (siblingMappings.Any(m => m.ProviderId == mapping.ProviderId))
                 {
-                    _logger.LogWarning("Mapping already exists for model alias {ModelAlias}", LoggingSanitizer.S(mapping.ModelAlias));
-                    return (false, $"A mapping for this model alias already exists: {mapping.ModelAlias}", null);
+                    _logger.LogWarning(
+                        "Mapping already exists for model alias {ModelAlias} and provider {ProviderId}",
+                        LoggingSanitizer.S(mapping.ModelAlias), mapping.ProviderId);
+                    return (false, $"A mapping for model alias '{mapping.ModelAlias}' and this provider already exists.", null);
                 }
+
+                // Cross-model visibility: an alias whose mappings resolve to different canonical
+                // models is a legitimate resilience strategy, but silent model substitution
+                // deserves an operator warning (surfaced by the Admin API).
+                WarnIfCrossModelAlias(mapping, siblingMappings);
 
                 // Create the mapping
                 await AddMappingAsync(mapping);
 
-                // Return the created mapping
-                var createdMapping = await GetMappingByModelAliasAsync(mapping.ModelAlias);
+                // Return the created mapping (this provider's row, not an arbitrary sibling)
+                var createdMapping = (await GetMappingsByModelAliasAsync(mapping.ModelAlias))
+                    .FirstOrDefault(m => m.ProviderId == mapping.ProviderId)
+                    ?? await GetMappingByModelAliasAsync(mapping.ModelAlias);
                 return (true, null, createdMapping);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error creating model provider mapping for alias {ModelAlias}", LoggingSanitizer.S(mapping.ModelAlias));
                 return (false, $"An error occurred while creating the model provider mapping: {ex.Message}", null);
+            }
+        }
+
+        /// <summary>
+        /// Logs a warning when a new mapping's canonical model differs from existing sibling
+        /// mappings of the same alias (silent model substitution during failover).
+        /// </summary>
+        private void WarnIfCrossModelAlias(
+            Entities.ModelProviderMapping mapping,
+            List<Entities.ModelProviderMapping> siblingMappings)
+        {
+            try
+            {
+                var siblingModelIds = siblingMappings
+                    .Select(m => m.ModelProviderTypeAssociation?.ModelId)
+                    .Where(id => id.HasValue)
+                    .Select(id => id!.Value)
+                    .Distinct()
+                    .ToList();
+
+                if (siblingModelIds.Count > 0 && mapping.ModelProviderTypeAssociation?.ModelId is { } newModelId
+                    && !siblingModelIds.Contains(newModelId))
+                {
+                    _logger.LogWarning(
+                        "Alias {ModelAlias} now maps to DIFFERENT canonical models across providers " +
+                        "(new mapping model {NewModelId}, existing: {ExistingModelIds}). Failover will " +
+                        "silently substitute models — verify this is intended.",
+                        LoggingSanitizer.S(mapping.ModelAlias), newModelId, string.Join(",", siblingModelIds));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Cross-model alias check failed (non-fatal)");
             }
         }
 

--- a/Shared/ConduitLLM.Configuration/Repositories/ModelProviderMappingRepository.cs
+++ b/Shared/ConduitLLM.Configuration/Repositories/ModelProviderMappingRepository.cs
@@ -60,8 +60,36 @@ namespace ConduitLLM.Configuration.Repositories
             {
                 var query = GetDbSet(context).AsNoTracking();
                 query = ApplyDefaultIncludes(query);
-                return await query.FirstOrDefaultAsync(m => m.ModelAlias == modelName, cancellationToken);
+                // Deterministic: the highest-priority mapping wins (was an arbitrary
+                // FirstOrDefault before multiple mappings per alias were allowed)
+                return await query
+                    .Where(m => m.ModelAlias == modelName)
+                    .OrderBy(m => m.Priority)
+                    .ThenBy(m => m.Id)
+                    .FirstOrDefaultAsync(cancellationToken);
             }, cancellationToken, $"getting by model name {LoggingSanitizer.S(modelName)}");
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<ModelProviderMapping>> GetAllByModelAliasAsync(
+            string modelAlias,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(modelAlias))
+            {
+                throw new ArgumentException("Model alias cannot be null or empty", nameof(modelAlias));
+            }
+
+            return await ExecuteAsync(async context =>
+            {
+                var query = GetDbSet(context).AsNoTracking();
+                query = ApplyDefaultIncludes(query);
+                return await query
+                    .Where(m => m.ModelAlias == modelAlias && m.IsEnabled)
+                    .OrderBy(m => m.Priority)
+                    .ThenBy(m => m.Id)
+                    .ToListAsync(cancellationToken);
+            }, cancellationToken, $"getting all by model alias {LoggingSanitizer.S(modelAlias)}");
         }
 
         /// <inheritdoc/>

--- a/Shared/ConduitLLM.Core/Services/CachedModelProviderMappingService.cs
+++ b/Shared/ConduitLLM.Core/Services/CachedModelProviderMappingService.cs
@@ -115,6 +115,43 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <summary>
+        /// Gets all enabled mappings for an alias (failover order) with caching.
+        /// </summary>
+        public async Task<List<ModelProviderMapping>> GetMappingsByModelAliasAsync(string modelAlias)
+        {
+            if (string.IsNullOrEmpty(modelAlias))
+            {
+                throw new ArgumentException("Model alias cannot be null or empty", nameof(modelAlias));
+            }
+
+            var cacheKey = CacheKeys.ModelMapping.AllByAlias(modelAlias);
+
+            try
+            {
+                var cached = await _cacheManager.GetOrCreateAsync(
+                    cacheKey,
+                    async () => await _innerService.GetMappingsByModelAliasAsync(modelAlias),
+                    Region,
+                    CacheTtl);
+
+                if (cached == null || cached.Any(IsMissingNavigationGraph))
+                {
+                    LogIncompleteCacheEntry($"alias list '{modelAlias}'");
+                    var fresh = await _innerService.GetMappingsByModelAliasAsync(modelAlias);
+                    await _cacheManager.SetAsync(cacheKey, fresh, Region, CacheTtl);
+                    return fresh;
+                }
+
+                return cached;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Cache operation failed for alias list '{ModelAlias}', falling back to database", modelAlias);
+                return await _innerService.GetMappingsByModelAliasAsync(modelAlias);
+            }
+        }
+
+        /// <summary>
         /// Gets all mappings with caching.
         /// </summary>
         public async Task<List<ModelProviderMapping>> GetAllMappingsAsync()
@@ -320,10 +357,11 @@ namespace ConduitLLM.Core.Services
                 // Always invalidate the ID-based key
                 keysToRemove.Add(CacheKeys.ModelMapping.ById(id));
 
-                // Invalidate alias-based key if we know the alias
+                // Invalidate alias-based keys if we know the alias
                 if (!string.IsNullOrEmpty(modelAlias))
                 {
                     keysToRemove.Add(CacheKeys.ModelMapping.ByAlias(modelAlias));
+                    keysToRemove.Add(CacheKeys.ModelMapping.AllByAlias(modelAlias));
                 }
 
                 // Invalidate the "all mappings" cache

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -88,12 +88,12 @@ namespace ConduitLLM.Providers
                 throw new ServiceUnavailableException($"Provider for model '{modelName}' is not available.", "Provider");
             }
 
-            // In-request key failover: wrap an ordered candidate list when enabled and more
-            // than one key is available. Flag off or a single key → today's chain, unchanged.
+            // In-request failover: wrap an ordered candidate list when enabled and more than
+            // one candidate is available. Flag off or a single candidate → today's chain.
             var failoverOptions = _serviceProvider.GetService<IOptions<FailoverOptions>>()?.Value;
             if (failoverOptions?.Enabled == true)
             {
-                var failoverClient = await TryCreateFailoverClientAsync(provider, mapping, failoverOptions);
+                var failoverClient = await TryCreateFailoverClientAsync(modelName, provider, mapping, failoverOptions);
                 if (failoverClient != null)
                 {
                     return failoverClient;
@@ -105,56 +105,107 @@ namespace ConduitLLM.Providers
         }
 
         /// <summary>
-        /// Builds a <see cref="FailoverLLMClient"/> over the provider's enabled keys, or null
-        /// when only one key exists (single-key requests keep the plain chain).
+        /// Builds a <see cref="FailoverLLMClient"/> over the failover candidates for a model
+        /// alias — keys of the primary provider, plus (when provider-level failover is on)
+        /// keys of fallback providers mapped to the same alias in priority order. Returns null
+        /// when only a single candidate exists (the plain chain is used instead).
         /// </summary>
         private async Task<ILLMClient?> TryCreateFailoverClientAsync(
-            Provider provider,
-            ModelProviderMapping mapping,
+            string modelAlias,
+            Provider primaryProvider,
+            ModelProviderMapping primaryMapping,
             FailoverOptions failoverOptions)
         {
-            if (!provider.IsEnabled)
+            if (!primaryProvider.IsEnabled)
             {
                 throw new ServiceUnavailableException(
-                    $"Provider '{provider.ProviderName}' is currently disabled.", provider.ProviderName);
+                    $"Provider '{primaryProvider.ProviderName}' is currently disabled.", primaryProvider.ProviderName);
             }
 
-            var keys = OrderKeysForFailover(
-                await _credentialService.GetKeyCredentialsByProviderIdAsync(provider.Id),
-                failoverOptions.MaxKeyAttemptsPerProvider);
+            var candidates = new List<FailoverCandidate>();
 
-            if (keys.Count == 0)
+            await AddProviderCandidatesAsync(candidates, primaryProvider, primaryMapping, failoverOptions);
+
+            if (candidates.Count == 0)
             {
-                throw new ConfigurationException($"No API key configured for provider '{provider.ProviderName}'.");
+                throw new ConfigurationException($"No API key configured for provider '{primaryProvider.ProviderName}'.");
             }
 
-            if (keys.Count == 1)
+            if (failoverOptions.ProviderFailoverEnabled)
+            {
+                var fallbackMappings = (await _mappingService.GetMappingsByModelAliasAsync(modelAlias))
+                    .Where(m => m.ProviderId != primaryProvider.Id);
+
+                foreach (var fallbackMapping in fallbackMappings)
+                {
+                    if (candidates.Count >= failoverOptions.MaxTotalAttempts)
+                    {
+                        break;
+                    }
+
+                    var fallbackProvider = fallbackMapping.Provider
+                        ?? await _credentialService.GetProviderByIdAsync(fallbackMapping.ProviderId);
+                    if (fallbackProvider is not { IsEnabled: true })
+                    {
+                        continue;
+                    }
+
+                    await AddProviderCandidatesAsync(candidates, fallbackProvider, fallbackMapping, failoverOptions);
+                }
+            }
+
+            if (candidates.Count > failoverOptions.MaxTotalAttempts)
+            {
+                candidates = candidates.Take(failoverOptions.MaxTotalAttempts).ToList();
+            }
+
+            if (candidates.Count <= 1)
             {
                 return null; // nothing to fail over to — use the plain chain
             }
 
-            var candidates = keys.Select(key => new FailoverCandidate
-            {
-                ProviderId = provider.Id,
-                ProviderType = provider.ProviderType,
-                KeyCredentialId = key.Id,
-                ProviderAccountGroup = key.ProviderAccountGroup,
-                ProviderModelId = mapping.ProviderModelId,
-                BaseUrl = key.BaseUrl ?? provider.BaseUrl,
-                MappingId = mapping.Id,
-                ModelCostId = mapping.ModelProviderTypeAssociation?.ModelCostId,
-                ClientFactory = () => CreateClientForProvider(provider, key, mapping.ProviderModelId),
-            }).ToList();
-
             _logger.LogDebug(
-                "Failover enabled for provider {ProviderId}: {CandidateCount} key candidates (keys: {KeyIds})",
-                provider.Id, candidates.Count, string.Join(",", candidates.Select(c => c.KeyCredentialId)));
+                "Failover enabled for alias {ModelAlias}: {CandidateCount} candidates ({Candidates})",
+                modelAlias,
+                candidates.Count,
+                string.Join(",", candidates.Select(c => $"p{c.ProviderId}/k{c.KeyCredentialId}")));
 
             return new FailoverLLMClient(
                 candidates,
                 failoverOptions,
                 _serviceProvider.GetService<IFailoverAttributionAccessor>(),
                 _loggerFactory.CreateLogger<FailoverLLMClient>());
+        }
+
+        /// <summary>
+        /// Appends one provider's key candidates (ordered per <see cref="OrderKeysForFailover"/>)
+        /// carrying that provider's mapping attribution (ProviderModelId, MappingId, ModelCostId).
+        /// </summary>
+        private async Task AddProviderCandidatesAsync(
+            List<FailoverCandidate> candidates,
+            Provider provider,
+            ModelProviderMapping mapping,
+            FailoverOptions failoverOptions)
+        {
+            var keys = OrderKeysForFailover(
+                await _credentialService.GetKeyCredentialsByProviderIdAsync(provider.Id),
+                failoverOptions.MaxKeyAttemptsPerProvider);
+
+            foreach (var key in keys)
+            {
+                candidates.Add(new FailoverCandidate
+                {
+                    ProviderId = provider.Id,
+                    ProviderType = provider.ProviderType,
+                    KeyCredentialId = key.Id,
+                    ProviderAccountGroup = key.ProviderAccountGroup,
+                    ProviderModelId = mapping.ProviderModelId,
+                    BaseUrl = key.BaseUrl ?? provider.BaseUrl,
+                    MappingId = mapping.Id,
+                    ModelCostId = mapping.ModelProviderTypeAssociation?.ModelCostId,
+                    ClientFactory = () => CreateClientForProvider(provider, key, mapping.ProviderModelId),
+                });
+            }
         }
 
         /// <summary>

--- a/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.AddMapping.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Controllers/ModelProviderMappingControllerTests.AddMapping.cs
@@ -77,11 +77,11 @@ namespace ConduitLLM.Tests.Admin.Controllers
                 Id = 100,
                 ModelAlias = "existing-model",
                 ModelProviderTypeAssociationId = 2,
-                ProviderId = 2,
+                ProviderId = 1, // same provider as the new mapping — this is the conflict
                 ProviderModelId = "gpt-4-old"
             };
 
-            // Mock GetAllMappingsAsync to return existing mapping with same alias
+            // Mock GetAllMappingsAsync to return existing mapping with same alias AND provider
             _mockService.Setup(x => x.GetAllMappingsAsync())
                 .ReturnsAsync(new List<ModelProviderMapping> { existingMapping });
 
@@ -91,7 +91,44 @@ namespace ConduitLLM.Tests.Admin.Controllers
             // Assert
             var conflictResult = actionResult.Should().BeOfType<ConflictObjectResult>().Subject;
             var errorResponse = conflictResult.Value.Should().BeOfType<ErrorResponseDto>().Subject;
-            errorResponse.error.ToString().Should().Contain("A mapping for model alias 'existing-model' already exists");
+            errorResponse.error.ToString().Should().Contain("A mapping for model alias 'existing-model' and this provider already exists");
+        }
+
+        [Fact]
+        public async Task AddMapping_SameAliasDifferentProvider_IsAllowed_ForFailoverChains()
+        {
+            // Arrange: alias already mapped to provider 2; the new mapping targets provider 1.
+            // Multiple providers per alias form a failover chain and must NOT conflict.
+            var mapping = new ModelProviderMapping
+            {
+                ModelAlias = "existing-model",
+                ModelProviderTypeAssociationId = 1,
+                ProviderId = 1,
+                ProviderModelId = "gpt-4"
+            };
+
+            var existingMapping = new ModelProviderMapping
+            {
+                Id = 100,
+                ModelAlias = "existing-model",
+                ModelProviderTypeAssociationId = 2,
+                ProviderId = 2,
+                ProviderModelId = "gpt-4-old"
+            };
+
+            _mockService.Setup(x => x.GetAllMappingsAsync())
+                .ReturnsAsync(new List<ModelProviderMapping> { existingMapping });
+            _mockService.Setup(x => x.AddMappingAsync(It.IsAny<ModelProviderMapping>()))
+                .ReturnsAsync(true);
+            _mockService.Setup(x => x.GetMappingByIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(mapping);
+
+            // Act
+            var actionResult = await _controller.CreateMapping(mapping.ToDto());
+
+            // Assert
+            actionResult.Should().NotBeOfType<ConflictObjectResult>();
+            _mockService.Verify(x => x.AddMappingAsync(It.IsAny<ModelProviderMapping>()), Times.Once);
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Configuration/Services/CachedModelProviderMappingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Services/CachedModelProviderMappingServiceTests.cs
@@ -250,9 +250,9 @@ namespace ConduitLLM.Tests.Configuration.Services
             // Assert
             _mockInnerService.Verify(x => x.UpdateMappingAsync(mapping), Times.Once);
 
-            // Verify cache invalidation
+            // Verify cache invalidation: by-id, by-alias, all-by-alias (failover list), all-mappings
             _mockCacheManager.Verify(x => x.RemoveManyAsync(
-                It.Is<IEnumerable<string>>(keys => keys.Count() == 3),
+                It.Is<IEnumerable<string>>(keys => keys.Count() == 4),
                 CacheRegion.ModelMetadata,
                 default), Times.Once);
         }

--- a/Tests/ConduitLLM.Tests/Core/Decorators/FailoverLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Decorators/FailoverLLMClientTests.cs
@@ -340,6 +340,58 @@ namespace ConduitLLM.Tests.Core.Decorators
         }
 
         [Fact]
+        public async Task ProviderScopedError_SkipsRemainingSameProviderKeys_JumpsToNextProvider()
+        {
+            var failingPrimary = ClientThrowing(Error(HttpStatusCode.ServiceUnavailable));
+            var siblingKeySameProvider = new Mock<ILLMClient>(); // must never be called (same endpoint)
+            var fallbackProvider = ClientReturning(Response("from-provider-2"));
+
+            var sut = new FailoverLLMClient(
+                new[]
+                {
+                    Candidate(1, failingPrimary.Object, providerId: 1, baseUrl: "http://p1"),
+                    Candidate(2, siblingKeySameProvider.Object, providerId: 1, baseUrl: "http://p1"),
+                    Candidate(3, fallbackProvider.Object, providerId: 2, baseUrl: "http://p2"),
+                },
+                _options, _attribution, null);
+
+            var response = await sut.CreateChatCompletionAsync(Request());
+
+            Assert.Equal("from-provider-2", response.Id);
+            Assert.Equal(2, _attribution.Current!.ProviderId);
+            siblingKeySameProvider.Verify(
+                c => c.CreateChatCompletionAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CrossProviderFailover_AttributionCarriesFallbackMappingCost()
+        {
+            var failing = ClientThrowing(Error(HttpStatusCode.NotFound)); // model gone at primary
+            var fallback = ClientReturning(Response("served"));
+
+            var primary = Candidate(1, failing.Object, providerId: 1, baseUrl: "http://p1") with
+            {
+                MappingId = 10,
+                ModelCostId = 100,
+            };
+            var secondary = Candidate(9, fallback.Object, providerId: 2, baseUrl: "http://p2") with
+            {
+                MappingId = 20,
+                ModelCostId = 200,
+            };
+
+            var sut = new FailoverLLMClient(new[] { primary, secondary }, _options, _attribution, null);
+
+            await sut.CreateChatCompletionAsync(Request());
+
+            // Billing attribution must follow the SERVING candidate's mapping, not the primary's.
+            Assert.Equal(20, _attribution.Current!.MappingId);
+            Assert.Equal(200, _attribution.Current.ModelCostId);
+            Assert.Equal(2, _attribution.Current.ProviderId);
+        }
+
+        [Fact]
         public void PromptCacheInjection_Idempotent_AcrossFailoverRedispatch()
         {
             // Failover re-dispatches the SAME request object through a second candidate chain,


### PR DESCRIPTION
## Summary

PR 5 of the provider-resilience overhaul (**stacked on #1043** — only the last commit is new). One model alias can now map to **multiple providers as an ordered failover chain** (`Priority`, lower = preferred), and the failover decorator crosses providers when the primary is down. Gated by `CONDUIT_PROVIDER_FAILOVER_ENABLED` (default **off**; requires the PR-4 flag too).

## Schema (expand-only, ADR-002 compliant)

- `ModelProviderMapping.Priority int NOT NULL DEFAULT 0` — this **realizes a contract the public DTO has declared all along**: `ModelProviderMappingDto.Priority` existed but `ToDto()` hardcoded `Priority = 0 // Entity doesn''t have Priority`.
- Non-unique index `(ModelAlias, IsEnabled, Priority)` for the failover lookup; the existing unique `(ModelAlias, ProviderId)` already permitted multi-provider aliases — only app code blocked it.
- `validate-migrations.ps1`: clean, no pending model changes. Rollback = flag off (column ignored by prior code).

## App changes

- Duplicate checks (shared service, Admin service, Admin controller) now match the DB constraint: once per (alias, provider).
- Singular `GetMappingByModelAliasAsync` is now **deterministic** (highest priority wins) — it was an arbitrary unordered `FirstOrDefault`, a latent bug the moment two rows existed.
- New plural `GetMappingsByModelAliasAsync` (enabled-only, priority order) through repository → service → cached decorator (new cache key `model:mapping:all-by-alias:*`, invalidated alongside existing keys).
- **Cross-model warning**: an alias mapping to different canonical models across providers is allowed (deliberate scope decision — it''s a legitimate resilience strategy) but logged loudly as silent model substitution.
- `UpdateMappingAsync` looks up by Id — an alias lookup could now hit a sibling row.
- Factory: candidate list = primary provider''s keys + fallback providers'' keys in mapping-priority order, each candidate carrying **its own** `ProviderModelId`, `MappingId`, `ModelCostId`; capped at `MaxTotalAttempts`.

## Billing attribution — the high-risk piece

`ChatController` pins `ProviderId`/`ProviderType`/`ModelCostId` into `HttpContext.Items` from the **primary** mapping *before* the LLM call. Unmitigated, fallback traffic would be **billed at the primary provider''s cost** and logged against the wrong provider — exactly the bug class the July revenue-loss audit dealt with.

Mitigation: `UsageTrackingMiddleware` rewrites those keys from the request-scoped failover accessor **immediately after the controller runs**, before *any* cost or logging consumer reads them (single choke point covers non-streaming, streaming, media, request-log, and billing-audit paths). When the serving mapping lacks a cost config, `ModelCostId` is removed so cost falls back to the model-name path, which resolves against the serving provider''s echoed model id.

**Before enabling in staging**: run the two-provider scenario below and the revenue-loss-audit billing queries with failover forced.

## Known nuance

`StreamingMetricsCollector` is constructed with the primary providerId pre-stream; under provider failover its label can be stale. Metrics-only, no billing impact; noted for a follow-up.

## Tests

Cross-provider skip (provider-scoped error skips remaining same-provider keys → next provider), attribution carries the fallback mapping/cost ids (the billing regression test at decorator level), Admin same-alias-different-provider allowed / same-provider 409, cache invalidation includes the new key. Full suite: **2986 passed, 0 failed**.

## Staging verification (before flag-on)

1. Alias mapped to two providers (P1 priority 0 with a broken key, P2 priority 1), both flags on → request 200 via P2, `X-Conduit-Fallback: attempts=2`.
2. Assert `RequestLog.ProviderId == P2` and cost == **P2''s** model cost.
3. Billing audit queries from the revenue-loss audit show no attribution drift.