### PR TITLE
feat(webadmin): failover chain UI with drag-to-reorder provider priority

### DIFF
--- a/SDKs/Node/Admin/src/models/modelMapping.ts
+++ b/SDKs/Node/Admin/src/models/modelMapping.ts
@@ -9,7 +9,11 @@ export interface ModelProviderMappingDto {
   providerModelId: string;
   modelProviderTypeAssociationId: number;  // REQUIRED: Links to provider-specific model metadata
   isEnabled: boolean;
-  priority: number;
+  priority: number;  // Lower = preferred; failover walks enabled mappings of an alias in ascending order
+  /** Canonical Model entity id (via the association) — lets clients detect failover chains spanning different models */
+  modelId?: number | null;
+  /** Canonical model name (populated when retrieving mappings) */
+  modelName?: string | null;
   createdAt: string;
   updatedAt: string;
   notes?: string;

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
@@ -49,6 +49,18 @@ namespace ConduitLLM.Configuration.DTOs
         public int Priority { get; set; }
 
         /// <summary>
+        /// The canonical Model entity id resolved via the ModelProviderTypeAssociation
+        /// (populated when retrieving mappings). Lets clients detect aliases whose failover
+        /// chain spans different canonical models.
+        /// </summary>
+        public int? ModelId { get; set; }
+
+        /// <summary>
+        /// The canonical model name (populated when retrieving mappings).
+        /// </summary>
+        public string? ModelName { get; set; }
+
+        /// <summary>
         /// Whether this mapping is currently enabled
         /// </summary>
         public bool IsEnabled { get; set; } = true;

--- a/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
@@ -36,6 +36,8 @@ namespace ConduitLLM.Configuration.Extensions
                 Provider = mapping.Provider?.ToReferenceDto(),
                 ModelProviderTypeAssociationId = mapping.ModelProviderTypeAssociationId,
                 Priority = mapping.Priority,
+                ModelId = mapping.ModelProviderTypeAssociation?.ModelId,
+                ModelName = mapping.ModelProviderTypeAssociation?.Model?.Name,
                 IsEnabled = mapping.IsEnabled,
                 CreatedAt = mapping.CreatedAt,
                 UpdatedAt = mapping.UpdatedAt,

--- a/WebAdmin/src/components/modelmappings/FailoverChainModal.tsx
+++ b/WebAdmin/src/components/modelmappings/FailoverChainModal.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  Paper,
+  Stack,
+  Text,
+} from '@mantine/core';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
+import { IconAlertTriangle, IconGripVertical } from '@tabler/icons-react';
+import type { ModelProviderMappingDto } from '@knn_labs/conduit-admin-client';
+import { useReorderFailoverChain } from '@/hooks/useModelMappingsApi';
+
+interface FailoverChainModalProps {
+  opened: boolean;
+  onClose: () => void;
+  modelAlias: string;
+  mappings: ModelProviderMappingDto[];
+}
+
+/**
+ * Per-alias failover chain editor: lists every provider mapped to the alias in priority
+ * order with drag-to-reorder. Saving writes priority = list index. Requests are routed to
+ * the top provider; provider-level failover walks the rest in order.
+ */
+export function FailoverChainModal({ opened, onClose, modelAlias, mappings }: FailoverChainModalProps) {
+  const chainMappings = useMemo(
+    () =>
+      mappings
+        .filter(m => m.modelAlias === modelAlias)
+        .sort((a, b) => a.priority - b.priority || a.id - b.id),
+    [mappings, modelAlias]
+  );
+
+  const [ordered, setOrdered] = useState<ModelProviderMappingDto[]>(chainMappings);
+  const reorderMutation = useReorderFailoverChain();
+
+  useEffect(() => {
+    setOrdered(chainMappings);
+  }, [chainMappings]);
+
+  const distinctModelIds = useMemo(() => {
+    const ids = new Set(
+      chainMappings.map(m => m.modelId).filter((id): id is number => id !== null && id !== undefined)
+    );
+    return ids.size;
+  }, [chainMappings]);
+
+  const isDirty = ordered.some((m, index) => m.priority !== index);
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination || result.destination.index === result.source.index) return;
+    const next = [...ordered];
+    const [moved] = next.splice(result.source.index, 1);
+    next.splice(result.destination.index, 0, moved);
+    setOrdered(next);
+  };
+
+  const handleSave = () => {
+    reorderMutation.mutate(ordered, { onSuccess: onClose });
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={`Failover chain — ${modelAlias}`}
+      size="lg"
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          Requests for this alias go to the top provider. When provider-level failover is
+          enabled, lower entries are tried in order if the one above fails. Drag to reorder.
+        </Text>
+
+        {distinctModelIds > 1 && (
+          <Alert color="yellow" icon={<IconAlertTriangle size={16} />} title="Different underlying models">
+            The providers in this chain resolve to different canonical models. During
+            failover, requests will be silently served by a different model than the primary.
+          </Alert>
+        )}
+
+        {ordered.length < 2 && (
+          <Alert color="blue" variant="light">
+            Only one provider is mapped to this alias. Add another mapping with the same
+            alias and a different provider to build a failover chain.
+          </Alert>
+        )}
+
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="failover-chain">
+            {(droppable) => (
+              <Stack gap="xs" ref={droppable.innerRef} {...droppable.droppableProps}>
+                {ordered.map((mapping, index) => (
+                  <Draggable key={mapping.id} draggableId={String(mapping.id)} index={index}>
+                    {(draggable, snapshot) => (
+                      <Paper
+                        ref={draggable.innerRef}
+                        {...draggable.draggableProps}
+                        withBorder
+                        p="sm"
+                        shadow={snapshot.isDragging ? 'md' : undefined}
+                        style={draggable.draggableProps.style}
+                      >
+                        <Group gap="sm" wrap="nowrap">
+                          <div {...draggable.dragHandleProps} style={{ display: 'flex', cursor: 'grab' }}>
+                            <IconGripVertical size={18} />
+                          </div>
+                          <Badge variant={index === 0 ? 'filled' : 'light'} color={index === 0 ? 'blue' : 'gray'}>
+                            {index === 0 ? 'Primary' : `Fallback ${index}`}
+                          </Badge>
+                          <Stack gap={0} style={{ flexGrow: 1, minWidth: 0 }}>
+                            <Text size="sm" fw={500} truncate>
+                              {mapping.provider?.displayName ?? `Provider #${mapping.providerId}`}
+                            </Text>
+                            <Text size="xs" c="dimmed" truncate>
+                              {mapping.providerModelId}
+                              {mapping.modelName ? ` · ${mapping.modelName}` : ''}
+                            </Text>
+                          </Stack>
+                          {!mapping.isEnabled && (
+                            <Badge color="red" variant="light">Disabled</Badge>
+                          )}
+                        </Group>
+                      </Paper>
+                    )}
+                  </Draggable>
+                ))}
+                {droppable.placeholder}
+              </Stack>
+            )}
+          </Droppable>
+        </DragDropContext>
+
+        <Group justify="flex-end" gap="sm">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            loading={reorderMutation.isPending}
+            disabled={!isDirty}
+          >
+            Save order
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/WebAdmin/src/components/modelmappings/ModelMappingsTableWithHooks.tsx
+++ b/WebAdmin/src/components/modelmappings/ModelMappingsTableWithHooks.tsx
@@ -18,6 +18,8 @@ import {
   IconDotsVertical,
   IconArrowRight,
   IconAlertCircle,
+  IconAlertTriangle,
+  IconListNumbers,
 } from '@tabler/icons-react';
 import { modals } from '@mantine/modals';
 import { useRouter } from 'next/navigation';
@@ -30,6 +32,7 @@ import {
 } from '@/hooks/useModelMappingsApi';
 import type { ModelProviderMappingDto } from '@knn_labs/conduit-admin-client';
 import { BulkActionsBar } from './BulkActionsBar';
+import { FailoverChainModal } from './FailoverChainModal';
 
 // Extend the DTO type to ensure provider and capabilities properties are available
 interface ExtendedModelProviderMappingDto extends ModelProviderMappingDto {
@@ -66,6 +69,23 @@ export function ModelMappingsTable({ onRefresh }: ModelMappingsTableProps) {
   
   // Selection state
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  // Failover chain modal state (alias being edited, null = closed)
+  const [failoverAlias, setFailoverAlias] = useState<string | null>(null);
+
+  // Per-alias stats: mapping count and whether the chain spans different canonical models
+  const aliasStats = useMemo(() => {
+    const stats = new Map<string, { count: number; modelIds: Set<number> }>();
+    for (const mapping of mappings) {
+      const entry = stats.get(mapping.modelAlias) ?? { count: 0, modelIds: new Set<number>() };
+      entry.count++;
+      if (mapping.modelId !== null && mapping.modelId !== undefined) {
+        entry.modelIds.add(mapping.modelId);
+      }
+      stats.set(mapping.modelAlias, entry);
+    }
+    return stats;
+  }, [mappings]);
   
   // Computed values for selection
   
@@ -221,6 +241,29 @@ export function ModelMappingsTable({ onRefresh }: ModelMappingsTableProps) {
           <Text size="sm" fw={500}>{mapping.modelAlias}</Text>
           <IconArrowRight size={14} style={{ color: 'var(--mantine-color-dimmed)' }} />
           <Text size="sm" c="dimmed">{mapping.providerModelId}</Text>
+          {(aliasStats.get(mapping.modelAlias)?.count ?? 0) > 1 && (
+            <Badge
+              size="xs"
+              variant="light"
+              color="blue"
+              style={{ cursor: 'pointer' }}
+              onClick={() => setFailoverAlias(mapping.modelAlias)}
+              title="This alias has a failover chain — click to reorder"
+            >
+              chain ×{aliasStats.get(mapping.modelAlias)?.count}
+            </Badge>
+          )}
+          {(aliasStats.get(mapping.modelAlias)?.modelIds.size ?? 0) > 1 && (
+            <Badge
+              size="xs"
+              variant="light"
+              color="yellow"
+              leftSection={<IconAlertTriangle size={10} />}
+              title="Providers in this failover chain resolve to different canonical models"
+            >
+              cross-model
+            </Badge>
+          )}
         </Group>
       </Table.Td>
       
@@ -264,6 +307,12 @@ export function ModelMappingsTable({ onRefresh }: ModelMappingsTableProps) {
                 onClick={() => handleEdit(mapping)}
               >
                 Edit
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<IconListNumbers style={{ width: rem(14), height: rem(14) }} />}
+                onClick={() => setFailoverAlias(mapping.modelAlias)}
+              >
+                Failover chain
               </Menu.Item>
               <Menu.Divider />
               <Menu.Item
@@ -317,6 +366,13 @@ export function ModelMappingsTable({ onRefresh }: ModelMappingsTableProps) {
         isDeleting={bulkDelete.isPending}
         isEnabling={bulkEnable.isPending}
         isDisabling={bulkDisable.isPending}
+      />
+
+      <FailoverChainModal
+        opened={failoverAlias !== null}
+        onClose={() => setFailoverAlias(null)}
+        modelAlias={failoverAlias ?? ''}
+        mappings={mappings}
       />
     </>
   );

--- a/WebAdmin/src/hooks/useModelMappingsApi.ts
+++ b/WebAdmin/src/hooks/useModelMappingsApi.ts
@@ -67,6 +67,22 @@ export function useDeleteModelMapping() {
   });
 }
 
+export function useReorderFailoverChain() {
+  return useAdminMutation({
+    // Writes priority = list index for an alias's mappings after a drag-reorder. The Admin
+    // API has no batch-priority endpoint; the SDK's bulkUpdate fans out to per-mapping
+    // updates. Unchanged rows are skipped.
+    mutationFn: (orderedMappings: ModelProviderMappingDto[]) => client =>
+      client.modelMappings.bulkUpdate(
+        orderedMappings
+          .map((mapping, index) => ({ id: mapping.id, data: { id: mapping.id, priority: index } }))
+          .filter((update, index) => orderedMappings[index].priority !== index)
+      ),
+    successMessage: 'Failover order saved',
+    invalidateKeys: [QUERY_KEY],
+  });
+}
+
 export function useBulkDeleteModelMappings() {
   return useAdminMutation({
     mutationFn: (ids: number[]) => client => client.modelMappings.bulkDelete(ids),


### PR DESCRIPTION
## Summary

PR 5b — the final PR of the provider-resilience overhaul (**stacked on #1045**; only the last commit is new). Gives operators a visual editor for the provider failover chains introduced in #1044.

## What it looks like

On `/model-mappings`:
- Aliases mapped to multiple providers get a **`chain ×N` badge** (click-through) and, when the chain spans different canonical models, a yellow **`cross-model`** warning badge.
- Every row''s menu gains **"Failover chain"**, opening a modal that lists the alias''s providers in priority order with **drag-to-reorder** (`@hello-pangea/dnd` — already a dependency, first actual use). Top = Primary, rest = Fallback 1..N; disabled mappings flagged; saving writes `priority = index` via the SDK''s `bulkUpdate` fan-out (unchanged rows skipped).
- Cross-model chains show an explicit warning Alert in the modal ("requests will be silently served by a different model than the primary") — the agreed allow-but-warn policy.

## Supporting changes

- **Backend DTO** (additive): `ModelProviderMappingDto` gains `ModelId`/`ModelName`, populated from the association in `ToDto()` — the UI previously had no cheap way to resolve a mapping''s canonical model (the edit page brute-forces it by walking every model''s providers).
- **Admin SDK**: `modelId`/`modelName` added to the hand-written `ModelProviderMappingDto` TS type (kept in sync with the DTO; this file predates the derive-from-generated pattern), dist rebuilt.
- New `useReorderFailoverChain` hook following the `useAdminMutation` house pattern (invalidates `['model-mappings']`).

## Verification

- `dotnet build` clean (DTO change)
- Admin SDK `npm run build` clean
- WebAdmin `npm run lint` + `npm run type-check`: **zero errors in files touched by this change**. Both report pre-existing errors in `src/lib/client/sdkChatStreamingAdapter.ts` that reproduce on the base branch with this change stashed — stale Core SDK dist on the host (the dev container builds its own SDK dists), not introduced here.
- Manual check after the stack merges: map one alias to two providers, open Failover chain, drag to reorder, confirm Priority persists and `GetMappingsByModelAliasAsync` order follows.