### PR TITLE
feat(openrouter): modernize provider integration — authoritative billing, full modality coverage, admin-reviewed drift sync

### DIFF
--- a/SDKs/Node/Admin/src/FetchConduitAdminClient.ts
+++ b/SDKs/Node/Admin/src/FetchConduitAdminClient.ts
@@ -27,6 +27,7 @@ import {
   FetchFunctionExecutionsService
 } from './services/FetchFunctionsService';
 import { FetchPricingService } from './services/FetchPricingService';
+import { FetchProviderSyncService } from './services/FetchProviderSyncService';
 import type { ApiClientConfig } from './client/types';
 import {
   isConduitError,
@@ -81,6 +82,7 @@ export class FetchConduitAdminClient extends FetchBaseApiClient {
   public readonly functionCosts: FetchFunctionCostsService;
   public readonly functionExecutions: FetchFunctionExecutionsService;
   public readonly pricing: FetchPricingService;
+  public readonly providerSync: FetchProviderSyncService;
 
   constructor(config: ApiClientConfig) {
     super(config);
@@ -112,6 +114,7 @@ export class FetchConduitAdminClient extends FetchBaseApiClient {
     this.functionCosts = new FetchFunctionCostsService(this);
     this.functionExecutions = new FetchFunctionExecutionsService(this);
     this.pricing = new FetchPricingService(this);
+    this.providerSync = new FetchProviderSyncService(this);
   }
 
   /**

--- a/SDKs/Node/Admin/src/constants.ts
+++ b/SDKs/Node/Admin/src/constants.ts
@@ -332,6 +332,18 @@ export const ENDPOINTS = {
   ADMIN_TASKS: {
     CLEANUP: '/v1/admin/tasks/cleanup',
   },
+
+  // Provider metadata sync (OpenRouter drift review)
+  PROVIDER_SYNC: {
+    DRIFT: '/api/providersync/drift',
+    DRIFT_BY_ID: (id: number) => `/api/providersync/drift/${id}`,
+    DRIFT_APPLY: (id: number) => `/api/providersync/drift/${id}/apply`,
+    DRIFT_DISMISS: (id: number) => `/api/providersync/drift/${id}/dismiss`,
+    DRIFT_BULK_APPLY: '/api/providersync/drift/bulk/apply',
+    DRIFT_BULK_DISMISS: '/api/providersync/drift/bulk/dismiss',
+    RUN: '/api/providersync/run',
+    RUNS: '/api/providersync/runs',
+  },
 } as const;
 
 export const DEFAULT_PAGE_SIZE = 20;

--- a/SDKs/Node/Admin/src/index.ts
+++ b/SDKs/Node/Admin/src/index.ts
@@ -28,6 +28,7 @@ export * from './models/ipFilter';
 export * from './models/media';
 export * from './models/functions';
 export * from './models/promptCaching';
+export * from './models/providerSync';
 // Re-export model types except ModelCapabilities (conflicts with providerModels)
 export {
   ModelType,
@@ -177,6 +178,7 @@ export {
 } from './services/FetchFunctionsService';
 export { FetchPricingService } from './services/FetchPricingService';
 export * from './models/pricing';
+export { FetchProviderSyncService } from './services/FetchProviderSyncService';
 
 // SignalR Hub Clients removed - WebAdmin uses React Query instead of SignalR for data fetching
 

--- a/SDKs/Node/Admin/src/models/modelMapping.ts
+++ b/SDKs/Node/Admin/src/models/modelMapping.ts
@@ -13,6 +13,8 @@ export interface ModelProviderMappingDto {
   createdAt: string;
   updatedAt: string;
   notes?: string;
+  /** Optional provider-specific request options (JSON object) merged into outgoing requests (OpenRouter). */
+  providerOptions?: string;
   capabilities?: ModelCapabilitiesDto;
 }
 
@@ -36,6 +38,7 @@ export interface CreateModelProviderMappingDto {
   isEnabled?: boolean;
   priority?: number;
   notes?: string;
+  providerOptions?: string;
 }
 
 export interface UpdateModelProviderMappingDto {
@@ -51,6 +54,7 @@ export interface UpdateModelProviderMappingDto {
   isEnabled?: boolean;
   priority?: number;
   notes?: string;
+  providerOptions?: string;
 }
 
 // For bulk operations

--- a/SDKs/Node/Admin/src/models/provider.ts
+++ b/SDKs/Node/Admin/src/models/provider.ts
@@ -9,6 +9,10 @@ export interface ProviderDto {
   providerName: string; // User-friendly display name, can be changed
   baseUrl?: string | null;
   isEnabled: boolean;
+  /** When true, the provider-reported per-request cost is authoritative for billing (falls back to ModelCost). */
+  trustProviderReportedCosts: boolean;
+  /** Multiplier applied to the provider-reported cost when billing (1.0 = pass-through). */
+  providerCostMarkupMultiplier: number;
   createdAt: string;
   updatedAt: string;
   // Note: apiKey and organization moved to ProviderKeyCredential
@@ -19,12 +23,16 @@ export interface CreateProviderDto {
   providerName: string;
   baseUrl?: string | null;
   isEnabled?: boolean;
+  trustProviderReportedCosts?: boolean;
+  providerCostMarkupMultiplier?: number;
 }
 
 export interface UpdateProviderDto {
   providerName?: string;
   baseUrl?: string | null;
   isEnabled?: boolean;
+  trustProviderReportedCosts?: boolean;
+  providerCostMarkupMultiplier?: number;
 }
 
 

--- a/SDKs/Node/Admin/src/models/providerSync.ts
+++ b/SDKs/Node/Admin/src/models/providerSync.ts
@@ -1,0 +1,63 @@
+// Provider metadata sync (OpenRouter drift review) DTOs.
+
+export interface DriftItemDto {
+  id: number;
+  modelProviderMappingId: number;
+  modelAlias: string;
+  providerId: number;
+  providerName: string;
+  openRouterModelId: string;
+  /** Pricing | MissingCost | ContextWindow | Capabilities | ModelRemoved | ModelDeprecated */
+  driftType: string;
+  /** Pending | Applied | Dismissed | AutoResolved */
+  status: string;
+  /** Conduit's current values at detection time (JSON; shape depends on driftType). */
+  currentValuesJson: string;
+  /** The provider's proposed values (JSON; shape depends on driftType). */
+  proposedValuesJson: string;
+  firstDetectedAt: string;
+  lastDetectedAt: string;
+  resolvedAt?: string | null;
+  resolvedBy?: string | null;
+}
+
+export interface ProviderSyncRunDto {
+  id: number;
+  providerType: string;
+  startedAt: string;
+  completedAt?: string | null;
+  status: string;
+  triggeredBy: string;
+  modelsFetched: number;
+  mappingsChecked: number;
+  itemsCreated: number;
+  itemsUpdated: number;
+  itemsAutoResolved: number;
+  errorMessage?: string | null;
+}
+
+export interface DriftActionResultDto {
+  id: number;
+  success: boolean;
+  /** True when rejected because Conduit's current values changed since detection. */
+  stale: boolean;
+  error?: string | null;
+}
+
+export interface BulkDriftActionRequest {
+  ids: number[];
+}
+
+export interface BulkDriftActionResponse {
+  succeededCount: number;
+  failedCount: number;
+  results: DriftActionResultDto[];
+}
+
+export interface DriftItemFilter {
+  status?: string;
+  driftType?: string;
+  providerId?: number;
+  page?: number;
+  pageSize?: number;
+}

--- a/SDKs/Node/Admin/src/services/FetchProviderSyncService.ts
+++ b/SDKs/Node/Admin/src/services/FetchProviderSyncService.ts
@@ -1,0 +1,165 @@
+import type { FetchBaseApiClient } from '../client/FetchBaseApiClient';
+import type { RequestConfig } from '../client/types';
+import { ENDPOINTS } from '../constants';
+import {
+  DriftItemDto,
+  DriftItemFilter,
+  DriftActionResultDto,
+  BulkDriftActionResponse,
+  ProviderSyncRunDto,
+} from '../models/providerSync';
+
+/**
+ * Type-safe Provider metadata sync service using native fetch.
+ *
+ * Surfaces the OpenRouter drift-review workflow: list/get pending drift, apply or
+ * dismiss individual items or in bulk, trigger a sync run, and read run history.
+ */
+export class FetchProviderSyncService {
+  constructor(private readonly client: FetchBaseApiClient) {}
+
+  /**
+   * List drift items (defaults to Pending on the server), optionally filtered.
+   */
+  async listDrift(
+    filter?: DriftItemFilter,
+    config?: RequestConfig
+  ): Promise<DriftItemDto[]> {
+    const queryParams = new URLSearchParams();
+    if (filter) {
+      Object.entries(filter).forEach(([key, value]) => {
+        if (value !== undefined) {
+          queryParams.append(key, String(value));
+        }
+      });
+    }
+
+    const url = queryParams.toString()
+      ? `${ENDPOINTS.PROVIDER_SYNC.DRIFT}?${queryParams.toString()}`
+      : ENDPOINTS.PROVIDER_SYNC.DRIFT;
+
+    return this.client['get']<DriftItemDto[]>(url, {
+      signal: config?.signal,
+      timeout: config?.timeout,
+      headers: config?.headers,
+    });
+  }
+
+  /**
+   * Get a single drift item by ID.
+   */
+  async getDrift(id: number, config?: RequestConfig): Promise<DriftItemDto> {
+    return this.client['get']<DriftItemDto>(
+      ENDPOINTS.PROVIDER_SYNC.DRIFT_BY_ID(id),
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * Apply a drift item's proposed change. Returns a stale flag when the item was
+   * rejected because Conduit's current values changed since detection.
+   */
+  async apply(id: number, config?: RequestConfig): Promise<DriftActionResultDto> {
+    return this.client['post']<DriftActionResultDto>(
+      ENDPOINTS.PROVIDER_SYNC.DRIFT_APPLY(id),
+      undefined,
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * Dismiss a drift item without applying it.
+   */
+  async dismiss(id: number, config?: RequestConfig): Promise<DriftActionResultDto> {
+    return this.client['post']<DriftActionResultDto>(
+      ENDPOINTS.PROVIDER_SYNC.DRIFT_DISMISS(id),
+      undefined,
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * Apply multiple drift items, returning per-item results.
+   */
+  async applyBulk(
+    ids: number[],
+    config?: RequestConfig
+  ): Promise<BulkDriftActionResponse> {
+    return this.client['post']<BulkDriftActionResponse, { ids: number[] }>(
+      ENDPOINTS.PROVIDER_SYNC.DRIFT_BULK_APPLY,
+      { ids },
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * Dismiss multiple drift items, returning per-item results.
+   */
+  async dismissBulk(
+    ids: number[],
+    config?: RequestConfig
+  ): Promise<BulkDriftActionResponse> {
+    return this.client['post']<BulkDriftActionResponse, { ids: number[] }>(
+      ENDPOINTS.PROVIDER_SYNC.DRIFT_BULK_DISMISS,
+      { ids },
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * Trigger a sync now. The server returns 409 if a sync is already in progress.
+   */
+  async run(config?: RequestConfig): Promise<ProviderSyncRunDto> {
+    return this.client['post']<ProviderSyncRunDto>(
+      ENDPOINTS.PROVIDER_SYNC.RUN,
+      undefined,
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+
+  /**
+   * List recent sync runs.
+   */
+  async listRuns(
+    page = 1,
+    pageSize = 25,
+    config?: RequestConfig
+  ): Promise<ProviderSyncRunDto[]> {
+    const queryParams = new URLSearchParams();
+    queryParams.append('page', String(page));
+    queryParams.append('pageSize', String(pageSize));
+
+    return this.client['get']<ProviderSyncRunDto[]>(
+      `${ENDPOINTS.PROVIDER_SYNC.RUNS}?${queryParams.toString()}`,
+      {
+        signal: config?.signal,
+        timeout: config?.timeout,
+        headers: config?.headers,
+      }
+    );
+  }
+}

--- a/SDKs/Node/Gateway/src/models/chat.ts
+++ b/SDKs/Node/Gateway/src/models/chat.ts
@@ -43,6 +43,14 @@ export interface ChatCompletionMessage {
   tool_call_id?: string;
 }
 
+/** Unified reasoning configuration (OpenRouter-style). Only set fields are sent. */
+export interface ReasoningConfig {
+  effort?: 'max' | 'xhigh' | 'high' | 'medium' | 'low' | 'minimal' | 'none';
+  max_tokens?: number;
+  enabled?: boolean;
+  exclude?: boolean;
+}
+
 export interface ChatCompletionRequest {
   model: string;
   messages: ChatCompletionMessage[];
@@ -54,6 +62,8 @@ export interface ChatCompletionRequest {
   n?: number;
   presence_penalty?: number;
   response_format?: ResponseFormat;
+  /** Unified reasoning configuration, forwarded to providers that support it (e.g. OpenRouter). */
+  reasoning?: ReasoningConfig;
   seed?: number;
   stop?: string | string[];
   stream?: boolean;

--- a/SDKs/Node/Gateway/src/models/common.ts
+++ b/SDKs/Node/Gateway/src/models/common.ts
@@ -3,7 +3,13 @@ export type { Usage, PerformanceMetrics } from '@knn_labs/conduit-common';
 
 // Core-specific types that aren't in Common
 export interface ResponseFormat {
-  type: 'text' | 'json_object';
+  type: 'text' | 'json_object' | 'json_schema';
+  /** Schema payload, required when type is 'json_schema'. */
+  json_schema?: {
+    name: string;
+    strict?: boolean;
+    schema: Record<string, unknown>;
+  };
 }
 
 export interface FunctionCall {

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.cs
@@ -193,6 +193,7 @@ namespace ConduitLLM.Admin.Controllers
                     SupportsVideoGeneration = baseDto.SupportsVideoGeneration,
                     SupportsSpeechToText = baseDto.SupportsSpeechToText,
                     SupportsTextToSpeech = baseDto.SupportsTextToSpeech,
+                    SupportsRerank = baseDto.SupportsRerank,
                     SupportsEmbeddings = baseDto.SupportsEmbeddings,
                     MaxInputTokens = baseDto.MaxInputTokens,
                     MaxOutputTokens = baseDto.MaxOutputTokens,
@@ -244,6 +245,7 @@ namespace ConduitLLM.Admin.Controllers
                 SupportsVideoGeneration = dto.SupportsVideoGeneration,
                 SupportsSpeechToText = dto.SupportsSpeechToText,
                 SupportsTextToSpeech = dto.SupportsTextToSpeech,
+                SupportsRerank = dto.SupportsRerank,
                 SupportsEmbeddings = dto.SupportsEmbeddings,
                 MaxInputTokens = dto.MaxInputTokens,
                 MaxOutputTokens = dto.MaxOutputTokens,
@@ -386,6 +388,12 @@ namespace ConduitLLM.Admin.Controllers
                     changes.Add(("SupportsTextToSpeech", model.SupportsTextToSpeech.ToString(), dto.SupportsTextToSpeech.Value.ToString()));
                 model.SupportsTextToSpeech = dto.SupportsTextToSpeech.Value;
             }
+            if (dto.SupportsRerank.HasValue)
+            {
+                if (model.SupportsRerank != dto.SupportsRerank.Value)
+                    changes.Add(("SupportsRerank", model.SupportsRerank.ToString(), dto.SupportsRerank.Value.ToString()));
+                model.SupportsRerank = dto.SupportsRerank.Value;
+            }
             if (dto.SupportsEmbeddings.HasValue)
             {
                 if (model.SupportsEmbeddings != dto.SupportsEmbeddings.Value)
@@ -490,6 +498,7 @@ namespace ConduitLLM.Admin.Controllers
             if (dto.SupportsVideoGeneration.HasValue) changedProps.Add("SupportsVideoGeneration");
             if (dto.SupportsSpeechToText.HasValue) changedProps.Add("SupportsSpeechToText");
             if (dto.SupportsTextToSpeech.HasValue) changedProps.Add("SupportsTextToSpeech");
+            if (dto.SupportsRerank.HasValue) changedProps.Add("SupportsRerank");
             if (dto.SupportsEmbeddings.HasValue) changedProps.Add("SupportsEmbeddings");
             if (dto.MaxInputTokens.HasValue) changedProps.Add("MaxInputTokens");
             if (dto.MaxOutputTokens.HasValue) changedProps.Add("MaxOutputTokens");

--- a/Services/ConduitLLM.Admin/Controllers/ModelController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelController.cs
@@ -191,6 +191,8 @@ namespace ConduitLLM.Admin.Controllers
                     SupportsStreaming = baseDto.SupportsStreaming,
                     SupportsImageGeneration = baseDto.SupportsImageGeneration,
                     SupportsVideoGeneration = baseDto.SupportsVideoGeneration,
+                    SupportsSpeechToText = baseDto.SupportsSpeechToText,
+                    SupportsTextToSpeech = baseDto.SupportsTextToSpeech,
                     SupportsEmbeddings = baseDto.SupportsEmbeddings,
                     MaxInputTokens = baseDto.MaxInputTokens,
                     MaxOutputTokens = baseDto.MaxOutputTokens,
@@ -240,6 +242,8 @@ namespace ConduitLLM.Admin.Controllers
                 SupportsStreaming = dto.SupportsStreaming,
                 SupportsImageGeneration = dto.SupportsImageGeneration,
                 SupportsVideoGeneration = dto.SupportsVideoGeneration,
+                SupportsSpeechToText = dto.SupportsSpeechToText,
+                SupportsTextToSpeech = dto.SupportsTextToSpeech,
                 SupportsEmbeddings = dto.SupportsEmbeddings,
                 MaxInputTokens = dto.MaxInputTokens,
                 MaxOutputTokens = dto.MaxOutputTokens,
@@ -370,6 +374,18 @@ namespace ConduitLLM.Admin.Controllers
                     changes.Add(("SupportsVideoGeneration", model.SupportsVideoGeneration.ToString(), dto.SupportsVideoGeneration.Value.ToString()));
                 model.SupportsVideoGeneration = dto.SupportsVideoGeneration.Value;
             }
+            if (dto.SupportsSpeechToText.HasValue)
+            {
+                if (model.SupportsSpeechToText != dto.SupportsSpeechToText.Value)
+                    changes.Add(("SupportsSpeechToText", model.SupportsSpeechToText.ToString(), dto.SupportsSpeechToText.Value.ToString()));
+                model.SupportsSpeechToText = dto.SupportsSpeechToText.Value;
+            }
+            if (dto.SupportsTextToSpeech.HasValue)
+            {
+                if (model.SupportsTextToSpeech != dto.SupportsTextToSpeech.Value)
+                    changes.Add(("SupportsTextToSpeech", model.SupportsTextToSpeech.ToString(), dto.SupportsTextToSpeech.Value.ToString()));
+                model.SupportsTextToSpeech = dto.SupportsTextToSpeech.Value;
+            }
             if (dto.SupportsEmbeddings.HasValue)
             {
                 if (model.SupportsEmbeddings != dto.SupportsEmbeddings.Value)
@@ -472,6 +488,8 @@ namespace ConduitLLM.Admin.Controllers
             if (dto.SupportsStreaming.HasValue) changedProps.Add("SupportsStreaming");
             if (dto.SupportsImageGeneration.HasValue) changedProps.Add("SupportsImageGeneration");
             if (dto.SupportsVideoGeneration.HasValue) changedProps.Add("SupportsVideoGeneration");
+            if (dto.SupportsSpeechToText.HasValue) changedProps.Add("SupportsSpeechToText");
+            if (dto.SupportsTextToSpeech.HasValue) changedProps.Add("SupportsTextToSpeech");
             if (dto.SupportsEmbeddings.HasValue) changedProps.Add("SupportsEmbeddings");
             if (dto.MaxInputTokens.HasValue) changedProps.Add("MaxInputTokens");
             if (dto.MaxOutputTokens.HasValue) changedProps.Add("MaxOutputTokens");

--- a/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ModelProviderMappingController.cs
@@ -89,6 +89,12 @@ public class ModelProviderMappingController : AdminControllerBase
             return Conflict(new ErrorResponseDto($"A mapping for model alias '{mappingDto.ModelAlias}' already exists"));
         }
 
+        var optionsError = ValidateProviderOptions(mappingDto.ProviderOptions);
+        if (optionsError != null)
+        {
+            return BadRequest(new ErrorResponseDto(optionsError));
+        }
+
         var mapping = mappingDto.ToEntity();
         var success = await _mappingService.AddMappingAsync(mapping);
 
@@ -130,6 +136,12 @@ public class ModelProviderMappingController : AdminControllerBase
             throw new KeyNotFoundException($"Model provider mapping with ID '{id}' not found");
         }
 
+        var optionsError = ValidateProviderOptions(mappingDto.ProviderOptions);
+        if (optionsError != null)
+        {
+            return BadRequest(new ErrorResponseDto(optionsError));
+        }
+
         existingMapping.UpdateFromDto(mappingDto);
         var success = await _mappingService.UpdateMappingAsync(existingMapping);
 
@@ -143,6 +155,49 @@ public class ModelProviderMappingController : AdminControllerBase
         AdminOperationsMetricsService.RecordConfigurationChange("modelmapping", "update");
 
         return NoContent();
+    }
+
+    private static readonly string[] ForbiddenProviderOptionKeys = { "model", "messages", "stream", "stream_options" };
+
+    /// <summary>
+    /// Validates a mapping's ProviderOptions JSON. Returns an error message if invalid, else null.
+    /// The value must be a JSON object and may not contain keys that would hijack the request
+    /// (model/messages/stream/stream_options).
+    /// </summary>
+    private static string? ValidateProviderOptions(string? providerOptions)
+    {
+        if (string.IsNullOrWhiteSpace(providerOptions))
+        {
+            return null;
+        }
+
+        System.Text.Json.JsonDocument doc;
+        try
+        {
+            doc = System.Text.Json.JsonDocument.Parse(providerOptions);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return "ProviderOptions must be valid JSON.";
+        }
+
+        using (doc)
+        {
+            if (doc.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
+            {
+                return "ProviderOptions must be a JSON object.";
+            }
+
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (ForbiddenProviderOptionKeys.Contains(prop.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    return $"ProviderOptions may not contain the reserved key '{prop.Name}'.";
+                }
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Models.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Models.cs
@@ -26,6 +26,18 @@ namespace ConduitLLM.Admin.Controllers
         /// Whether the provider is enabled
         /// </summary>
         public bool IsEnabled { get; set; } = true;
+
+        /// <summary>
+        /// When true, the cost the provider reports per request is authoritative for billing
+        /// (falls back to ModelCost when no cost is reported). Defaults to false.
+        /// </summary>
+        public bool TrustProviderReportedCosts { get; set; } = false;
+
+        /// <summary>
+        /// Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).
+        /// Only consulted when <see cref="TrustProviderReportedCosts"/> is true.
+        /// </summary>
+        public decimal ProviderCostMarkupMultiplier { get; set; } = 1.0m;
     }
 
     /// <summary>
@@ -37,16 +49,28 @@ namespace ConduitLLM.Admin.Controllers
         /// The new name for the provider (optional)
         /// </summary>
         public string? ProviderName { get; set; }
-        
+
         /// <summary>
         /// The new base URL for the provider (optional)
         /// </summary>
         public string? BaseUrl { get; set; }
-        
+
         /// <summary>
         /// Whether the provider is enabled
         /// </summary>
         public bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// When true, the cost the provider reports per request is authoritative for billing
+        /// (falls back to ModelCost when no cost is reported). Defaults to false when omitted.
+        /// </summary>
+        public bool TrustProviderReportedCosts { get; set; } = false;
+
+        /// <summary>
+        /// Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).
+        /// Defaults to 1.0 when omitted, so a partial update never silently zeroes the markup.
+        /// </summary>
+        public decimal ProviderCostMarkupMultiplier { get; set; } = 1.0m;
     }
 
     /// <summary>

--- a/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderCredentialsController.Providers.cs
@@ -71,6 +71,8 @@ namespace ConduitLLM.Admin.Controllers
                 p.ProviderName,
                 p.BaseUrl,
                 p.IsEnabled,
+                p.TrustProviderReportedCosts,
+                p.ProviderCostMarkupMultiplier,
                 p.CreatedAt,
                 p.UpdatedAt,
                 KeyCount = p.ProviderKeyCredentials?.Count ?? 0
@@ -111,6 +113,8 @@ namespace ConduitLLM.Admin.Controllers
                 provider.ProviderName,
                 provider.BaseUrl,
                 provider.IsEnabled,
+                provider.TrustProviderReportedCosts,
+                provider.ProviderCostMarkupMultiplier,
                 provider.CreatedAt,
                 provider.UpdatedAt,
                 KeyCount = provider.ProviderKeyCredentials?.Count ?? 0
@@ -132,6 +136,8 @@ namespace ConduitLLM.Admin.Controllers
                 ProviderName = request.ProviderName,
                 BaseUrl = request.BaseUrl,
                 IsEnabled = request.IsEnabled,
+                TrustProviderReportedCosts = request.TrustProviderReportedCosts,
+                ProviderCostMarkupMultiplier = request.ProviderCostMarkupMultiplier,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -162,6 +168,8 @@ namespace ConduitLLM.Admin.Controllers
                 provider.ProviderName,
                 provider.BaseUrl,
                 provider.IsEnabled,
+                provider.TrustProviderReportedCosts,
+                provider.ProviderCostMarkupMultiplier,
                 provider.CreatedAt,
                 provider.UpdatedAt,
                 KeyCount = 0
@@ -204,6 +212,18 @@ namespace ConduitLLM.Admin.Controllers
             {
                 changes.Add(("IsEnabled", provider.IsEnabled.ToString(), request.IsEnabled.ToString()));
                 provider.IsEnabled = request.IsEnabled;
+            }
+
+            if (provider.TrustProviderReportedCosts != request.TrustProviderReportedCosts)
+            {
+                changes.Add(("TrustProviderReportedCosts", provider.TrustProviderReportedCosts.ToString(), request.TrustProviderReportedCosts.ToString()));
+                provider.TrustProviderReportedCosts = request.TrustProviderReportedCosts;
+            }
+
+            if (provider.ProviderCostMarkupMultiplier != request.ProviderCostMarkupMultiplier)
+            {
+                changes.Add(("ProviderCostMarkupMultiplier", provider.ProviderCostMarkupMultiplier.ToString(), request.ProviderCostMarkupMultiplier.ToString()));
+                provider.ProviderCostMarkupMultiplier = request.ProviderCostMarkupMultiplier;
             }
 
             provider.UpdatedAt = DateTime.UtcNow;

--- a/Services/ConduitLLM.Admin/Controllers/ProviderSyncController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/ProviderSyncController.cs
@@ -1,0 +1,128 @@
+using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Filters;
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Models.ProviderSync;
+using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Core.Interfaces;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ConduitLLM.Admin.Controllers
+{
+    /// <summary>
+    /// Admin API for reviewing and applying OpenRouter metadata drift, and triggering the sync.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Policy = "MasterKeyPolicy")]
+    [ServiceFilter(typeof(OperationLoggingFilter))]
+    public class ProviderSyncController : AdminControllerBase
+    {
+        private readonly IAdminProviderSyncService _syncService;
+        private readonly IOpenRouterDriftDetectionService _detectionService;
+        private readonly IDistributedLockService _lockService;
+
+        private const string SyncLockKey = "openrouter:metadata-sync:leader";
+
+        public ProviderSyncController(
+            IAdminProviderSyncService syncService,
+            IOpenRouterDriftDetectionService detectionService,
+            IDistributedLockService lockService,
+            ILogger<ProviderSyncController> logger)
+            : base(logger)
+        {
+            _syncService = syncService;
+            _detectionService = detectionService;
+            _lockService = lockService;
+        }
+
+        /// <summary>Lists drift items (defaults to Pending), optionally filtered.</summary>
+        [HttpGet("drift")]
+        public async Task<IActionResult> GetDrift(
+            [FromQuery] string? status,
+            [FromQuery] string? driftType,
+            [FromQuery] int? providerId,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 50)
+        {
+            if (pageSize is < 1 or > 200) pageSize = 50;
+            var items = await _syncService.GetDriftItemsAsync(status, driftType, providerId, page, pageSize);
+            return Ok(items);
+        }
+
+        /// <summary>Gets a single drift item.</summary>
+        [HttpGet("drift/{id}")]
+        public async Task<IActionResult> GetDriftItem(int id)
+        {
+            var item = await _syncService.GetDriftItemAsync(id);
+            if (item == null)
+                return this.NotFoundEntity("Drift item", id);
+            return Ok(item);
+        }
+
+        /// <summary>Applies a drift item's proposed change.</summary>
+        [HttpPost("drift/{id}/apply")]
+        public async Task<IActionResult> Apply(int id)
+        {
+            var result = await _syncService.ApplyAsync(id, CurrentActor());
+            LogAdminAudit("AppliedDrift", "ProviderMetadataDriftItem", id, result.Success ? "applied" : result.Error);
+            return Ok(result);
+        }
+
+        /// <summary>Dismisses a drift item.</summary>
+        [HttpPost("drift/{id}/dismiss")]
+        public async Task<IActionResult> Dismiss(int id)
+        {
+            var result = await _syncService.DismissAsync(id, CurrentActor());
+            LogAdminAudit("DismissedDrift", "ProviderMetadataDriftItem", id);
+            return Ok(result);
+        }
+
+        /// <summary>Applies multiple drift items.</summary>
+        [HttpPost("drift/bulk/apply")]
+        public async Task<IActionResult> ApplyBulk([FromBody] BulkDriftActionRequest request)
+        {
+            if (request?.Ids == null || request.Ids.Count == 0)
+                return BadRequest(new ErrorResponseDto("No drift item ids provided."));
+            var result = await _syncService.ApplyBulkAsync(request.Ids, CurrentActor());
+            LogAdminAuditBulk("BulkAppliedDrift", "ProviderMetadataDriftItem", result.SucceededCount, result.FailedCount);
+            return Ok(result);
+        }
+
+        /// <summary>Dismisses multiple drift items.</summary>
+        [HttpPost("drift/bulk/dismiss")]
+        public async Task<IActionResult> DismissBulk([FromBody] BulkDriftActionRequest request)
+        {
+            if (request?.Ids == null || request.Ids.Count == 0)
+                return BadRequest(new ErrorResponseDto("No drift item ids provided."));
+            var result = await _syncService.DismissBulkAsync(request.Ids, CurrentActor());
+            LogAdminAuditBulk("BulkDismissedDrift", "ProviderMetadataDriftItem", result.SucceededCount, result.FailedCount);
+            return Ok(result);
+        }
+
+        /// <summary>Triggers a sync now. Returns 409 if a sync is already in progress.</summary>
+        [HttpPost("run")]
+        public async Task<IActionResult> RunNow()
+        {
+            using var lockHandle = await _lockService.AcquireLockAsync(SyncLockKey, TimeSpan.FromMinutes(15));
+            if (lockHandle == null)
+                return Conflict(new ErrorResponseDto("A sync is already in progress."));
+
+            var run = await _detectionService.RunSyncAsync("Manual");
+            LogAdminAudit("RanSync", "ProviderMetadataSyncRun", run.Id, $"Status: {run.Status}");
+            return Ok(run);
+        }
+
+        /// <summary>Lists recent sync runs.</summary>
+        [HttpGet("runs")]
+        public async Task<IActionResult> GetRuns([FromQuery] int page = 1, [FromQuery] int pageSize = 25)
+        {
+            if (pageSize is < 1 or > 100) pageSize = 25;
+            var runs = await _syncService.GetSyncRunsAsync(page, pageSize);
+            return Ok(runs);
+        }
+
+        private string CurrentActor() => User?.Identity?.Name ?? "admin";
+    }
+}

--- a/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
+++ b/Services/ConduitLLM.Admin/Controllers/VirtualKeyGroupsController.cs
@@ -388,7 +388,8 @@ namespace ConduitLLM.Admin.Controllers
                 request.RefundReason,
                 request.OriginalTransactionId,
                 initiatedBy,
-                initiatedByUserId);
+                initiatedByUserId,
+                request.RequestLogId);
 
             // Get updated group info for balance
             var group = await _groupRepository.GetByIdAsync(id);

--- a/Services/ConduitLLM.Admin/Extensions/EntityMappingExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/EntityMappingExtensions.cs
@@ -68,6 +68,8 @@ namespace ConduitLLM.Admin.Extensions
                 SupportsVision = model.SupportsVision,
                 SupportsImageGeneration = model.SupportsImageGeneration,
                 SupportsVideoGeneration = model.SupportsVideoGeneration,
+                SupportsSpeechToText = model.SupportsSpeechToText,
+                SupportsTextToSpeech = model.SupportsTextToSpeech,
                 SupportsEmbeddings = model.SupportsEmbeddings,
                 SupportsFunctionCalling = model.SupportsFunctionCalling,
                 SupportsStreaming = model.SupportsStreaming,

--- a/Services/ConduitLLM.Admin/Extensions/EntityMappingExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/EntityMappingExtensions.cs
@@ -70,6 +70,7 @@ namespace ConduitLLM.Admin.Extensions
                 SupportsVideoGeneration = model.SupportsVideoGeneration,
                 SupportsSpeechToText = model.SupportsSpeechToText,
                 SupportsTextToSpeech = model.SupportsTextToSpeech,
+                SupportsRerank = model.SupportsRerank,
                 SupportsEmbeddings = model.SupportsEmbeddings,
                 SupportsFunctionCalling = model.SupportsFunctionCalling,
                 SupportsStreaming = model.SupportsStreaming,

--- a/Services/ConduitLLM.Admin/Extensions/OpenRouterSyncExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/OpenRouterSyncExtensions.cs
@@ -1,0 +1,30 @@
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Services;
+using ConduitLLM.Configuration.Options;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ConduitLLM.Admin.Extensions
+{
+    /// <summary>
+    /// Registration for the OpenRouter metadata sync (drift detection + review + scheduled job).
+    /// </summary>
+    public static class OpenRouterSyncExtensions
+    {
+        /// <summary>
+        /// Registers the OpenRouter drift-detection + apply services, the named HTTP client, and the
+        /// scheduled sync hosted service. Relies on <c>IDistributedLockService</c> being registered
+        /// (by AddMediaLifecycleServices).
+        /// </summary>
+        public static IServiceCollection AddOpenRouterSyncServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.Configure<OpenRouterSyncOptions>(configuration.GetSection(OpenRouterSyncOptions.SectionName));
+            services.AddHttpClient("OpenRouterSync");
+            services.AddScoped<IOpenRouterDriftDetectionService, OpenRouterDriftDetectionService>();
+            services.AddScoped<IAdminProviderSyncService, AdminProviderSyncService>();
+            services.AddHostedService<OpenRouterMetadataSyncService>();
+            return services;
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
@@ -221,6 +221,8 @@ namespace ConduitLLM.Admin.Extensions
                 CachedInputCostPerMillionTokens = modelCost.CachedInputCostPerMillionTokens,
                 CachedInputWriteCostPerMillionTokens = modelCost.CachedInputWriteCostPerMillionTokens,
                 CostPerSearchUnit = modelCost.CostPerSearchUnit,
+                AudioCostPerMinute = modelCost.AudioCostPerMinute,
+                AudioCostPerThousandCharacters = modelCost.AudioCostPerThousandCharacters,
                 CreatedAt = modelCost.CreatedAt,
                 UpdatedAt = modelCost.UpdatedAt,
                 ModelType = modelCost.ModelType,
@@ -257,6 +259,8 @@ namespace ConduitLLM.Admin.Extensions
                 CachedInputCostPerMillionTokens = dto.CachedInputCostPerMillionTokens,
                 CachedInputWriteCostPerMillionTokens = dto.CachedInputWriteCostPerMillionTokens,
                 CostPerSearchUnit = dto.CostPerSearchUnit,
+                AudioCostPerMinute = dto.AudioCostPerMinute,
+                AudioCostPerThousandCharacters = dto.AudioCostPerThousandCharacters,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -295,6 +299,8 @@ namespace ConduitLLM.Admin.Extensions
             entity.CachedInputCostPerMillionTokens = dto.CachedInputCostPerMillionTokens;
             entity.CachedInputWriteCostPerMillionTokens = dto.CachedInputWriteCostPerMillionTokens;
             entity.CostPerSearchUnit = dto.CostPerSearchUnit;
+            entity.AudioCostPerMinute = dto.AudioCostPerMinute;
+            entity.AudioCostPerThousandCharacters = dto.AudioCostPerThousandCharacters;
             entity.UpdatedAt = DateTime.UtcNow;
 
             return entity;

--- a/Services/ConduitLLM.Admin/Interfaces/IAdminProviderSyncService.cs
+++ b/Services/ConduitLLM.Admin/Interfaces/IAdminProviderSyncService.cs
@@ -1,0 +1,31 @@
+using ConduitLLM.Admin.Models.ProviderSync;
+
+namespace ConduitLLM.Admin.Interfaces
+{
+    /// <summary>
+    /// Admin-facing service for reviewing and applying OpenRouter metadata drift items.
+    /// </summary>
+    public interface IAdminProviderSyncService
+    {
+        /// <summary>Lists drift items, optionally filtered by status/type/provider.</summary>
+        Task<List<DriftItemDto>> GetDriftItemsAsync(string? status, string? driftType, int? providerId, int page, int pageSize);
+
+        /// <summary>Gets a single drift item.</summary>
+        Task<DriftItemDto?> GetDriftItemAsync(int id);
+
+        /// <summary>Applies a drift item's proposed change (routing through the event-publishing services).</summary>
+        Task<DriftActionResultDto> ApplyAsync(int id, string actor);
+
+        /// <summary>Dismisses a drift item without applying it.</summary>
+        Task<DriftActionResultDto> DismissAsync(int id, string actor);
+
+        /// <summary>Applies multiple drift items, returning per-item results.</summary>
+        Task<BulkDriftActionResponse> ApplyBulkAsync(IReadOnlyList<int> ids, string actor);
+
+        /// <summary>Dismisses multiple drift items, returning per-item results.</summary>
+        Task<BulkDriftActionResponse> DismissBulkAsync(IReadOnlyList<int> ids, string actor);
+
+        /// <summary>Lists recent sync runs.</summary>
+        Task<List<ProviderSyncRunDto>> GetSyncRunsAsync(int page, int pageSize);
+    }
+}

--- a/Services/ConduitLLM.Admin/Interfaces/IOpenRouterDriftDetectionService.cs
+++ b/Services/ConduitLLM.Admin/Interfaces/IOpenRouterDriftDetectionService.cs
@@ -1,0 +1,19 @@
+using ConduitLLM.Admin.Models.ProviderSync;
+
+namespace ConduitLLM.Admin.Interfaces
+{
+    /// <summary>
+    /// Fetches OpenRouter's model catalog and detects drift against Conduit's configured ModelCost /
+    /// Model rows for every OpenRouter-mapped model, persisting drift items for admin review.
+    /// </summary>
+    public interface IOpenRouterDriftDetectionService
+    {
+        /// <summary>
+        /// Runs one sync cycle: fetch the catalog, compare against enabled OpenRouter mappings, and
+        /// idempotently upsert drift items. Returns a summary of the run.
+        /// </summary>
+        /// <param name="triggeredBy">"Schedule" or "Manual".</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<ProviderSyncRunDto> RunSyncAsync(string triggeredBy, CancellationToken cancellationToken = default);
+    }
+}

--- a/Services/ConduitLLM.Admin/Interfaces/IRefundService.cs
+++ b/Services/ConduitLLM.Admin/Interfaces/IRefundService.cs
@@ -18,6 +18,8 @@ public interface IRefundService
     /// <param name="originalTransactionId">Optional original transaction ID for audit trail</param>
     /// <param name="initiatedBy">User who initiated the refund</param>
     /// <param name="initiatedByUserId">Clerk user ID if initiated by an admin user</param>
+    /// <param name="requestLogId">Optional ID of the original request log, used to prorate refunds of
+    /// provider-cost-billed requests from the amount actually charged.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A RefundResult containing the refund details and transaction ID</returns>
     /// <exception cref="InvalidOperationException">Thrown when the virtual key group is not found</exception>
@@ -31,5 +33,6 @@ public interface IRefundService
         string? originalTransactionId,
         string initiatedBy,
         string? initiatedByUserId,
+        int? requestLogId = null,
         CancellationToken cancellationToken = default);
 }

--- a/Services/ConduitLLM.Admin/Models/Models/CreateModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/CreateModelDto.cs
@@ -84,6 +84,9 @@ namespace ConduitLLM.Admin.Models.Models
         /// <summary>Whether the model supports text-to-speech synthesis.</summary>
         public bool SupportsTextToSpeech { get; set; }
 
+        /// <summary>Whether the model supports document reranking.</summary>
+        public bool SupportsRerank { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/Models/CreateModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/CreateModelDto.cs
@@ -78,6 +78,12 @@ namespace ConduitLLM.Admin.Models.Models
         /// </summary>
         public bool SupportsVideoGeneration { get; set; }
 
+        /// <summary>Whether the model supports speech-to-text transcription.</summary>
+        public bool SupportsSpeechToText { get; set; }
+
+        /// <summary>Whether the model supports text-to-speech synthesis.</summary>
+        public bool SupportsTextToSpeech { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/Models/ModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/ModelDto.cs
@@ -120,6 +120,9 @@ namespace ConduitLLM.Admin.Models.Models
         /// <summary>Whether the model supports text-to-speech synthesis.</summary>
         public bool SupportsTextToSpeech { get; set; }
 
+        /// <summary>Whether the model supports document reranking.</summary>
+        public bool SupportsRerank { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/Models/ModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/ModelDto.cs
@@ -114,6 +114,12 @@ namespace ConduitLLM.Admin.Models.Models
         /// </summary>
         public bool SupportsVideoGeneration { get; set; }
 
+        /// <summary>Whether the model supports speech-to-text transcription.</summary>
+        public bool SupportsSpeechToText { get; set; }
+
+        /// <summary>Whether the model supports text-to-speech synthesis.</summary>
+        public bool SupportsTextToSpeech { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/Models/UpdateModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/UpdateModelDto.cs
@@ -98,6 +98,9 @@ namespace ConduitLLM.Admin.Models.Models
         /// <summary>Whether the model supports text-to-speech synthesis.</summary>
         public bool? SupportsTextToSpeech { get; set; }
 
+        /// <summary>Whether the model supports document reranking.</summary>
+        public bool? SupportsRerank { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/Models/UpdateModelDto.cs
+++ b/Services/ConduitLLM.Admin/Models/Models/UpdateModelDto.cs
@@ -92,6 +92,12 @@ namespace ConduitLLM.Admin.Models.Models
         /// <value>True to enable video generation, false to disable, or null to keep existing.</value>
         public bool? SupportsVideoGeneration { get; set; }
 
+        /// <summary>Whether the model supports speech-to-text transcription.</summary>
+        public bool? SupportsSpeechToText { get; set; }
+
+        /// <summary>Whether the model supports text-to-speech synthesis.</summary>
+        public bool? SupportsTextToSpeech { get; set; }
+
         /// <summary>
         /// Gets or sets whether the model supports text embeddings generation.
         /// </summary>

--- a/Services/ConduitLLM.Admin/Models/ProviderSync/DriftPayloads.cs
+++ b/Services/ConduitLLM.Admin/Models/ProviderSync/DriftPayloads.cs
@@ -1,0 +1,29 @@
+namespace ConduitLLM.Admin.Models.ProviderSync
+{
+    /// <summary>
+    /// Pricing snapshot (per-million USD, cache read/write nullable) used for Pricing and MissingCost
+    /// drift. Current = Conduit's ModelCost; Proposed = OpenRouter's published pricing.
+    /// </summary>
+    public class PricingDriftPayload
+    {
+        public decimal? InputPerMillion { get; set; }
+        public decimal? OutputPerMillion { get; set; }
+        public decimal? CachedInputPerMillion { get; set; }
+        public decimal? CachedWritePerMillion { get; set; }
+    }
+
+    /// <summary>Context-window snapshot for ContextWindow drift.</summary>
+    public class ContextWindowDriftPayload
+    {
+        public int? MaxInputTokens { get; set; }
+        public int? MaxOutputTokens { get; set; }
+    }
+
+    /// <summary>Capability snapshot for Capabilities drift.</summary>
+    public class CapabilitiesDriftPayload
+    {
+        public bool SupportsVision { get; set; }
+        public bool SupportsFunctionCalling { get; set; }
+        public bool SupportsImageGeneration { get; set; }
+    }
+}

--- a/Services/ConduitLLM.Admin/Models/ProviderSync/OpenRouterCatalog.cs
+++ b/Services/ConduitLLM.Admin/Models/ProviderSync/OpenRouterCatalog.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Admin.Models.ProviderSync
+{
+    /// <summary>Typed subset of OpenRouter's /models response used for drift detection.</summary>
+    internal record OpenRouterCatalogResponse
+    {
+        [JsonPropertyName("data")]
+        public List<OpenRouterCatalogModel>? Data { get; init; }
+    }
+
+    internal record OpenRouterCatalogModel
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; init; }
+
+        [JsonPropertyName("canonical_slug")]
+        public string? CanonicalSlug { get; init; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; init; }
+
+        [JsonPropertyName("context_length")]
+        public int? ContextLength { get; init; }
+
+        [JsonPropertyName("architecture")]
+        public OpenRouterCatalogArchitecture? Architecture { get; init; }
+
+        [JsonPropertyName("pricing")]
+        public OpenRouterCatalogPricing? Pricing { get; init; }
+
+        [JsonPropertyName("top_provider")]
+        public OpenRouterCatalogTopProvider? TopProvider { get; init; }
+
+        [JsonPropertyName("supported_parameters")]
+        public List<string>? SupportedParameters { get; init; }
+
+        [JsonPropertyName("expiration_date")]
+        public string? ExpirationDate { get; init; }
+    }
+
+    internal record OpenRouterCatalogArchitecture
+    {
+        [JsonPropertyName("input_modalities")]
+        public List<string>? InputModalities { get; init; }
+
+        [JsonPropertyName("output_modalities")]
+        public List<string>? OutputModalities { get; init; }
+    }
+
+    internal record OpenRouterCatalogPricing
+    {
+        [JsonPropertyName("prompt")]
+        public string? Prompt { get; init; }
+
+        [JsonPropertyName("completion")]
+        public string? Completion { get; init; }
+
+        [JsonPropertyName("input_cache_read")]
+        public string? InputCacheRead { get; init; }
+
+        [JsonPropertyName("input_cache_write")]
+        public string? InputCacheWrite { get; init; }
+    }
+
+    internal record OpenRouterCatalogTopProvider
+    {
+        [JsonPropertyName("max_completion_tokens")]
+        public int? MaxCompletionTokens { get; init; }
+
+        [JsonPropertyName("context_length")]
+        public int? ContextLength { get; init; }
+    }
+}

--- a/Services/ConduitLLM.Admin/Models/ProviderSync/ProviderSyncDtos.cs
+++ b/Services/ConduitLLM.Admin/Models/ProviderSync/ProviderSyncDtos.cs
@@ -1,0 +1,69 @@
+namespace ConduitLLM.Admin.Models.ProviderSync
+{
+    /// <summary>A drift item surfaced to the admin review UI.</summary>
+    public class DriftItemDto
+    {
+        public int Id { get; set; }
+        public int ModelProviderMappingId { get; set; }
+        public string ModelAlias { get; set; } = string.Empty;
+        public int ProviderId { get; set; }
+        public string ProviderName { get; set; } = string.Empty;
+        public string OpenRouterModelId { get; set; } = string.Empty;
+        public string DriftType { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>Conduit's current values at detection time (JSON; shape depends on DriftType).</summary>
+        public string CurrentValuesJson { get; set; } = "{}";
+
+        /// <summary>The provider's proposed values (JSON; shape depends on DriftType).</summary>
+        public string ProposedValuesJson { get; set; } = "{}";
+
+        public DateTime FirstDetectedAt { get; set; }
+        public DateTime LastDetectedAt { get; set; }
+        public DateTime? ResolvedAt { get; set; }
+        public string? ResolvedBy { get; set; }
+    }
+
+    /// <summary>A summary of a sync run for the run-history panel.</summary>
+    public class ProviderSyncRunDto
+    {
+        public int Id { get; set; }
+        public string ProviderType { get; set; } = string.Empty;
+        public DateTime StartedAt { get; set; }
+        public DateTime? CompletedAt { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string TriggeredBy { get; set; } = string.Empty;
+        public int ModelsFetched { get; set; }
+        public int MappingsChecked { get; set; }
+        public int ItemsCreated { get; set; }
+        public int ItemsUpdated { get; set; }
+        public int ItemsAutoResolved { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    /// <summary>Result of applying or dismissing a single drift item.</summary>
+    public class DriftActionResultDto
+    {
+        public int Id { get; set; }
+        public bool Success { get; set; }
+
+        /// <summary>True when the item was rejected because Conduit's current values changed since detection.</summary>
+        public bool Stale { get; set; }
+
+        public string? Error { get; set; }
+    }
+
+    /// <summary>Request body for bulk apply/dismiss.</summary>
+    public class BulkDriftActionRequest
+    {
+        public List<int> Ids { get; set; } = new();
+    }
+
+    /// <summary>Partial-success response for bulk apply/dismiss.</summary>
+    public class BulkDriftActionResponse
+    {
+        public int SucceededCount { get; set; }
+        public int FailedCount { get; set; }
+        public List<DriftActionResultDto> Results { get; set; } = new();
+    }
+}

--- a/Services/ConduitLLM.Admin/Program.Services.cs
+++ b/Services/ConduitLLM.Admin/Program.Services.cs
@@ -65,5 +65,8 @@ public partial class Program
 
         // Add media lifecycle services (scheduler, storage, distributed locking)
         builder.Services.AddMediaLifecycleServices(builder.Configuration);
+
+        // Add OpenRouter metadata sync (drift detection + review + scheduled job)
+        builder.Services.AddOpenRouterSyncServices(builder.Configuration);
     }
 }

--- a/Services/ConduitLLM.Admin/Services/AdminModelProviderMappingService.cs
+++ b/Services/ConduitLLM.Admin/Services/AdminModelProviderMappingService.cs
@@ -161,7 +161,8 @@ public class AdminModelProviderMappingService : EventPublishingServiceBase, IAdm
             existingMapping.ProviderId = mapping.ProviderId;
             existingMapping.ModelProviderTypeAssociationId = mapping.ModelProviderTypeAssociationId;
             existingMapping.IsEnabled = mapping.IsEnabled;
-            
+            existingMapping.ProviderOptions = mapping.ProviderOptions;
+
             existingMapping.UpdatedAt = DateTime.UtcNow;
 
             // Update the mapping

--- a/Services/ConduitLLM.Admin/Services/AdminProviderSyncService.cs
+++ b/Services/ConduitLLM.Admin/Services/AdminProviderSyncService.cs
@@ -1,0 +1,364 @@
+using System.Text.Json;
+
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Models.ProviderSync;
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Data;
+using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Enums;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Services;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Admin.Services
+{
+    /// <inheritdoc />
+    public class AdminProviderSyncService : EventPublishingServiceBase, IAdminProviderSyncService
+    {
+        private readonly IDbContextFactory<ConduitDbContext> _dbFactory;
+        private readonly IAdminModelCostService _modelCostService;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public AdminProviderSyncService(
+            IDbContextFactory<ConduitDbContext> dbFactory,
+            IAdminModelCostService modelCostService,
+            ILogger<AdminProviderSyncService> logger,
+            IEventBus? eventBus = null)
+            : base(eventBus, logger)
+        {
+            _dbFactory = dbFactory;
+            _modelCostService = modelCostService;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<DriftItemDto>> GetDriftItemsAsync(string? status, string? driftType, int? providerId, int page, int pageSize)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var query = db.ProviderMetadataDriftItems
+                .Include(x => x.Mapping)
+                .AsNoTracking()
+                .AsQueryable();
+
+            if (!string.IsNullOrEmpty(status) && Enum.TryParse<DriftStatus>(status, true, out var s))
+                query = query.Where(x => x.Status == s);
+            else if (string.IsNullOrEmpty(status))
+                query = query.Where(x => x.Status == DriftStatus.Pending);
+
+            if (!string.IsNullOrEmpty(driftType) && Enum.TryParse<DriftType>(driftType, true, out var dt))
+                query = query.Where(x => x.DriftType == dt);
+            if (providerId.HasValue)
+                query = query.Where(x => x.ProviderId == providerId.Value);
+
+            var items = await query
+                .OrderByDescending(x => x.LastDetectedAt)
+                .Skip(Math.Max(0, page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            var providerNames = await LoadProviderNamesAsync(db, items.Select(i => i.ProviderId));
+            return items.Select(i => MapItem(i, providerNames)).ToList();
+        }
+
+        /// <inheritdoc />
+        public async Task<DriftItemDto?> GetDriftItemAsync(int id)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var item = await db.ProviderMetadataDriftItems.Include(x => x.Mapping).AsNoTracking()
+                .FirstOrDefaultAsync(x => x.Id == id);
+            if (item == null)
+                return null;
+            var providerNames = await LoadProviderNamesAsync(db, new[] { item.ProviderId });
+            return MapItem(item, providerNames);
+        }
+
+        /// <inheritdoc />
+        public async Task<DriftActionResultDto> ApplyAsync(int id, string actor)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var item = await db.ProviderMetadataDriftItems.FirstOrDefaultAsync(x => x.Id == id);
+            if (item == null)
+                return new DriftActionResultDto { Id = id, Success = false, Error = "Drift item not found." };
+            if (item.Status != DriftStatus.Pending)
+                return new DriftActionResultDto { Id = id, Success = false, Error = $"Drift item is already {item.Status}." };
+
+            var mapping = await db.ModelProviderMappings
+                .Include(m => m.ModelProviderTypeAssociation).ThenInclude(a => a.Model)
+                .Include(m => m.ModelProviderTypeAssociation).ThenInclude(a => a.ModelCost)
+                .FirstOrDefaultAsync(m => m.Id == item.ModelProviderMappingId);
+            if (mapping == null)
+                return new DriftActionResultDto { Id = id, Success = false, Error = "Mapping no longer exists." };
+
+            // Staleness guard: if Conduit's current values changed since detection, refuse to apply.
+            var liveCurrent = RecomputeCurrentJson(item.DriftType, mapping);
+            if (liveCurrent != null && !JsonEquivalent(liveCurrent, item.CurrentValuesJson))
+            {
+                return new DriftActionResultDto
+                {
+                    Id = id,
+                    Success = false,
+                    Stale = true,
+                    Error = "Current values changed since detection — re-run sync and review again."
+                };
+            }
+
+            try
+            {
+                await ApplyDriftAsync(db, item, mapping);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to apply drift item {DriftItemId}", id);
+                return new DriftActionResultDto { Id = id, Success = false, Error = ex.Message };
+            }
+
+            item.Status = DriftStatus.Applied;
+            item.ResolvedAt = DateTime.UtcNow;
+            item.ResolvedBy = actor;
+            await db.SaveChangesAsync();
+
+            return new DriftActionResultDto { Id = id, Success = true };
+        }
+
+        /// <inheritdoc />
+        public async Task<DriftActionResultDto> DismissAsync(int id, string actor)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var item = await db.ProviderMetadataDriftItems.FirstOrDefaultAsync(x => x.Id == id);
+            if (item == null)
+                return new DriftActionResultDto { Id = id, Success = false, Error = "Drift item not found." };
+            if (item.Status != DriftStatus.Pending)
+                return new DriftActionResultDto { Id = id, Success = false, Error = $"Drift item is already {item.Status}." };
+
+            item.Status = DriftStatus.Dismissed;
+            item.ResolvedAt = DateTime.UtcNow;
+            item.ResolvedBy = actor;
+            await db.SaveChangesAsync();
+            return new DriftActionResultDto { Id = id, Success = true };
+        }
+
+        /// <inheritdoc />
+        public async Task<BulkDriftActionResponse> ApplyBulkAsync(IReadOnlyList<int> ids, string actor)
+        {
+            var results = new List<DriftActionResultDto>();
+            foreach (var id in ids)
+                results.Add(await ApplyAsync(id, actor));
+            return AggregateBulk(results);
+        }
+
+        /// <inheritdoc />
+        public async Task<BulkDriftActionResponse> DismissBulkAsync(IReadOnlyList<int> ids, string actor)
+        {
+            var results = new List<DriftActionResultDto>();
+            foreach (var id in ids)
+                results.Add(await DismissAsync(id, actor));
+            return AggregateBulk(results);
+        }
+
+        /// <inheritdoc />
+        public async Task<List<ProviderSyncRunDto>> GetSyncRunsAsync(int page, int pageSize)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var runs = await db.ProviderMetadataSyncRuns.AsNoTracking()
+                .OrderByDescending(r => r.Id)
+                .Skip(Math.Max(0, page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return runs.Select(r => new ProviderSyncRunDto
+            {
+                Id = r.Id,
+                ProviderType = r.ProviderType.ToString(),
+                StartedAt = r.StartedAt,
+                CompletedAt = r.CompletedAt,
+                Status = r.Status,
+                TriggeredBy = r.TriggeredBy,
+                ModelsFetched = r.ModelsFetched,
+                MappingsChecked = r.MappingsChecked,
+                ItemsCreated = r.ItemsCreated,
+                ItemsUpdated = r.ItemsUpdated,
+                ItemsAutoResolved = r.ItemsAutoResolved,
+                ErrorMessage = r.ErrorMessage
+            }).ToList();
+        }
+
+        private async Task ApplyDriftAsync(ConduitDbContext db, ProviderMetadataDriftItem item, ModelProviderMapping mapping)
+        {
+            var mpta = mapping.ModelProviderTypeAssociation;
+
+            switch (item.DriftType)
+            {
+                case DriftType.Pricing:
+                {
+                    var proposed = Deserialize<PricingDriftPayload>(item.ProposedValuesJson);
+                    var cost = mpta?.ModelCost
+                        ?? throw new InvalidOperationException("Mapping has no ModelCost to update.");
+                    var dto = BuildUpdateDto(cost, proposed);
+                    await _modelCostService.UpdateModelCostAsync(dto); // fires ModelCostChanged -> cache invalidation
+                    break;
+                }
+                case DriftType.MissingCost:
+                {
+                    var proposed = Deserialize<PricingDriftPayload>(item.ProposedValuesJson);
+                    if (mpta == null)
+                        throw new InvalidOperationException("Mapping has no provider-type association to associate a cost with.");
+                    var dto = BuildCreateDto(item.OpenRouterModelId, mpta.Id, proposed);
+                    await _modelCostService.CreateModelCostAsync(dto); // fires ModelCostChanged (Created)
+                    break;
+                }
+                case DriftType.ContextWindow:
+                {
+                    var proposed = Deserialize<ContextWindowDriftPayload>(item.ProposedValuesJson);
+                    if (mpta == null)
+                        throw new InvalidOperationException("Mapping has no provider-type association to update.");
+                    // Provider-scoped override (safe for other providers of the same canonical model).
+                    var tracked = await db.ModelProviderTypeAssociations.FirstAsync(a => a.Id == mpta.Id);
+                    if (proposed.MaxInputTokens.HasValue) tracked.MaxInputTokens = proposed.MaxInputTokens;
+                    if (proposed.MaxOutputTokens.HasValue) tracked.MaxOutputTokens = proposed.MaxOutputTokens;
+                    await db.SaveChangesAsync();
+                    break;
+                }
+                case DriftType.Capabilities:
+                {
+                    var proposed = Deserialize<CapabilitiesDriftPayload>(item.ProposedValuesJson);
+                    if (mpta?.Model == null)
+                        throw new InvalidOperationException("Mapping has no model to update.");
+                    // Shared canonical Model flags (affects all providers routing this model).
+                    var tracked = await db.Models.FirstAsync(m => m.Id == mpta.Model.Id);
+                    tracked.SupportsVision = proposed.SupportsVision;
+                    tracked.SupportsFunctionCalling = proposed.SupportsFunctionCalling;
+                    tracked.SupportsImageGeneration = proposed.SupportsImageGeneration;
+                    await db.SaveChangesAsync();
+                    break;
+                }
+                case DriftType.ModelRemoved:
+                case DriftType.ModelDeprecated:
+                {
+                    // Disable the mapping so it stops routing to the removed/deprecated model.
+                    var tracked = await db.ModelProviderMappings.FirstAsync(m => m.Id == mapping.Id);
+                    tracked.IsEnabled = false;
+                    await db.SaveChangesAsync();
+                    break;
+                }
+            }
+        }
+
+        private static string? RecomputeCurrentJson(DriftType driftType, ModelProviderMapping mapping)
+        {
+            var mpta = mapping.ModelProviderTypeAssociation;
+            var model = mpta?.Model;
+            var cost = mpta?.ModelCost;
+
+            switch (driftType)
+            {
+                case DriftType.Pricing:
+                    if (cost == null) return null;
+                    return Serialize(new PricingDriftPayload
+                    {
+                        InputPerMillion = Math.Round(cost.InputCostPerMillionTokens, 4),
+                        OutputPerMillion = Math.Round(cost.OutputCostPerMillionTokens, 4),
+                        CachedInputPerMillion = cost.CachedInputCostPerMillionTokens.HasValue ? Math.Round(cost.CachedInputCostPerMillionTokens.Value, 4) : null,
+                        CachedWritePerMillion = cost.CachedInputWriteCostPerMillionTokens.HasValue ? Math.Round(cost.CachedInputWriteCostPerMillionTokens.Value, 4) : null
+                    });
+                case DriftType.ContextWindow:
+                    return Serialize(new ContextWindowDriftPayload
+                    {
+                        MaxInputTokens = mpta?.MaxInputTokens ?? model?.MaxInputTokens,
+                        MaxOutputTokens = mpta?.MaxOutputTokens ?? model?.MaxOutputTokens
+                    });
+                case DriftType.Capabilities:
+                    if (model == null) return null;
+                    return Serialize(new CapabilitiesDriftPayload
+                    {
+                        SupportsVision = model.SupportsVision,
+                        SupportsFunctionCalling = model.SupportsFunctionCalling,
+                        SupportsImageGeneration = model.SupportsImageGeneration
+                    });
+                default:
+                    return null; // MissingCost / ModelRemoved / ModelDeprecated: no meaningful current snapshot to guard.
+            }
+        }
+
+        private static UpdateModelCostDto BuildUpdateDto(ModelCost cost, PricingDriftPayload proposed) => new()
+        {
+            Id = cost.Id,
+            CostName = cost.CostName,
+            PricingModel = cost.PricingModel,
+            PricingConfiguration = cost.PricingConfiguration,
+            ModelType = cost.ModelType,
+            IsActive = cost.IsActive,
+            Priority = cost.Priority,
+            Description = cost.Description,
+            InputCostPerMillionTokens = proposed.InputPerMillion ?? cost.InputCostPerMillionTokens,
+            OutputCostPerMillionTokens = proposed.OutputPerMillion ?? cost.OutputCostPerMillionTokens,
+            EmbeddingCostPerMillionTokens = cost.EmbeddingCostPerMillionTokens,
+            BatchProcessingMultiplier = cost.BatchProcessingMultiplier,
+            SupportsBatchProcessing = cost.SupportsBatchProcessing,
+            CachedInputCostPerMillionTokens = proposed.CachedInputPerMillion ?? cost.CachedInputCostPerMillionTokens,
+            CachedInputWriteCostPerMillionTokens = proposed.CachedWritePerMillion ?? cost.CachedInputWriteCostPerMillionTokens,
+            CostPerSearchUnit = cost.CostPerSearchUnit,
+            AudioCostPerMinute = cost.AudioCostPerMinute,
+            AudioCostPerThousandCharacters = cost.AudioCostPerThousandCharacters,
+            ModelProviderTypeAssociationIds = null // leave associations unchanged
+        };
+
+        private static CreateModelCostDto BuildCreateDto(string modelId, int mptaId, PricingDriftPayload proposed) => new()
+        {
+            CostName = $"openrouter/{modelId} (synced)",
+            PricingModel = PricingModel.Standard,
+            ModelType = "chat",
+            InputCostPerMillionTokens = proposed.InputPerMillion ?? 0m,
+            OutputCostPerMillionTokens = proposed.OutputPerMillion ?? 0m,
+            CachedInputCostPerMillionTokens = proposed.CachedInputPerMillion,
+            CachedInputWriteCostPerMillionTokens = proposed.CachedWritePerMillion,
+            ModelProviderTypeAssociationIds = new List<int> { mptaId }
+        };
+
+        private static async Task<Dictionary<int, string>> LoadProviderNamesAsync(ConduitDbContext db, IEnumerable<int> providerIds)
+        {
+            var ids = providerIds.Distinct().ToList();
+            return await db.Providers.AsNoTracking()
+                .Where(p => ids.Contains(p.Id))
+                .ToDictionaryAsync(p => p.Id, p => p.ProviderName);
+        }
+
+        private static DriftItemDto MapItem(ProviderMetadataDriftItem item, IReadOnlyDictionary<int, string> providerNames) => new()
+        {
+            Id = item.Id,
+            ModelProviderMappingId = item.ModelProviderMappingId,
+            ModelAlias = item.Mapping?.ModelAlias ?? string.Empty,
+            ProviderId = item.ProviderId,
+            ProviderName = providerNames.TryGetValue(item.ProviderId, out var name) ? name : string.Empty,
+            OpenRouterModelId = item.OpenRouterModelId,
+            DriftType = item.DriftType.ToString(),
+            Status = item.Status.ToString(),
+            CurrentValuesJson = item.CurrentValuesJson,
+            ProposedValuesJson = item.ProposedValuesJson,
+            FirstDetectedAt = item.FirstDetectedAt,
+            LastDetectedAt = item.LastDetectedAt,
+            ResolvedAt = item.ResolvedAt,
+            ResolvedBy = item.ResolvedBy
+        };
+
+        private static BulkDriftActionResponse AggregateBulk(List<DriftActionResultDto> results) => new()
+        {
+            Results = results,
+            SucceededCount = results.Count(r => r.Success),
+            FailedCount = results.Count(r => !r.Success)
+        };
+
+        private static T Deserialize<T>(string json) where T : new()
+            => JsonSerializer.Deserialize<T>(json, JsonOptions) ?? new T();
+
+        private static string Serialize(object value) => JsonSerializer.Serialize(value, JsonOptions);
+
+        private static bool JsonEquivalent(string a, string b)
+            => string.Equals(a, b, StringComparison.Ordinal);
+    }
+}

--- a/Services/ConduitLLM.Admin/Services/OpenRouterDriftDetectionService.cs
+++ b/Services/ConduitLLM.Admin/Services/OpenRouterDriftDetectionService.cs
@@ -1,0 +1,331 @@
+using System.Globalization;
+using System.Text.Json;
+
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Models.ProviderSync;
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Data;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Enums;
+using ConduitLLM.Configuration.Options;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ConduitLLM.Admin.Services
+{
+    /// <inheritdoc />
+    public class OpenRouterDriftDetectionService : IOpenRouterDriftDetectionService
+    {
+        private readonly IDbContextFactory<ConduitDbContext> _dbFactory;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly OpenRouterSyncOptions _options;
+        private readonly ILogger<OpenRouterDriftDetectionService> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        public OpenRouterDriftDetectionService(
+            IDbContextFactory<ConduitDbContext> dbFactory,
+            IHttpClientFactory httpClientFactory,
+            IOptions<OpenRouterSyncOptions> options,
+            ILogger<OpenRouterDriftDetectionService> logger)
+        {
+            _dbFactory = dbFactory;
+            _httpClientFactory = httpClientFactory;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<ProviderSyncRunDto> RunSyncAsync(string triggeredBy, CancellationToken cancellationToken = default)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+            var run = new ProviderMetadataSyncRun
+            {
+                ProviderType = ProviderType.OpenRouter,
+                TriggeredBy = triggeredBy,
+                Status = "Running",
+                StartedAt = DateTime.UtcNow
+            };
+            db.ProviderMetadataSyncRuns.Add(run);
+            await db.SaveChangesAsync(cancellationToken);
+
+            try
+            {
+                var catalog = await FetchCatalogAsync(cancellationToken);
+                run.ModelsFetched = catalog.Count;
+
+                var byId = new Dictionary<string, OpenRouterCatalogModel>(StringComparer.OrdinalIgnoreCase);
+                var bySlug = new Dictionary<string, OpenRouterCatalogModel>(StringComparer.OrdinalIgnoreCase);
+                foreach (var m in catalog)
+                {
+                    if (!string.IsNullOrEmpty(m.Id)) byId[m.Id] = m;
+                    if (!string.IsNullOrEmpty(m.CanonicalSlug)) bySlug[m.CanonicalSlug!] = m;
+                }
+
+                var mappings = await db.ModelProviderMappings
+                    .Include(x => x.Provider)
+                    .Include(x => x.ModelProviderTypeAssociation).ThenInclude(a => a.Model)
+                    .Include(x => x.ModelProviderTypeAssociation).ThenInclude(a => a.ModelCost)
+                    .Where(x => x.IsEnabled && x.Provider.ProviderType == ProviderType.OpenRouter)
+                    .ToListAsync(cancellationToken);
+                run.MappingsChecked = mappings.Count;
+
+                foreach (var mapping in mappings)
+                {
+                    await ProcessMappingAsync(db, run, mapping, byId, bySlug, cancellationToken);
+                }
+
+                run.Status = "Completed";
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "OpenRouter metadata sync run {RunId} failed", run.Id);
+                run.Status = "Failed";
+                run.ErrorMessage = ex.Message.Length > 2000 ? ex.Message[..2000] : ex.Message;
+            }
+            finally
+            {
+                run.CompletedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync(cancellationToken);
+            }
+
+            return MapRun(run);
+        }
+
+        private async Task<List<OpenRouterCatalogModel>> FetchCatalogAsync(CancellationToken cancellationToken)
+        {
+            using var client = _httpClientFactory.CreateClient("OpenRouterSync");
+            client.Timeout = TimeSpan.FromSeconds(_options.HttpTimeoutSeconds);
+
+            using var response = await client.GetAsync(_options.ModelsEndpoint, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var parsed = JsonSerializer.Deserialize<OpenRouterCatalogResponse>(json, JsonOptions);
+            var models = parsed?.Data ?? new List<OpenRouterCatalogModel>();
+
+            // The full list is returned when offset/limit are omitted; a suspiciously round count may
+            // indicate a paginated truncation. Log it rather than silently under-comparing.
+            if (models.Count is 500 or 1000)
+            {
+                _logger.LogWarning(
+                    "OpenRouter catalog returned exactly {Count} models — verify this is the full list, not a paginated page.",
+                    models.Count);
+            }
+
+            return models;
+        }
+
+        private async Task ProcessMappingAsync(
+            ConduitDbContext db,
+            ProviderMetadataSyncRun run,
+            ModelProviderMapping mapping,
+            IReadOnlyDictionary<string, OpenRouterCatalogModel> byId,
+            IReadOnlyDictionary<string, OpenRouterCatalogModel> bySlug,
+            CancellationToken cancellationToken)
+        {
+            var modelId = mapping.ProviderModelId;
+            OpenRouterCatalogModel? catalog = byId.TryGetValue(modelId, out var c1) ? c1
+                : bySlug.TryGetValue(modelId, out var c2) ? c2 : null;
+
+            var mpta = mapping.ModelProviderTypeAssociation;
+            var model = mpta?.Model;
+            var cost = mpta?.ModelCost;
+
+            var detected = new Dictionary<DriftType, (string current, string proposed)>();
+
+            if (catalog == null)
+            {
+                detected[DriftType.ModelRemoved] = ("{}", Json(new { removed = true }));
+            }
+            else
+            {
+                ComputePricingDrift(catalog, cost, detected);
+                ComputeContextWindowDrift(catalog, mpta, model, detected);
+                ComputeCapabilitiesDrift(catalog, model, detected);
+
+                if (!string.IsNullOrEmpty(catalog.ExpirationDate))
+                    detected[DriftType.ModelDeprecated] = ("{}", Json(new { expirationDate = catalog.ExpirationDate }));
+            }
+
+            foreach (var driftType in Enum.GetValues<DriftType>())
+            {
+                var existingPending = await db.ProviderMetadataDriftItems.FirstOrDefaultAsync(
+                    x => x.ModelProviderMappingId == mapping.Id && x.DriftType == driftType && x.Status == DriftStatus.Pending,
+                    cancellationToken);
+
+                if (detected.TryGetValue(driftType, out var d))
+                {
+                    if (existingPending != null)
+                    {
+                        existingPending.CurrentValuesJson = d.current;
+                        existingPending.ProposedValuesJson = d.proposed;
+                        existingPending.LastDetectedAt = DateTime.UtcNow;
+                        existingPending.LastSyncRunId = run.Id;
+                        existingPending.OpenRouterModelId = modelId;
+                        run.ItemsUpdated++;
+                    }
+                    else
+                    {
+                        // Don't re-open an item an admin dismissed with the same proposal.
+                        var lastDismissed = await db.ProviderMetadataDriftItems
+                            .Where(x => x.ModelProviderMappingId == mapping.Id && x.DriftType == driftType && x.Status == DriftStatus.Dismissed)
+                            .OrderByDescending(x => x.Id)
+                            .FirstOrDefaultAsync(cancellationToken);
+                        if (lastDismissed != null && lastDismissed.ProposedValuesJson == d.proposed)
+                            continue;
+
+                        db.ProviderMetadataDriftItems.Add(new ProviderMetadataDriftItem
+                        {
+                            ModelProviderMappingId = mapping.Id,
+                            ProviderId = mapping.ProviderId,
+                            OpenRouterModelId = modelId,
+                            DriftType = driftType,
+                            Status = DriftStatus.Pending,
+                            CurrentValuesJson = d.current,
+                            ProposedValuesJson = d.proposed,
+                            FirstDetectedAt = DateTime.UtcNow,
+                            LastDetectedAt = DateTime.UtcNow,
+                            LastSyncRunId = run.Id
+                        });
+                        run.ItemsCreated++;
+                    }
+                }
+                else if (existingPending != null)
+                {
+                    existingPending.Status = DriftStatus.AutoResolved;
+                    existingPending.ResolvedAt = DateTime.UtcNow;
+                    existingPending.ResolvedBy = "system:auto-resolve";
+                    existingPending.LastSyncRunId = run.Id;
+                    run.ItemsAutoResolved++;
+                }
+            }
+        }
+
+        private static void ComputePricingDrift(
+            OpenRouterCatalogModel catalog, ModelCost? cost,
+            Dictionary<DriftType, (string current, string proposed)> detected)
+        {
+            var proposed = new PricingDriftPayload
+            {
+                InputPerMillion = ToPerMillion(catalog.Pricing?.Prompt),
+                OutputPerMillion = ToPerMillion(catalog.Pricing?.Completion),
+                CachedInputPerMillion = ToPerMillion(catalog.Pricing?.InputCacheRead),
+                CachedWritePerMillion = ToPerMillion(catalog.Pricing?.InputCacheWrite)
+            };
+
+            if (cost == null)
+            {
+                if (proposed.InputPerMillion.HasValue || proposed.OutputPerMillion.HasValue)
+                    detected[DriftType.MissingCost] = (Json(new PricingDriftPayload()), Json(proposed));
+                return;
+            }
+
+            var current = new PricingDriftPayload
+            {
+                InputPerMillion = Round4(cost.InputCostPerMillionTokens),
+                OutputPerMillion = Round4(cost.OutputCostPerMillionTokens),
+                CachedInputPerMillion = Round4(cost.CachedInputCostPerMillionTokens),
+                CachedWritePerMillion = Round4(cost.CachedInputWriteCostPerMillionTokens)
+            };
+
+            if (current.InputPerMillion != proposed.InputPerMillion
+                || current.OutputPerMillion != proposed.OutputPerMillion
+                || current.CachedInputPerMillion != proposed.CachedInputPerMillion
+                || current.CachedWritePerMillion != proposed.CachedWritePerMillion)
+            {
+                detected[DriftType.Pricing] = (Json(current), Json(proposed));
+            }
+        }
+
+        private static void ComputeContextWindowDrift(
+            OpenRouterCatalogModel catalog, ModelProviderTypeAssociation? mpta, Model? model,
+            Dictionary<DriftType, (string current, string proposed)> detected)
+        {
+            var proposed = new ContextWindowDriftPayload
+            {
+                MaxInputTokens = catalog.ContextLength ?? catalog.TopProvider?.ContextLength,
+                MaxOutputTokens = catalog.TopProvider?.MaxCompletionTokens
+            };
+            var current = new ContextWindowDriftPayload
+            {
+                MaxInputTokens = mpta?.MaxInputTokens ?? model?.MaxInputTokens,
+                MaxOutputTokens = mpta?.MaxOutputTokens ?? model?.MaxOutputTokens
+            };
+
+            // Only flag when the provider reports a value that differs (never propose a heuristic).
+            var inputDrift = proposed.MaxInputTokens.HasValue && proposed.MaxInputTokens != current.MaxInputTokens;
+            var outputDrift = proposed.MaxOutputTokens.HasValue && proposed.MaxOutputTokens != current.MaxOutputTokens;
+            if (inputDrift || outputDrift)
+                detected[DriftType.ContextWindow] = (Json(current), Json(proposed));
+        }
+
+        private static void ComputeCapabilitiesDrift(
+            OpenRouterCatalogModel catalog, Model? model,
+            Dictionary<DriftType, (string current, string proposed)> detected)
+        {
+            if (model == null)
+                return;
+
+            var input = catalog.Architecture?.InputModalities ?? new List<string>();
+            var output = catalog.Architecture?.OutputModalities ?? new List<string>();
+            var supported = catalog.SupportedParameters ?? new List<string>();
+
+            var proposed = new CapabilitiesDriftPayload
+            {
+                SupportsVision = input.Contains("image", StringComparer.OrdinalIgnoreCase),
+                SupportsFunctionCalling = supported.Contains("tools", StringComparer.OrdinalIgnoreCase),
+                SupportsImageGeneration = output.Contains("image", StringComparer.OrdinalIgnoreCase)
+            };
+            var current = new CapabilitiesDriftPayload
+            {
+                SupportsVision = model.SupportsVision,
+                SupportsFunctionCalling = model.SupportsFunctionCalling,
+                SupportsImageGeneration = model.SupportsImageGeneration
+            };
+
+            if (proposed.SupportsVision != current.SupportsVision
+                || proposed.SupportsFunctionCalling != current.SupportsFunctionCalling
+                || proposed.SupportsImageGeneration != current.SupportsImageGeneration)
+            {
+                detected[DriftType.Capabilities] = (Json(current), Json(proposed));
+            }
+        }
+
+        private static decimal? ToPerMillion(string? price)
+        {
+            if (string.IsNullOrEmpty(price))
+                return null;
+            if (!decimal.TryParse(price, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+                return null;
+            return Math.Round(parsed * 1_000_000m, 4);
+        }
+
+        private static decimal? Round4(decimal value) => Math.Round(value, 4);
+        private static decimal? Round4(decimal? value) => value.HasValue ? Math.Round(value.Value, 4) : null;
+
+        private static string Json(object value) => JsonSerializer.Serialize(value, JsonOptions);
+
+        private static ProviderSyncRunDto MapRun(ProviderMetadataSyncRun run) => new()
+        {
+            Id = run.Id,
+            ProviderType = run.ProviderType.ToString(),
+            StartedAt = run.StartedAt,
+            CompletedAt = run.CompletedAt,
+            Status = run.Status,
+            TriggeredBy = run.TriggeredBy,
+            ModelsFetched = run.ModelsFetched,
+            MappingsChecked = run.MappingsChecked,
+            ItemsCreated = run.ItemsCreated,
+            ItemsUpdated = run.ItemsUpdated,
+            ItemsAutoResolved = run.ItemsAutoResolved,
+            ErrorMessage = run.ErrorMessage
+        };
+    }
+}

--- a/Services/ConduitLLM.Admin/Services/OpenRouterMetadataSyncService.cs
+++ b/Services/ConduitLLM.Admin/Services/OpenRouterMetadataSyncService.cs
@@ -1,0 +1,80 @@
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Configuration.Options;
+using ConduitLLM.Core.Interfaces;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ConduitLLM.Admin.Services
+{
+    /// <summary>
+    /// Scheduled OpenRouter metadata drift detection. Leader-locked so it runs once cluster-wide, and
+    /// gated by <see cref="OpenRouterSyncOptions.Enabled"/> (drift can also be triggered on demand via
+    /// the Admin API regardless of this flag).
+    /// </summary>
+    public class OpenRouterMetadataSyncService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IDistributedLockService _lockService;
+        private readonly OpenRouterSyncOptions _options;
+        private readonly ILogger<OpenRouterMetadataSyncService> _logger;
+
+        private const string LeaderLockKey = "openrouter:metadata-sync:leader";
+
+        public OpenRouterMetadataSyncService(
+            IServiceScopeFactory scopeFactory,
+            IDistributedLockService lockService,
+            IOptions<OpenRouterSyncOptions> options,
+            ILogger<OpenRouterMetadataSyncService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _lockService = lockService;
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!_options.Enabled)
+            {
+                _logger.LogInformation("OpenRouter metadata sync scheduler is disabled (OpenRouterSync:Enabled=false).");
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(_options.InitialDelaySeconds), stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var lockHandle = await _lockService.AcquireLockAsync(
+                        LeaderLockKey, TimeSpan.FromMinutes(15), stoppingToken);
+
+                    if (lockHandle != null)
+                    {
+                        using var scope = _scopeFactory.CreateScope();
+                        var detection = scope.ServiceProvider.GetRequiredService<IOpenRouterDriftDetectionService>();
+                        var run = await detection.RunSyncAsync("Schedule", stoppingToken);
+                        _logger.LogInformation(
+                            "OpenRouter metadata sync {Status}: {Created} created, {Updated} updated, {AutoResolved} auto-resolved across {Mappings} mappings.",
+                            run.Status, run.ItemsCreated, run.ItemsUpdated, run.ItemsAutoResolved, run.MappingsChecked);
+                    }
+
+                    await Task.Delay(TimeSpan.FromHours(_options.ScheduleIntervalHours), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "OpenRouter metadata sync loop encountered an error; retrying after backoff.");
+                    await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+                }
+            }
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/Services/RefundService.cs
+++ b/Services/ConduitLLM.Admin/Services/RefundService.cs
@@ -17,6 +17,7 @@ public class RefundService : IRefundService
     private readonly ICostCalculationService _costCalculationService;
     private readonly IVirtualKeyGroupRepository _groupRepository;
     private readonly IConfigurationDbContext _context;
+    private readonly IRequestLogRepository? _requestLogRepository;
     private readonly ILogger<RefundService> _logger;
 
     /// <summary>
@@ -26,12 +27,14 @@ public class RefundService : IRefundService
         ICostCalculationService costCalculationService,
         IVirtualKeyGroupRepository groupRepository,
         IConfigurationDbContext context,
-        ILogger<RefundService> logger)
+        ILogger<RefundService> logger,
+        IRequestLogRepository? requestLogRepository = null)
     {
         _costCalculationService = costCalculationService;
         _groupRepository = groupRepository;
         _context = context;
         _logger = logger;
+        _requestLogRepository = requestLogRepository;
     }
 
     /// <inheritdoc />
@@ -44,6 +47,7 @@ public class RefundService : IRefundService
         string? originalTransactionId,
         string initiatedBy,
         string? initiatedByUserId,
+        int? requestLogId = null,
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation(
@@ -91,6 +95,23 @@ public class RefundService : IRefundService
                 virtualKeyGroupId);
         }
 
+        // If the original request was billed from a trusted provider-reported cost, it has no per-unit
+        // rates to recompute a refund from. Look up the original request log and, when it was billed
+        // that way, prorate the refund from the amount actually charged.
+        ProviderCostRefundContext? providerCostContext = null;
+        if (requestLogId.HasValue && _requestLogRepository != null)
+        {
+            var requestLog = await _requestLogRepository.GetByIdAsync(requestLogId.Value, cancellationToken);
+            if (requestLog?.BillingMethod == RequestBillingMethod.ProviderReportedCost)
+            {
+                providerCostContext = new ProviderCostRefundContext { OriginalChargedCost = requestLog.Cost };
+                _logger.LogInformation(
+                    "Refund for group {GroupId} references provider-cost-billed request log {RequestLogId} " +
+                    "(charged {Charged}); refund will be prorated from the charged amount.",
+                    virtualKeyGroupId, requestLogId.Value, requestLog.Cost);
+            }
+        }
+
         // Calculate refund using the cost calculation service
         var refundResult = await _costCalculationService.CalculateRefundAsync(
             modelId,
@@ -98,6 +119,7 @@ public class RefundService : IRefundService
             refundUsage,
             refundReason,
             originalTransactionId,
+            providerCostContext,
             cancellationToken);
 
         // Check for validation errors

--- a/Services/ConduitLLM.Gateway/Constants/HttpContextKeys.cs
+++ b/Services/ConduitLLM.Gateway/Constants/HttpContextKeys.cs
@@ -56,6 +56,22 @@ public static class HttpContextKeys
     /// </summary>
     public const string ModelCostId = "ModelCostId";
 
+    /// <summary>
+    /// Key for storing the provider billing policy (whether provider-reported cost is authoritative
+    /// and the markup to apply). Stamped by the controller from the resolved provider before the
+    /// request runs, and applied onto the Usage by UsageTrackingMiddleware before cost calculation.
+    /// Value type: ConduitLLM.Core.Models.ProviderCostBillingPolicy
+    /// </summary>
+    public const string ProviderBillingPolicy = "ProviderBillingPolicy";
+
+    /// <summary>
+    /// Key for storing the provider-reported cost (USD) for the request. Stashed by the controller
+    /// from the response Usage on non-streaming/media paths (the value is never serialized into the
+    /// client-facing body). On streaming, the cost travels on the StreamingUsage object instead.
+    /// Value type: decimal
+    /// </summary>
+    public const string ProviderReportedCost = "ProviderReportedCost";
+
     // NOTE: Image and video request-shape data (model, size, quality, duration, fps, style,
     // N, pricing parameters) is no longer carried via string keys. It now flows through the
     // typed ConduitLLM.Gateway.Usage.IUsageContext set by ImagesController/VideosController

--- a/Services/ConduitLLM.Gateway/Controllers/AudioController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/AudioController.cs
@@ -1,0 +1,154 @@
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Controllers;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models.Audio;
+using ConduitLLM.Gateway.Authorization;
+using ConduitLLM.Gateway.Constants;
+using ConduitLLM.Gateway.UsageTracking;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ConduitLLM.Gateway.Controllers
+{
+    /// <summary>
+    /// Handles audio transcription (speech-to-text) and speech synthesis (text-to-speech)
+    /// following OpenAI's API format.
+    /// </summary>
+    [ApiController]
+    [Route("v1/audio")]
+    [Authorize(AuthenticationSchemes = "VirtualKey")]
+    [RequireBalance]
+    [Tags("Audio")]
+    public class AudioController : GatewayControllerBase
+    {
+        private readonly ILLMClientFactory _clientFactory;
+        private readonly IModelProviderMappingService _modelMappingService;
+        private readonly ILogger<AudioController> _logger;
+
+        public AudioController(
+            ILLMClientFactory clientFactory,
+            IModelProviderMappingService modelMappingService,
+            ILogger<AudioController> logger,
+            IEventBus eventBus)
+            : base(eventBus, logger)
+        {
+            _clientFactory = clientFactory;
+            _modelMappingService = modelMappingService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Transcribes uploaded audio to text (OpenAI <c>/audio/transcriptions</c> compatible).
+        /// </summary>
+        [HttpPost("transcriptions")]
+        [RequestSizeLimit(26_214_400)] // 25 MB
+        public async Task<IActionResult> CreateTranscription(
+            [FromForm] IFormFile file,
+            [FromForm] string model,
+            [FromForm] string? language = null,
+            [FromForm] string? prompt = null,
+            [FromForm(Name = "response_format")] string? responseFormat = null,
+            [FromForm] double? temperature = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (file == null || file.Length == 0)
+                return OpenAIError(400, "An audio file is required.", "invalid_request_error", "invalid_request");
+            if (string.IsNullOrEmpty(model))
+                return OpenAIError(400, "A model is required.", "invalid_request_error", "invalid_request");
+
+            var mapping = await _modelMappingService.GetMappingByModelAliasAsync(model);
+            var supported = mapping?.ModelProviderTypeAssociation?.Model?.SupportsSpeechToText ?? false;
+            if (mapping == null || !supported)
+                return OpenAIError(400, $"Model {model} does not support speech-to-text transcription.", "invalid_request_error", "unsupported_model");
+
+            StampBillingItems(mapping);
+
+            var client = await _clientFactory.GetClientAsync(model, cancellationToken);
+            var stt = client.FindInChain<IAudioTranscriptionClient>();
+            if (stt == null)
+                return OpenAIError(400, $"Model {model} does not support speech-to-text transcription.", "invalid_request_error", "unsupported_model");
+
+            using var ms = new MemoryStream();
+            await file.CopyToAsync(ms, cancellationToken);
+
+            var request = new AudioTranscriptionRequest
+            {
+                Model = mapping.ProviderModelId,
+                AudioData = ms.ToArray(),
+                FileName = file.FileName,
+                ContentType = file.ContentType,
+                Language = language,
+                Prompt = prompt,
+                Temperature = temperature,
+                ResponseFormat = responseFormat
+            };
+
+            var result = await stt.TranscribeAudioAsync(request, cancellationToken: cancellationToken);
+            result.Model = model; // echo the caller's alias, not the provider model id
+
+            // Hand the billable audio duration to the middleware, which never parses the response body.
+            HttpContext.SetUsageContext(new AudioUsageContext
+            {
+                Model = model,
+                AudioDurationSeconds = result.DurationSeconds
+            });
+
+            if (string.Equals(responseFormat, "text", StringComparison.OrdinalIgnoreCase))
+                return Content(result.Text, "text/plain");
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Synthesizes speech from text (OpenAI <c>/audio/speech</c> compatible). Returns raw audio bytes.
+        /// </summary>
+        [HttpPost("speech")]
+        public async Task<IActionResult> CreateSpeech(
+            [FromBody] TextToSpeechRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null || string.IsNullOrEmpty(request.Model))
+                return OpenAIError(400, "A model is required.", "invalid_request_error", "invalid_request");
+            if (string.IsNullOrEmpty(request.Input))
+                return OpenAIError(400, "Input text is required.", "invalid_request_error", "invalid_request");
+            if (string.IsNullOrEmpty(request.Voice))
+                return OpenAIError(400, "A voice is required.", "invalid_request_error", "invalid_request");
+
+            var alias = request.Model;
+            var mapping = await _modelMappingService.GetMappingByModelAliasAsync(alias);
+            var supported = mapping?.ModelProviderTypeAssociation?.Model?.SupportsTextToSpeech ?? false;
+            if (mapping == null || !supported)
+                return OpenAIError(400, $"Model {alias} does not support text-to-speech.", "invalid_request_error", "unsupported_model");
+
+            StampBillingItems(mapping);
+
+            var client = await _clientFactory.GetClientAsync(alias, cancellationToken);
+            var tts = client.FindInChain<ITextToSpeechClient>();
+            if (tts == null)
+                return OpenAIError(400, $"Model {alias} does not support text-to-speech.", "invalid_request_error", "unsupported_model");
+
+            var characterCount = request.Input.Length;
+            request.Model = mapping.ProviderModelId; // swap alias -> provider model id before dispatch
+
+            var result = await tts.CreateSpeechAsync(request, cancellationToken: cancellationToken);
+
+            // Hand the billable character count to the middleware, which never parses the binary body.
+            HttpContext.SetUsageContext(new AudioUsageContext
+            {
+                Model = alias,
+                TtsCharacters = characterCount
+            });
+
+            return File(result.AudioData, result.ContentType);
+        }
+
+        private void StampBillingItems(ConduitLLM.Configuration.Entities.ModelProviderMapping mapping)
+        {
+            HttpContext.Items["ProviderId"] = mapping.ProviderId;
+            HttpContext.Items["ProviderType"] = mapping.Provider?.ProviderType;
+            if (mapping.ModelProviderTypeAssociation?.ModelCostId != null)
+                HttpContext.Items[HttpContextKeys.ModelCostId] = mapping.ModelProviderTypeAssociation.ModelCostId;
+        }
+    }
+}

--- a/Services/ConduitLLM.Gateway/Controllers/ChatController.Streaming.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/ChatController.Streaming.cs
@@ -30,6 +30,14 @@ namespace ConduitLLM.Gateway.Controllers
                 StoreFunctionExecutionResults(response.AgenticMetrics);
             }
 
+            // Stash the provider-reported cost via the side channel so the middleware can bill from it.
+            // It is intentionally not serialized into the response body (server-only), so the middleware
+            // cannot recover it by re-parsing the body the way it does for token counts.
+            if (response.Usage?.ProviderReportedCostUsd is decimal providerReportedCost)
+            {
+                HttpContext.Items[HttpContextKeys.ProviderReportedCost] = providerReportedCost;
+            }
+
             GatewayOpsMetrics.RecordLlmOperation("chat_completion", request.Model, "success", operationStopwatch.Elapsed.TotalSeconds);
             return Ok(response);
         }

--- a/Services/ConduitLLM.Gateway/Controllers/ChatController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/ChatController.cs
@@ -123,6 +123,16 @@ namespace ConduitLLM.Gateway.Controllers
                     {
                         HttpContext.Items[ConduitLLM.Gateway.Constants.HttpContextKeys.ModelCostId] = modelMapping.ModelProviderTypeAssociation.ModelCostId;
                     }
+
+                    if (modelMapping.Provider?.TrustProviderReportedCosts == true)
+                    {
+                        HttpContext.Items[ConduitLLM.Gateway.Constants.HttpContextKeys.ProviderBillingPolicy] =
+                            new ConduitLLM.Core.Models.ProviderCostBillingPolicy
+                            {
+                                TrustProviderReportedCost = true,
+                                MarkupMultiplier = modelMapping.Provider.ProviderCostMarkupMultiplier
+                            };
+                    }
                 }
             }
             catch (Exception ex)

--- a/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
@@ -124,6 +124,7 @@ namespace ConduitLLM.Gateway.Controllers
                         "function_calling" => caps.SupportsFunctionCalling,
                         "speech_to_text" or "audio_transcription" => caps.SupportsSpeechToText,
                         "text_to_speech" => caps.SupportsTextToSpeech,
+                        "rerank" => caps.SupportsRerank,
                         _ => false
                     };
 
@@ -173,6 +174,7 @@ namespace ConduitLLM.Gateway.Controllers
                         video_understanding = false, // Not yet supported
                         speech_to_text = caps.SupportsSpeechToText,
                         text_to_speech = caps.SupportsTextToSpeech,
+                        rerank = caps.SupportsRerank,
                         function_calling = caps.SupportsFunctionCalling,
                         tool_use = caps.SupportsFunctionCalling, // Same as function calling for now
                         json_mode = false, // Not yet tracked
@@ -222,6 +224,7 @@ namespace ConduitLLM.Gateway.Controllers
                 "embeddings",
                 "speech_to_text",
                 "text_to_speech",
+                "rerank",
                 "function_calling",
                 "tool_use",
                 "json_mode"

--- a/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/DiscoveryController.cs
@@ -122,6 +122,8 @@ namespace ConduitLLM.Gateway.Controllers
                         "image_generation" => caps.SupportsImageGeneration,
                         "embeddings" => caps.SupportsEmbeddings,
                         "function_calling" => caps.SupportsFunctionCalling,
+                        "speech_to_text" or "audio_transcription" => caps.SupportsSpeechToText,
+                        "text_to_speech" => caps.SupportsTextToSpeech,
                         _ => false
                     };
 
@@ -169,6 +171,8 @@ namespace ConduitLLM.Gateway.Controllers
                         vision = caps.SupportsVision,
                         video_generation = caps.SupportsVideoGeneration,
                         video_understanding = false, // Not yet supported
+                        speech_to_text = caps.SupportsSpeechToText,
+                        text_to_speech = caps.SupportsTextToSpeech,
                         function_calling = caps.SupportsFunctionCalling,
                         tool_use = caps.SupportsFunctionCalling, // Same as function calling for now
                         json_mode = false, // Not yet tracked
@@ -216,6 +220,8 @@ namespace ConduitLLM.Gateway.Controllers
                 "video_generation",
                 "image_generation",
                 "embeddings",
+                "speech_to_text",
+                "text_to_speech",
                 "function_calling",
                 "tool_use",
                 "json_mode"

--- a/Services/ConduitLLM.Gateway/Controllers/RerankController.cs
+++ b/Services/ConduitLLM.Gateway/Controllers/RerankController.cs
@@ -1,0 +1,80 @@
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Controllers;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models.Rerank;
+using ConduitLLM.Gateway.Authorization;
+using ConduitLLM.Gateway.Constants;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ConduitLLM.Gateway.Controllers
+{
+    /// <summary>
+    /// Handles document reranking requests (Cohere-compatible <c>/rerank</c>).
+    /// </summary>
+    [ApiController]
+    [Route("v1")]
+    [Authorize(AuthenticationSchemes = "VirtualKey")]
+    [RequireBalance]
+    [Tags("Rerank")]
+    public class RerankController : GatewayControllerBase
+    {
+        private readonly ILLMClientFactory _clientFactory;
+        private readonly IModelProviderMappingService _modelMappingService;
+        private readonly ILogger<RerankController> _logger;
+
+        public RerankController(
+            ILLMClientFactory clientFactory,
+            IModelProviderMappingService modelMappingService,
+            ILogger<RerankController> logger,
+            IEventBus eventBus)
+            : base(eventBus, logger)
+        {
+            _clientFactory = clientFactory;
+            _modelMappingService = modelMappingService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Scores and orders documents by relevance to a query.
+        /// </summary>
+        [HttpPost("rerank")]
+        public async Task<IActionResult> CreateRerank(
+            [FromBody] RerankRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null || string.IsNullOrEmpty(request.Model))
+                return OpenAIError(400, "A model is required.", "invalid_request_error", "invalid_request");
+            if (string.IsNullOrEmpty(request.Query))
+                return OpenAIError(400, "A query is required.", "invalid_request_error", "invalid_request");
+            if (request.Documents == null || request.Documents.Count == 0)
+                return OpenAIError(400, "At least one document is required.", "invalid_request_error", "invalid_request");
+
+            var alias = request.Model;
+            var mapping = await _modelMappingService.GetMappingByModelAliasAsync(alias);
+            var supported = mapping?.ModelProviderTypeAssociation?.Model?.SupportsRerank ?? false;
+            if (mapping == null || !supported)
+                return OpenAIError(400, $"Model {alias} does not support reranking.", "invalid_request_error", "unsupported_model");
+
+            HttpContext.Items["ProviderId"] = mapping.ProviderId;
+            HttpContext.Items["ProviderType"] = mapping.Provider?.ProviderType;
+            if (mapping.ModelProviderTypeAssociation?.ModelCostId != null)
+                HttpContext.Items[HttpContextKeys.ModelCostId] = mapping.ModelProviderTypeAssociation.ModelCostId;
+
+            var client = await _clientFactory.GetClientAsync(alias, cancellationToken);
+            var reranker = client.FindInChain<IRerankClient>();
+            if (reranker == null)
+                return OpenAIError(400, $"Model {alias} does not support reranking.", "invalid_request_error", "unsupported_model");
+
+            request.Model = mapping.ProviderModelId; // swap alias -> provider model id before dispatch
+
+            var result = await reranker.CreateRerankAsync(request, cancellationToken: cancellationToken);
+            // Echo the caller's alias; the middleware bills from usage.search_units + the stamped ModelCostId.
+            result.Model = alias;
+
+            return Ok(result);
+        }
+    }
+}

--- a/Services/ConduitLLM.Gateway/Middleware/UsageExtractor.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageExtractor.cs
@@ -108,6 +108,8 @@ namespace ConduitLLM.Gateway.Middleware
                 return "tts";
             if (pathValue.Contains("/videos/generations"))
                 return "video";
+            if (pathValue.Contains("/rerank"))
+                return "rerank";
             if (pathValue.Contains("/functions/execute"))
                 return "function";
 

--- a/Services/ConduitLLM.Gateway/Middleware/UsageExtractor.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageExtractor.cs
@@ -55,10 +55,23 @@ namespace ConduitLLM.Gateway.Middleware
                 if (usageElement.TryGetProperty("images", out var imageCount))
                     usage.ImageCount = imageCount.GetInt32();
 
+                // Rerank search units
+                if (usageElement.TryGetProperty("search_units", out var searchUnits) && searchUnits.TryGetInt32(out var su))
+                    usage.SearchUnits = su;
+
+                // Audio (speech-to-text duration / text-to-speech characters)
+                if (usageElement.TryGetProperty("audio_duration_seconds", out var audioSeconds) && audioSeconds.TryGetDouble(out var asec))
+                    usage.AudioDurationSeconds = asec;
+                if (usageElement.TryGetProperty("tts_characters", out var ttsChars) && ttsChars.TryGetInt32(out var tc))
+                    usage.TtsCharacters = tc;
+
                 // Validate we have at least some usage data
-                if (usage.PromptTokens == null && 
-                    usage.CompletionTokens == null && 
-                    usage.ImageCount == null)
+                if (usage.PromptTokens == null &&
+                    usage.CompletionTokens == null &&
+                    usage.ImageCount == null &&
+                    usage.SearchUnits == null &&
+                    usage.AudioDurationSeconds == null &&
+                    usage.TtsCharacters == null)
                 {
                     return null;
                 }

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.BillingAndMetrics.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.BillingAndMetrics.cs
@@ -32,6 +32,13 @@ namespace ConduitLLM.Gateway.Middleware
                     ? providerTypeObj?.ToString()
                     : null;
 
+                // Record how the request was billed so refunds can be calculated correctly. A trusted
+                // provider-reported cost is billed via CostCalculationService's short-circuit; mirror
+                // that condition here to tag the log.
+                var billedFromProviderCost =
+                    usage.ProviderCostPolicy is { TrustProviderReportedCost: true } &&
+                    usage.ProviderReportedCostUsd is >= 0m;
+
                 var logRequest = new LogRequestDto
                 {
                     VirtualKeyId = virtualKeyId,
@@ -44,6 +51,10 @@ namespace ConduitLLM.Gateway.Middleware
                     CachedInputTokens = usage.CachedInputTokens,
                     CachedWriteTokens = usage.CachedWriteTokens,
                     Cost = cost,
+                    BillingMethod = billedFromProviderCost
+                        ? ConduitLLM.Configuration.Enums.RequestBillingMethod.ProviderReportedCost
+                        : ConduitLLM.Configuration.Enums.RequestBillingMethod.ModelCost,
+                    ProviderReportedCostUsd = billedFromProviderCost ? usage.ProviderReportedCostUsd : null,
                     ResponseTimeMs = UsageExtractor.GetResponseTime(context),
                     UserId = context.User?.Identity?.Name,
                     ClientIp = context.Connection.RemoteIpAddress?.ToString(),

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.MediaProcessing.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.MediaProcessing.cs
@@ -284,6 +284,9 @@ namespace ConduitLLM.Gateway.Middleware
                 if (string.IsNullOrEmpty(usage.ImageResolution))
                     usage.ImageResolution = size;
 
+                // Apply provider billing policy + provider-reported cost (side channel) before billing.
+                ApplyProviderBillingPolicy(context, usage);
+
                 var metadata = JsonSerializer.Serialize(new
                 {
                     type = "image",

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.MediaProcessing.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.MediaProcessing.cs
@@ -229,6 +229,62 @@ namespace ConduitLLM.Gateway.Middleware
         /// Process image generation responses and log them with image-specific metadata.
         /// Extracts image-specific data, then delegates to the shared media pipeline.
         /// </summary>
+        /// <summary>
+        /// Bills an audio (STT/TTS) request from the typed <see cref="AudioUsageContext"/> set by the
+        /// controller — never from the response body, which for TTS is raw binary audio.
+        /// </summary>
+        private async Task ProcessAudioResponseAsync(
+            HttpContext context,
+            ICostCalculationService costCalculationService,
+            IBatchSpendUpdateService batchSpendService,
+            IRequestLogService requestLogService,
+            IVirtualKeyService virtualKeyService,
+            IBillingAuditService billingAuditService)
+        {
+            try
+            {
+                var virtualKeyId = (int)context.Items["VirtualKeyId"]!;
+                var providerType = context.Items.TryGetValue("ProviderType", out var providerTypeObj)
+                    ? providerTypeObj?.ToString() ?? "unknown"
+                    : "unknown";
+
+                var audioContext = context.GetUsageContext() as AudioUsageContext;
+                var endpointType = UsageExtractor.DetermineRequestType(context.Request.Path);
+                var model = audioContext?.Model ?? "unknown";
+
+                var usage = new Usage
+                {
+                    AudioDurationSeconds = audioContext?.AudioDurationSeconds,
+                    TtsCharacters = audioContext?.TtsCharacters
+                };
+                ApplyProviderBillingPolicy(context, usage);
+
+                var metadata = JsonSerializer.Serialize(new
+                {
+                    type = endpointType,
+                    audioDurationSeconds = audioContext?.AudioDurationSeconds,
+                    ttsCharacters = audioContext?.TtsCharacters
+                });
+
+                await ProcessMediaResponseAsync(context, new MediaProcessingContext
+                {
+                    MediaType = endpointType,
+                    Model = model,
+                    Usage = usage,
+                    MetadataJson = metadata,
+                    ProviderType = providerType,
+                    VirtualKeyId = virtualKeyId,
+                    LogDetail = endpointType == "tts"
+                        ? $"TtsCharacters={audioContext?.TtsCharacters ?? 0}"
+                        : $"AudioSeconds={audioContext?.AudioDurationSeconds ?? 0}"
+                }, costCalculationService, batchSpendService, requestLogService, virtualKeyService, billingAuditService);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process audio response for usage tracking");
+            }
+        }
+
         private async Task ProcessImageResponseAsync(
             HttpContext context,
             MemoryStream responseBody,

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.Streaming.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.Streaming.cs
@@ -49,6 +49,10 @@ namespace ConduitLLM.Gateway.Middleware
                 return;
             }
 
+            // Stamp the provider billing policy onto the streaming usage (which already carries the
+            // provider-reported cost captured from the final SSE chunk) before cost calculation.
+            ApplyProviderBillingPolicy(context, usage);
+
             var virtualKeyId = (int)context.Items["VirtualKeyId"]!;
 
             // Get provider type for metrics

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
@@ -205,6 +205,15 @@ namespace ConduitLLM.Gateway.Middleware
                     return;
                 }
 
+                // Handle audio (STT/TTS) — bill from the typed usage context, never the body. The TTS
+                // response body is raw binary audio and would fail JSON parsing below.
+                if (endpointType == "transcription" || endpointType == "tts")
+                {
+                    await ProcessAudioResponseAsync(context, costCalculationService, batchSpendService,
+                        requestLogService, virtualKeyService, billingAuditService);
+                    return;
+                }
+
                 // Parse the response JSON
                 using var jsonDocument = await JsonDocument.ParseAsync(responseBody);
                 var root = jsonDocument.RootElement;

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
@@ -141,6 +141,29 @@ namespace ConduitLLM.Gateway.Middleware
                    path.Contains("/functions/execute");
         }
 
+        /// <summary>
+        /// Stamps the provider billing policy — and, where the controller stashed it, the
+        /// provider-reported cost — from HttpContext.Items onto the usage object before cost
+        /// calculation. Streaming carries the cost on the usage object itself; non-streaming and
+        /// media paths supply it via the ProviderReportedCost item because the cost is never
+        /// serialized into the client-facing response body.
+        /// </summary>
+        private static void ApplyProviderBillingPolicy(HttpContext context, ConduitLLM.Core.Models.Usage usage)
+        {
+            if (context.Items.TryGetValue(HttpContextKeys.ProviderBillingPolicy, out var policyObj) &&
+                policyObj is ConduitLLM.Core.Models.ProviderCostBillingPolicy policy)
+            {
+                usage.ProviderCostPolicy = policy;
+            }
+
+            if (usage.ProviderReportedCostUsd == null &&
+                context.Items.TryGetValue(HttpContextKeys.ProviderReportedCost, out var costObj) &&
+                costObj is decimal reportedCost)
+            {
+                usage.ProviderReportedCostUsd = reportedCost;
+            }
+        }
+
         private async Task ProcessResponseAsync(
             HttpContext context,
             MemoryStream responseBody,
@@ -215,6 +238,10 @@ namespace ConduitLLM.Gateway.Middleware
                     _logger.LogWarning("Failed to extract usage data for {Path}", LoggingSanitizer.S(context.Request.Path.ToString()));
                     return;
                 }
+
+                // Apply the provider billing policy + provider-reported cost from the side channel
+                // (the cost is never in the re-parsed body, so it must come from HttpContext.Items).
+                ApplyProviderBillingPolicy(context, usage);
 
                 // Get virtual key ID
                 var virtualKeyId = (int)context.Items["VirtualKeyId"]!;

--- a/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
+++ b/Services/ConduitLLM.Gateway/Middleware/UsageTrackingMiddleware.cs
@@ -138,6 +138,7 @@ namespace ConduitLLM.Gateway.Middleware
                    path.Contains("/audio/transcriptions") ||
                    path.Contains("/audio/speech") ||
                    path.Contains("/videos/generations") ||
+                   path.Contains("/rerank") ||
                    path.Contains("/functions/execute");
         }
 

--- a/Services/ConduitLLM.Gateway/Usage/UsageContext.cs
+++ b/Services/ConduitLLM.Gateway/Usage/UsageContext.cs
@@ -43,6 +43,22 @@ public sealed class VideoUsageContext : IUsageContext
     public Dictionary<string, object>? PricingParameters { get; init; }
 }
 
+/// <summary>
+/// Audio (speech-to-text / text-to-speech) request context captured by <c>AudioController</c>.
+/// Carries the billable units (audio duration for STT, character count for TTS) so the middleware
+/// can bill without parsing the response — which for TTS is raw binary audio.
+/// </summary>
+public sealed class AudioUsageContext : IUsageContext
+{
+    public required string Model { get; init; }
+
+    /// <summary>Transcribed audio duration in seconds (speech-to-text).</summary>
+    public double? AudioDurationSeconds { get; init; }
+
+    /// <summary>Number of input characters synthesized (text-to-speech).</summary>
+    public int? TtsCharacters { get; init; }
+}
+
 public static class UsageContextExtensions
 {
     private static readonly object Key = new();

--- a/Shared/ConduitLLM.Configuration/DTOs/LogRequestDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/LogRequestDto.cs
@@ -61,6 +61,17 @@ namespace ConduitLLM.Configuration.DTOs
         public decimal Cost { get; set; }
 
         /// <summary>
+        /// How the cost was determined (ModelCost vs. provider-reported cost). Null for
+        /// ModelCost-billed requests.
+        /// </summary>
+        public Enums.RequestBillingMethod? BillingMethod { get; set; }
+
+        /// <summary>
+        /// The raw provider-reported cost (USD, pre-markup) when billed from provider cost; else null.
+        /// </summary>
+        public decimal? ProviderReportedCostUsd { get; set; }
+
+        /// <summary>
         /// Response time in milliseconds
         /// </summary>
         public double ResponseTimeMs { get; set; }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Create.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Create.cs
@@ -118,5 +118,11 @@ namespace ConduitLLM.Configuration.DTOs
         /// Documents over 500 tokens are split into chunks, each counting as a separate document.
         /// </remarks>
         public decimal? CostPerSearchUnit { get; set; }
+
+        /// <summary>Cost per minute of transcribed audio (speech-to-text).</summary>
+        public decimal? AudioCostPerMinute { get; set; }
+
+        /// <summary>Cost per thousand input characters synthesized (text-to-speech).</summary>
+        public decimal? AudioCostPerThousandCharacters { get; set; }
     }
 }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Update.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.Update.cs
@@ -131,5 +131,11 @@ namespace ConduitLLM.Configuration.DTOs
         /// Documents over 500 tokens are split into chunks, each counting as a separate document.
         /// </remarks>
         public decimal? CostPerSearchUnit { get; set; }
+
+        /// <summary>Cost per minute of transcribed audio (speech-to-text).</summary>
+        public decimal? AudioCostPerMinute { get; set; }
+
+        /// <summary>Cost per thousand input characters synthesized (text-to-speech).</summary>
+        public decimal? AudioCostPerThousandCharacters { get; set; }
     }
 }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelCostDto.cs
@@ -164,5 +164,11 @@ namespace ConduitLLM.Configuration.DTOs
         /// </remarks>
         public decimal? CostPerSearchUnit { get; set; }
 
+        /// <summary>Cost per minute of transcribed audio (speech-to-text).</summary>
+        public decimal? AudioCostPerMinute { get; set; }
+
+        /// <summary>Cost per thousand input characters synthesized (text-to-speech).</summary>
+        public decimal? AudioCostPerThousandCharacters { get; set; }
+
     }
 }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelCostExportDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelCostExportDto.cs
@@ -14,6 +14,8 @@ namespace ConduitLLM.Configuration.DTOs
         public decimal? BatchProcessingMultiplier { get; set; }
         public bool SupportsBatchProcessing { get; set; }
         public decimal? CostPerSearchUnit { get; set; }
+        public decimal? AudioCostPerMinute { get; set; }
+        public decimal? AudioCostPerThousandCharacters { get; set; }
         public decimal? CachedInputCostPerMillionTokens { get; set; }
         public decimal? CachedInputWriteCostPerMillionTokens { get; set; }
     }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
@@ -100,6 +100,16 @@ namespace ConduitLLM.Configuration.DTOs
         public bool SupportsEmbeddings { get; set; }
 
         /// <summary>
+        /// Indicates whether the model supports speech-to-text transcription.
+        /// </summary>
+        public bool SupportsSpeechToText { get; set; }
+
+        /// <summary>
+        /// Indicates whether the model supports text-to-speech synthesis.
+        /// </summary>
+        public bool SupportsTextToSpeech { get; set; }
+
+        /// <summary>
         /// Indicates whether this model supports chat completions
         /// </summary>
         public bool SupportsChat { get; set; }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
@@ -110,6 +110,11 @@ namespace ConduitLLM.Configuration.DTOs
         public bool SupportsTextToSpeech { get; set; }
 
         /// <summary>
+        /// Indicates whether the model supports document reranking.
+        /// </summary>
+        public bool SupportsRerank { get; set; }
+
+        /// <summary>
         /// Indicates whether this model supports chat completions
         /// </summary>
         public bool SupportsChat { get; set; }

--- a/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ModelProviderMappingDto.cs
@@ -69,6 +69,12 @@ namespace ConduitLLM.Configuration.DTOs
         public string? Notes { get; set; }
 
         /// <summary>
+        /// Optional provider-specific request options as a JSON object (OpenRouter: provider/plugins/
+        /// transforms/models/route), merged into outgoing requests routed through this mapping.
+        /// </summary>
+        public string? ProviderOptions { get; set; }
+
+        /// <summary>
         /// Model capability flags (populated from Model entity)
         /// </summary>
         public ModelCapabilitiesDto? Capabilities { get; set; }

--- a/Shared/ConduitLLM.Configuration/DTOs/VirtualKey/ProcessRefundRequestDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/VirtualKey/ProcessRefundRequestDto.cs
@@ -29,6 +29,13 @@ namespace ConduitLLM.Configuration.DTOs.VirtualKey
         /// Optional original transaction ID for audit trail
         /// </summary>
         public string? OriginalTransactionId { get; set; }
+
+        /// <summary>
+        /// Optional ID of the original request log being refunded. When supplied and that request was
+        /// billed from a trusted provider-reported cost, the refund is prorated from the amount actually
+        /// charged rather than recomputed from ModelCost rates.
+        /// </summary>
+        public int? RequestLogId { get; set; }
     }
 
     /// <summary>

--- a/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
+++ b/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
@@ -103,6 +103,16 @@ namespace ConduitLLM.Configuration
         public virtual DbSet<ModelProviderTypeAssociation> ModelProviderTypeAssociations { get; set; } = null!;
 
         /// <summary>
+        /// Database set for provider metadata sync runs (OpenRouter drift detection).
+        /// </summary>
+        public virtual DbSet<ProviderMetadataSyncRun> ProviderMetadataSyncRuns { get; set; } = null!;
+
+        /// <summary>
+        /// Database set for provider metadata drift items awaiting admin review.
+        /// </summary>
+        public virtual DbSet<ProviderMetadataDriftItem> ProviderMetadataDriftItems { get; set; } = null!;
+
+        /// <summary>
         /// Database set for media records
         /// </summary>
         public virtual DbSet<MediaRecord> MediaRecords { get; set; } = null!;
@@ -441,6 +451,9 @@ namespace ConduitLLM.Configuration
 
             // Apply PricingAuditEvent configuration (rules-based pricing)
             modelBuilder.ApplyConfiguration(new EntityConfigurations.PricingAuditEventConfiguration());
+
+            // Apply ProviderMetadataDriftItem configuration (string enums + partial unique index)
+            modelBuilder.ApplyConfiguration(new EntityConfigurations.ProviderMetadataDriftItemConfiguration());
 
             // Note: ModelProviderMapping and Provider are now included in test environments
             // as they are required by the application code during tests

--- a/Shared/ConduitLLM.Configuration/Entities/Model.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/Model.cs
@@ -84,6 +84,11 @@ namespace ConduitLLM.Configuration.Entities
         public bool SupportsTextToSpeech { get; set; } = false;
 
         /// <summary>
+        /// Indicates whether this model supports document reranking.
+        /// </summary>
+        public bool SupportsRerank { get; set; } = false;
+
+        /// <summary>
         /// Indicates whether this model supports chat completions.
         /// </summary>
         public bool SupportsChat { get; set; } = false;

--- a/Shared/ConduitLLM.Configuration/Entities/Model.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/Model.cs
@@ -74,6 +74,16 @@ namespace ConduitLLM.Configuration.Entities
         public bool SupportsEmbeddings { get; set; } = false;
 
         /// <summary>
+        /// Indicates whether this model supports speech-to-text transcription.
+        /// </summary>
+        public bool SupportsSpeechToText { get; set; } = false;
+
+        /// <summary>
+        /// Indicates whether this model supports text-to-speech synthesis.
+        /// </summary>
+        public bool SupportsTextToSpeech { get; set; } = false;
+
+        /// <summary>
         /// Indicates whether this model supports chat completions.
         /// </summary>
         public bool SupportsChat { get; set; } = false;

--- a/Shared/ConduitLLM.Configuration/Entities/ModelCost.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ModelCost.cs
@@ -234,6 +234,20 @@ public class ModelCost : IEntity<int>, IAuditableEntity
     public decimal? CostPerSearchUnit { get; set; }
 
     /// <summary>
+    /// Gets or sets the cost per minute of transcribed audio (speech-to-text). Nullable when the
+    /// model is not an STT model. Stored with moderate precision (decimal 18,8).
+    /// </summary>
+    [Column(TypeName = "decimal(18, 8)")]
+    public decimal? AudioCostPerMinute { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cost per thousand input characters synthesized (text-to-speech). Nullable
+    /// when the model is not a TTS model. Stored with moderate precision (decimal 18,8).
+    /// </summary>
+    [Column(TypeName = "decimal(18, 8)")]
+    public decimal? AudioCostPerThousandCharacters { get; set; }
+
+    /// <summary>
     /// Gets or sets the cost per million reasoning tokens for models with reasoning capabilities.
     /// </summary>
     /// <remarks>

--- a/Shared/ConduitLLM.Configuration/Entities/ModelProviderMapping.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ModelProviderMapping.cs
@@ -56,6 +56,15 @@ namespace ConduitLLM.Configuration.Entities
         public bool IsEnabled { get; set; } = true;
 
         /// <summary>
+        /// Optional provider-specific request options as a JSON object. For OpenRouter mappings the
+        /// top-level keys (provider, plugins, transforms, models, route) are merged into every
+        /// outgoing request routed through this mapping. Caller-supplied ExtensionData wins on key
+        /// conflict; standard parameters always win.
+        /// </summary>
+        [Column(TypeName = "text")]
+        public string? ProviderOptions { get; set; }
+
+        /// <summary>
         /// The UTC timestamp when this mapping was created.
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Shared/ConduitLLM.Configuration/Entities/Provider.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/Provider.cs
@@ -46,6 +46,23 @@ namespace ConduitLLM.Configuration.Entities
         public bool IsEnabled { get; set; } = true;
 
         /// <summary>
+        /// When true, the cost the provider reports for each request (e.g. OpenRouter's usage.cost)
+        /// is authoritative for billing virtual keys; ModelCost calculation is only a fallback when
+        /// no cost is reported. Defaults to false (bill from ModelCost, the historical behavior).
+        /// </summary>
+        /// <remarks>
+        /// Only enable for providers that return a trustworthy per-request charge. Note that for BYOK
+        /// keys some providers report only their own fee, not the full upstream cost.
+        /// </remarks>
+        public bool TrustProviderReportedCosts { get; set; } = false;
+
+        /// <summary>
+        /// Multiplier applied to the provider-reported cost when billing (1.0 = pass-through markup).
+        /// Only consulted when <see cref="TrustProviderReportedCosts"/> is true.
+        /// </summary>
+        public decimal ProviderCostMarkupMultiplier { get; set; } = 1.0m;
+
+        /// <summary>
         /// Gets or sets the UTC timestamp when this provider was created.
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Shared/ConduitLLM.Configuration/Entities/ProviderMetadataDriftItem.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ProviderMetadataDriftItem.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Configuration.Entities.Interfaces;
+using ConduitLLM.Configuration.Enums;
+
+namespace ConduitLLM.Configuration.Entities
+{
+    /// <summary>
+    /// A single detected drift between a provider's published model metadata and Conduit's configured
+    /// values for one model mapping, awaiting (or resolved by) admin review.
+    /// </summary>
+    public class ProviderMetadataDriftItem : IEntity<int>
+    {
+        /// <summary>Unique identifier for the drift item.</summary>
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>The model mapping this drift applies to.</summary>
+        public int ModelProviderMappingId { get; set; }
+
+        /// <summary>Navigation to the model mapping.</summary>
+        [ForeignKey(nameof(ModelProviderMappingId))]
+        [JsonIgnore]
+        public virtual ModelProviderMapping? Mapping { get; set; }
+
+        /// <summary>Denormalized provider id for cheap filtering.</summary>
+        public int ProviderId { get; set; }
+
+        /// <summary>The provider (OpenRouter) model id, e.g. <c>anthropic/claude-3.5-sonnet</c>.</summary>
+        [Required]
+        [MaxLength(200)]
+        public string OpenRouterModelId { get; set; } = string.Empty;
+
+        /// <summary>The kind of drift. Stored as a string via a value conversion.</summary>
+        public DriftType DriftType { get; set; }
+
+        /// <summary>The review status. Stored as a string via a value conversion.</summary>
+        public DriftStatus Status { get; set; }
+
+        /// <summary>Snapshot (JSON) of Conduit's current values at detection time.</summary>
+        [Column(TypeName = "text")]
+        public string CurrentValuesJson { get; set; } = "{}";
+
+        /// <summary>The provider's proposed values (JSON) at detection time.</summary>
+        [Column(TypeName = "text")]
+        public string ProposedValuesJson { get; set; } = "{}";
+
+        /// <summary>When this drift was first detected (UTC).</summary>
+        public DateTime FirstDetectedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>When this drift was most recently detected (UTC).</summary>
+        public DateTime LastDetectedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>The most recent sync run that touched this item.</summary>
+        public int? LastSyncRunId { get; set; }
+
+        /// <summary>When the item was resolved (applied/dismissed/auto-resolved), if it has been.</summary>
+        public DateTime? ResolvedAt { get; set; }
+
+        /// <summary>Who/what resolved the item ("admin" or "system:auto-resolve").</summary>
+        [MaxLength(100)]
+        public string? ResolvedBy { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Entities/ProviderMetadataSyncRun.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ProviderMetadataSyncRun.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+
+using ConduitLLM.Configuration.Entities.Interfaces;
+
+namespace ConduitLLM.Configuration.Entities
+{
+    /// <summary>
+    /// Records a single execution of the provider metadata sync (fetch + drift detection).
+    /// </summary>
+    public class ProviderMetadataSyncRun : IEntity<int>
+    {
+        /// <summary>Unique identifier for the sync run.</summary>
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>The provider type this run covered (currently only OpenRouter).</summary>
+        public ProviderType ProviderType { get; set; } = ProviderType.OpenRouter;
+
+        /// <summary>When the run started (UTC).</summary>
+        public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>When the run completed (UTC), or null if still running.</summary>
+        public DateTime? CompletedAt { get; set; }
+
+        /// <summary>Run status: Running | Completed | Failed.</summary>
+        [MaxLength(20)]
+        public string Status { get; set; } = "Running";
+
+        /// <summary>What triggered the run: "Schedule" or "Manual".</summary>
+        [MaxLength(100)]
+        public string TriggeredBy { get; set; } = "Schedule";
+
+        /// <summary>Number of models fetched from the provider catalog.</summary>
+        public int ModelsFetched { get; set; }
+
+        /// <summary>Number of model mappings checked for drift.</summary>
+        public int MappingsChecked { get; set; }
+
+        /// <summary>Number of new drift items created this run.</summary>
+        public int ItemsCreated { get; set; }
+
+        /// <summary>Number of existing pending drift items refreshed this run.</summary>
+        public int ItemsUpdated { get; set; }
+
+        /// <summary>Number of pending drift items auto-resolved (no longer drifting) this run.</summary>
+        public int ItemsAutoResolved { get; set; }
+
+        /// <summary>Error message when the run failed.</summary>
+        [MaxLength(2000)]
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Entities/RequestLog.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/RequestLog.cs
@@ -82,6 +82,20 @@ public class RequestLog : IEntity<int>, IAuditEvent
     public decimal Cost { get; set; }
 
     /// <summary>
+    /// How <see cref="Cost"/> was determined. Null (or ModelCost) means it was computed from the
+    /// configured ModelCost rates; ProviderReportedCost means it was billed from the provider's
+    /// reported per-request cost (times markup), which changes how refunds are calculated.
+    /// </summary>
+    public Enums.RequestBillingMethod? BillingMethod { get; set; }
+
+    /// <summary>
+    /// The raw provider-reported cost (USD, pre-markup) when the request was billed from provider
+    /// cost. Recorded for reconciliation/margin analysis; null for ModelCost-billed requests.
+    /// </summary>
+    [Column(TypeName = "decimal(18, 8)")]
+    public decimal? ProviderReportedCostUsd { get; set; }
+
+    /// <summary>
     /// Response time in milliseconds
     /// </summary>
     public double ResponseTimeMs { get; set; }

--- a/Shared/ConduitLLM.Configuration/EntityConfigurations/ProviderMetadataDriftItemConfiguration.cs
+++ b/Shared/ConduitLLM.Configuration/EntityConfigurations/ProviderMetadataDriftItemConfiguration.cs
@@ -1,0 +1,42 @@
+using ConduitLLM.Configuration.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ConduitLLM.Configuration.EntityConfigurations
+{
+    /// <summary>
+    /// EF configuration for <see cref="ProviderMetadataDriftItem"/>.
+    /// </summary>
+    public class ProviderMetadataDriftItemConfiguration : IEntityTypeConfiguration<ProviderMetadataDriftItem>
+    {
+        /// <inheritdoc />
+        public void Configure(EntityTypeBuilder<ProviderMetadataDriftItem> builder)
+        {
+            builder.ToTable("ProviderMetadataDriftItems");
+            builder.HasKey(e => e.Id);
+
+            // Store the drift enums as strings so the partial unique index filter reads naturally
+            // ("Status" = 'Pending') and is robust to enum reordering.
+            builder.Property(e => e.DriftType).HasConversion<string>().HasMaxLength(30);
+            builder.Property(e => e.Status).HasConversion<string>().HasMaxLength(20);
+
+            builder.HasOne(e => e.Mapping)
+                .WithMany()
+                .HasForeignKey(e => e.ModelProviderMappingId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // At most one PENDING drift item per (mapping, drift type) — enforces idempotent re-detection.
+            builder.HasIndex(e => new { e.ModelProviderMappingId, e.DriftType })
+                .IsUnique()
+                .HasFilter("\"Status\" = 'Pending'")
+                .HasDatabaseName("IX_ProviderMetadataDriftItems_Mapping_Type_Pending");
+
+            builder.HasIndex(e => new { e.Status, e.DriftType })
+                .HasDatabaseName("IX_ProviderMetadataDriftItems_Status_Type");
+
+            builder.HasIndex(e => e.ProviderId)
+                .HasDatabaseName("IX_ProviderMetadataDriftItems_ProviderId");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Enums/ProviderMetadataDrift.cs
+++ b/Shared/ConduitLLM.Configuration/Enums/ProviderMetadataDrift.cs
@@ -1,0 +1,45 @@
+namespace ConduitLLM.Configuration.Enums
+{
+    /// <summary>
+    /// The kind of drift detected between a provider's published model metadata and Conduit's
+    /// configured values for a model mapping.
+    /// </summary>
+    public enum DriftType
+    {
+        /// <summary>Provider pricing differs from the configured ModelCost.</summary>
+        Pricing,
+
+        /// <summary>The mapping has no ModelCost configured but the provider publishes pricing.</summary>
+        MissingCost,
+
+        /// <summary>Provider context length / max output differs from the configured limits.</summary>
+        ContextWindow,
+
+        /// <summary>Provider capabilities (vision, tools, etc.) differ from the configured flags.</summary>
+        Capabilities,
+
+        /// <summary>The model is no longer present in the provider's catalog.</summary>
+        ModelRemoved,
+
+        /// <summary>The provider has published a deprecation/expiration date for the model.</summary>
+        ModelDeprecated
+    }
+
+    /// <summary>
+    /// The review status of a detected drift item.
+    /// </summary>
+    public enum DriftStatus
+    {
+        /// <summary>Detected and awaiting an admin decision.</summary>
+        Pending,
+
+        /// <summary>An admin applied the proposed change.</summary>
+        Applied,
+
+        /// <summary>An admin dismissed the item.</summary>
+        Dismissed,
+
+        /// <summary>The drift resolved on its own (values now match) before an admin acted.</summary>
+        AutoResolved
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Enums/RequestBillingMethod.cs
+++ b/Shared/ConduitLLM.Configuration/Enums/RequestBillingMethod.cs
@@ -1,0 +1,19 @@
+namespace ConduitLLM.Configuration.Enums
+{
+    /// <summary>
+    /// How a request's cost was determined for billing.
+    /// </summary>
+    public enum RequestBillingMethod
+    {
+        /// <summary>
+        /// Cost was computed from the configured ModelCost rates (the default/historical behavior).
+        /// </summary>
+        ModelCost = 0,
+
+        /// <summary>
+        /// Cost was billed from the provider-reported per-request cost (times the provider markup),
+        /// bypassing ModelCost. Refunds for these requests are prorated from the charged amount.
+        /// </summary>
+        ProviderReportedCost = 1
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Extensions/ProviderMappingExtensions.cs
@@ -40,6 +40,7 @@ namespace ConduitLLM.Configuration.Extensions
                 CreatedAt = mapping.CreatedAt,
                 UpdatedAt = mapping.UpdatedAt,
                 Notes = null, // Entity doesn't have Notes
+                ProviderOptions = mapping.ProviderOptions,
                 Capabilities = mapping.ModelProviderTypeAssociation?.Model != null ? new ModelCapabilitiesDto
                 {
                     SupportsVision = mapping.ModelProviderTypeAssociation.Model.SupportsVision,
@@ -65,6 +66,7 @@ namespace ConduitLLM.Configuration.Extensions
             mapping.ProviderId = dto.ProviderId;
             mapping.ModelProviderTypeAssociationId = dto.ModelProviderTypeAssociationId;
             mapping.IsEnabled = dto.IsEnabled;
+            mapping.ProviderOptions = dto.ProviderOptions;
             mapping.UpdatedAt = System.DateTime.UtcNow;
             // Note: Priority and Notes are DTO-only properties
         }

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719031638_AddProviderCostTrustFields.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719031638_AddProviderCostTrustFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719031638_AddProviderCostTrustFields")]
+    partial class AddProviderCostTrustFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719031638_AddProviderCostTrustFields.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719031638_AddProviderCostTrustFields.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderCostTrustFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Backfill existing providers to a 1.0 (pass-through) markup rather than 0.0, so that
+            // enabling TrustProviderReportedCosts later never silently bills at zero.
+            migrationBuilder.AddColumn<decimal>(
+                name: "ProviderCostMarkupMultiplier",
+                table: "Providers",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 1.0m);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TrustProviderReportedCosts",
+                table: "Providers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProviderCostMarkupMultiplier",
+                table: "Providers");
+
+            migrationBuilder.DropColumn(
+                name: "TrustProviderReportedCosts",
+                table: "Providers");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719033618_AddBillingMethodToRequestLogs.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719033618_AddBillingMethodToRequestLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719033618_AddBillingMethodToRequestLogs")]
+    partial class AddBillingMethodToRequestLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719033618_AddBillingMethodToRequestLogs.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719033618_AddBillingMethodToRequestLogs.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBillingMethodToRequestLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BillingMethod",
+                table: "RequestLogs",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "ProviderReportedCostUsd",
+                table: "RequestLogs",
+                type: "numeric(18,8)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BillingMethod",
+                table: "RequestLogs");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderReportedCostUsd",
+                table: "RequestLogs");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719043937_AddAudioCapabilitiesAndCosts.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719043937_AddAudioCapabilitiesAndCosts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719043937_AddAudioCapabilitiesAndCosts")]
+    partial class AddAudioCapabilitiesAndCosts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719043937_AddAudioCapabilitiesAndCosts.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719043937_AddAudioCapabilitiesAndCosts.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAudioCapabilitiesAndCosts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SupportsSpeechToText",
+                table: "Models",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "SupportsTextToSpeech",
+                table: "Models",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "AudioCostPerMinute",
+                table: "ModelCosts",
+                type: "numeric(18,8)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "AudioCostPerThousandCharacters",
+                table: "ModelCosts",
+                type: "numeric(18,8)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SupportsSpeechToText",
+                table: "Models");
+
+            migrationBuilder.DropColumn(
+                name: "SupportsTextToSpeech",
+                table: "Models");
+
+            migrationBuilder.DropColumn(
+                name: "AudioCostPerMinute",
+                table: "ModelCosts");
+
+            migrationBuilder.DropColumn(
+                name: "AudioCostPerThousandCharacters",
+                table: "ModelCosts");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719050026_AddRerankSupport.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719050026_AddRerankSupport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719050026_AddRerankSupport")]
+    partial class AddRerankSupport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719050026_AddRerankSupport.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719050026_AddRerankSupport.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRerankSupport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SupportsRerank",
+                table: "Models",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SupportsRerank",
+                table: "Models");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719051358_AddProviderMetadataSync.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719051358_AddProviderMetadataSync.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719051358_AddProviderMetadataSync")]
+    partial class AddProviderMetadataSync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719051358_AddProviderMetadataSync.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719051358_AddProviderMetadataSync.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderMetadataSync : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProviderMetadataDriftItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ModelProviderMappingId = table.Column<int>(type: "integer", nullable: false),
+                    ProviderId = table.Column<int>(type: "integer", nullable: false),
+                    OpenRouterModelId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    DriftType = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CurrentValuesJson = table.Column<string>(type: "text", nullable: false),
+                    ProposedValuesJson = table.Column<string>(type: "text", nullable: false),
+                    FirstDetectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastDetectedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastSyncRunId = table.Column<int>(type: "integer", nullable: true),
+                    ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ResolvedBy = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProviderMetadataDriftItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProviderMetadataDriftItems_ModelProviderMappings_ModelProvi~",
+                        column: x => x.ModelProviderMappingId,
+                        principalTable: "ModelProviderMappings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProviderMetadataSyncRuns",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ProviderType = table.Column<int>(type: "integer", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    TriggeredBy = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ModelsFetched = table.Column<int>(type: "integer", nullable: false),
+                    MappingsChecked = table.Column<int>(type: "integer", nullable: false),
+                    ItemsCreated = table.Column<int>(type: "integer", nullable: false),
+                    ItemsUpdated = table.Column<int>(type: "integer", nullable: false),
+                    ItemsAutoResolved = table.Column<int>(type: "integer", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProviderMetadataSyncRuns", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProviderMetadataDriftItems_Mapping_Type_Pending",
+                table: "ProviderMetadataDriftItems",
+                columns: new[] { "ModelProviderMappingId", "DriftType" },
+                unique: true,
+                filter: "\"Status\" = 'Pending'");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProviderMetadataDriftItems_ProviderId",
+                table: "ProviderMetadataDriftItems",
+                column: "ProviderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProviderMetadataDriftItems_Status_Type",
+                table: "ProviderMetadataDriftItems",
+                columns: new[] { "Status", "DriftType" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProviderMetadataDriftItems");
+
+            migrationBuilder.DropTable(
+                name: "ProviderMetadataSyncRuns");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719052921_AddProviderOptionsToModelProviderMapping.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719052921_AddProviderOptionsToModelProviderMapping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719052921_AddProviderOptionsToModelProviderMapping")]
+    partial class AddProviderOptionsToModelProviderMapping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260719052921_AddProviderOptionsToModelProviderMapping.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260719052921_AddProviderOptionsToModelProviderMapping.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderOptionsToModelProviderMapping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderOptions",
+                table: "ModelProviderMappings",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProviderOptions",
+                table: "ModelProviderMappings");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Options/OpenRouterSyncOptions.cs
+++ b/Shared/ConduitLLM.Configuration/Options/OpenRouterSyncOptions.cs
@@ -1,0 +1,30 @@
+namespace ConduitLLM.Configuration.Options
+{
+    /// <summary>
+    /// Options for the scheduled OpenRouter metadata sync (drift detection). Bound from the
+    /// <c>OpenRouterSync</c> configuration section (env: <c>OpenRouterSync__*</c>).
+    /// </summary>
+    public class OpenRouterSyncOptions
+    {
+        /// <summary>Configuration section name.</summary>
+        public const string SectionName = "OpenRouterSync";
+
+        /// <summary>
+        /// Whether the scheduled sync is enabled. Defaults to false — drift detection is opt-in and can
+        /// also be triggered on demand via the Admin API regardless of this flag.
+        /// </summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>How often the scheduled sync runs, in hours.</summary>
+        public int ScheduleIntervalHours { get; set; } = 24;
+
+        /// <summary>Delay before the first scheduled run after startup, in seconds.</summary>
+        public int InitialDelaySeconds { get; set; } = 60;
+
+        /// <summary>The OpenRouter models endpoint to fetch (public, unauthenticated).</summary>
+        public string ModelsEndpoint { get; set; } = "https://openrouter.ai/api/v1/models";
+
+        /// <summary>HTTP timeout for the catalog fetch, in seconds.</summary>
+        public int HttpTimeoutSeconds { get; set; } = 60;
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Services/RequestLogService.cs
+++ b/Shared/ConduitLLM.Configuration/Services/RequestLogService.cs
@@ -102,6 +102,8 @@ public class RequestLogService : BatchAuditServiceBase<RequestLog>, IRequestLogS
         CachedInputTokens = request.CachedInputTokens,
         CachedWriteTokens = request.CachedWriteTokens,
         Cost = request.Cost,
+        BillingMethod = request.BillingMethod,
+        ProviderReportedCostUsd = request.ProviderReportedCostUsd,
         ResponseTimeMs = request.ResponseTimeMs,
         Timestamp = DateTime.UtcNow,
         UserId = request.UserId,

--- a/Shared/ConduitLLM.Core/Interfaces/IAudioTranscriptionClient.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IAudioTranscriptionClient.cs
@@ -1,0 +1,20 @@
+using ConduitLLM.Core.Models.Audio;
+
+namespace ConduitLLM.Core.Interfaces
+{
+    /// <summary>
+    /// Optional capability: speech-to-text transcription. Implemented by provider clients that support
+    /// an <c>/audio/transcriptions</c> endpoint and discovered via
+    /// <see cref="LLMClientDecoratorExtensions.FindInChain{T}"/> (it is not part of <see cref="ILLMClient"/>).
+    /// </summary>
+    public interface IAudioTranscriptionClient
+    {
+        /// <summary>
+        /// Transcribes the supplied audio to text.
+        /// </summary>
+        Task<AudioTranscriptionResponse> TranscribeAudioAsync(
+            AudioTranscriptionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Shared/ConduitLLM.Core/Interfaces/ICostCalculationService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ICostCalculationService.cs
@@ -54,6 +54,11 @@ public interface ICostCalculationService
     /// <param name="refundUsage">The usage data to be refunded.</param>
     /// <param name="refundReason">The reason for the refund.</param>
     /// <param name="originalTransactionId">Optional original transaction ID for audit trail.</param>
+    /// <param name="providerCostContext">
+    /// Optional context for refunding a request that was billed from a trusted provider-reported cost.
+    /// When supplied, the refund is prorated from the amount actually charged rather than recomputed
+    /// from ModelCost rates (which do not describe how a provider-cost request was billed).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A RefundResult containing the refund details and any validation messages.</returns>
     Task<RefundResult> CalculateRefundAsync(
@@ -62,5 +67,6 @@ public interface ICostCalculationService
         Usage refundUsage,
         string refundReason,
         string? originalTransactionId = null,
+        ProviderCostRefundContext? providerCostContext = null,
         CancellationToken cancellationToken = default);
 }

--- a/Shared/ConduitLLM.Core/Interfaces/ILLMClientDecorator.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ILLMClientDecorator.cs
@@ -38,5 +38,27 @@ namespace ConduitLLM.Core.Interfaces
 
             return client;
         }
+
+        /// <summary>
+        /// Walks a decorator chain (outermost first) and returns the first client assignable to
+        /// <typeparamref name="T"/>, or null if none is. Used to reach optional capability interfaces
+        /// (e.g. audio transcription/TTS, rerank) that are not part of <see cref="ILLMClient"/>.
+        /// </summary>
+        /// <typeparam name="T">The capability interface to locate.</typeparam>
+        /// <param name="client">The potentially decorated client.</param>
+        /// <returns>The first client in the chain assignable to <typeparamref name="T"/>, or null.</returns>
+        public static T? FindInChain<T>(this ILLMClient client) where T : class
+        {
+            for (ILLMClient? current = client; current != null;
+                 current = (current as ILLMClientDecorator)?.InnerClient)
+            {
+                if (current is T match)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/Shared/ConduitLLM.Core/Interfaces/IModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IModelCapabilityService.cs
@@ -36,6 +36,13 @@ namespace ConduitLLM.Core.Interfaces
         Task<bool> SupportsTextToSpeechAsync(string model);
 
         /// <summary>
+        /// Determines if a model supports document reranking.
+        /// </summary>
+        /// <param name="model">The model identifier to check.</param>
+        /// <returns>True if the model supports reranking, false otherwise.</returns>
+        Task<bool> SupportsRerankAsync(string model);
+
+        /// <summary>
         /// Gets the tokenizer type for a model.
         /// </summary>
         /// <param name="model">The model identifier.</param>

--- a/Shared/ConduitLLM.Core/Interfaces/IModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IModelCapabilityService.cs
@@ -22,6 +22,20 @@ namespace ConduitLLM.Core.Interfaces
         Task<bool> SupportsVideoGenerationAsync(string model);
 
         /// <summary>
+        /// Determines if a model supports speech-to-text transcription.
+        /// </summary>
+        /// <param name="model">The model identifier to check.</param>
+        /// <returns>True if the model supports speech-to-text, false otherwise.</returns>
+        Task<bool> SupportsSpeechToTextAsync(string model);
+
+        /// <summary>
+        /// Determines if a model supports text-to-speech synthesis.
+        /// </summary>
+        /// <param name="model">The model identifier to check.</param>
+        /// <returns>True if the model supports text-to-speech, false otherwise.</returns>
+        Task<bool> SupportsTextToSpeechAsync(string model);
+
+        /// <summary>
         /// Gets the tokenizer type for a model.
         /// </summary>
         /// <param name="model">The model identifier.</param>

--- a/Shared/ConduitLLM.Core/Interfaces/IRerankClient.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IRerankClient.cs
@@ -1,0 +1,20 @@
+using ConduitLLM.Core.Models.Rerank;
+
+namespace ConduitLLM.Core.Interfaces
+{
+    /// <summary>
+    /// Optional capability: document reranking. Implemented by provider clients that support a
+    /// <c>/rerank</c> endpoint and discovered via
+    /// <see cref="LLMClientDecoratorExtensions.FindInChain{T}"/> (it is not part of <see cref="ILLMClient"/>).
+    /// </summary>
+    public interface IRerankClient
+    {
+        /// <summary>
+        /// Scores and orders the supplied documents by relevance to the query.
+        /// </summary>
+        Task<RerankResponse> CreateRerankAsync(
+            RerankRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Shared/ConduitLLM.Core/Interfaces/ITextToSpeechClient.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ITextToSpeechClient.cs
@@ -1,0 +1,20 @@
+using ConduitLLM.Core.Models.Audio;
+
+namespace ConduitLLM.Core.Interfaces
+{
+    /// <summary>
+    /// Optional capability: text-to-speech synthesis. Implemented by provider clients that support an
+    /// <c>/audio/speech</c> endpoint and discovered via
+    /// <see cref="LLMClientDecoratorExtensions.FindInChain{T}"/> (it is not part of <see cref="ILLMClient"/>).
+    /// </summary>
+    public interface ITextToSpeechClient
+    {
+        /// <summary>
+        /// Synthesizes speech audio from the supplied text.
+        /// </summary>
+        Task<TextToSpeechResponse> CreateSpeechAsync(
+            TextToSpeechRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/Audio/AudioTranscriptionRequest.cs
+++ b/Shared/ConduitLLM.Core/Models/Audio/AudioTranscriptionRequest.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+
+namespace ConduitLLM.Core.Models.Audio
+{
+    /// <summary>
+    /// A speech-to-text transcription request (OpenAI <c>/audio/transcriptions</c> compatible).
+    /// Built by the Gateway controller from the uploaded audio file plus form fields.
+    /// </summary>
+    public class AudioTranscriptionRequest
+    {
+        /// <summary>The model (alias) to transcribe with.</summary>
+        public required string Model { get; set; }
+
+        /// <summary>The raw audio bytes to transcribe.</summary>
+        public required byte[] AudioData { get; set; }
+
+        /// <summary>The original file name (used to infer format for the multipart upload).</summary>
+        public required string FileName { get; set; }
+
+        /// <summary>The audio content type, e.g. <c>audio/mpeg</c>.</summary>
+        public string? ContentType { get; set; }
+
+        /// <summary>Optional ISO-639-1 language hint; auto-detected when omitted.</summary>
+        public string? Language { get; set; }
+
+        /// <summary>Optional prompt to guide the transcription style.</summary>
+        public string? Prompt { get; set; }
+
+        /// <summary>Optional sampling temperature (0-1).</summary>
+        public double? Temperature { get; set; }
+
+        /// <summary>Response format: <c>json</c> (default), <c>text</c>, or <c>verbose_json</c>.</summary>
+        public string? ResponseFormat { get; set; }
+
+        /// <summary>Optional end-user identifier.</summary>
+        public string? User { get; set; }
+
+        /// <summary>Provider-specific passthrough fields.</summary>
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/Audio/AudioTranscriptionResponse.cs
+++ b/Shared/ConduitLLM.Core/Models/Audio/AudioTranscriptionResponse.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Core.Models.Audio
+{
+    /// <summary>
+    /// A speech-to-text transcription response.
+    /// </summary>
+    public class AudioTranscriptionResponse
+    {
+        /// <summary>The transcribed text.</summary>
+        [JsonPropertyName("text")]
+        public required string Text { get; set; }
+
+        /// <summary>Detected/echoed language, when the provider reports it.</summary>
+        [JsonPropertyName("language")]
+        public string? Language { get; set; }
+
+        /// <summary>Audio duration in seconds, when the provider reports it (used for billing).</summary>
+        [JsonPropertyName("duration")]
+        public double? DurationSeconds { get; set; }
+
+        /// <summary>The model that produced the transcription.</summary>
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        /// <summary>Usage/cost information, when the provider reports it.</summary>
+        [JsonPropertyName("usage")]
+        public Usage? Usage { get; set; }
+
+        /// <summary>Additional provider fields (e.g. segments/words for verbose_json).</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/Audio/TextToSpeechRequest.cs
+++ b/Shared/ConduitLLM.Core/Models/Audio/TextToSpeechRequest.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+
+namespace ConduitLLM.Core.Models.Audio
+{
+    /// <summary>
+    /// A text-to-speech synthesis request (OpenAI <c>/audio/speech</c> compatible).
+    /// </summary>
+    public class TextToSpeechRequest
+    {
+        /// <summary>The model (alias) to synthesize with.</summary>
+        public required string Model { get; set; }
+
+        /// <summary>The text to synthesize.</summary>
+        public required string Input { get; set; }
+
+        /// <summary>The voice identifier (provider/model specific).</summary>
+        public required string Voice { get; set; }
+
+        /// <summary>
+        /// Output audio format, e.g. <c>mp3</c> or <c>pcm</c>. Defaults to <c>mp3</c> (OpenAI-compatible
+        /// default; OpenRouter's own default is pcm, so we normalize to mp3 for stored/played audio).
+        /// </summary>
+        public string? ResponseFormat { get; set; } = "mp3";
+
+        /// <summary>Optional playback speed multiplier (provider support varies).</summary>
+        public double? Speed { get; set; }
+
+        /// <summary>Provider-specific passthrough fields.</summary>
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/Audio/TextToSpeechResponse.cs
+++ b/Shared/ConduitLLM.Core/Models/Audio/TextToSpeechResponse.cs
@@ -1,0 +1,20 @@
+namespace ConduitLLM.Core.Models.Audio
+{
+    /// <summary>
+    /// A text-to-speech synthesis response carrying the raw audio bytes.
+    /// </summary>
+    public class TextToSpeechResponse
+    {
+        /// <summary>The synthesized audio bytes.</summary>
+        public required byte[] AudioData { get; set; }
+
+        /// <summary>The audio content type, e.g. <c>audio/mpeg</c> or <c>audio/pcm</c>.</summary>
+        public required string ContentType { get; set; }
+
+        /// <summary>The model that produced the audio.</summary>
+        public string? Model { get; set; }
+
+        /// <summary>Usage/cost information (character count is the billable unit for TTS).</summary>
+        public Usage? Usage { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/ChatCompletionRequest.cs
+++ b/Shared/ConduitLLM.Core/Models/ChatCompletionRequest.cs
@@ -141,6 +141,14 @@ public class ChatCompletionRequest
     public ResponseFormat? ResponseFormat { get; set; }
 
     /// <summary>
+    /// Unified reasoning configuration (effort / max tokens / enabled / exclude). Forwarded to
+    /// providers that support reasoning (e.g. OpenRouter). Only serialized when set.
+    /// </summary>
+    [JsonPropertyName("reasoning")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ReasoningConfig? Reasoning { get; set; }
+
+    /// <summary>
     /// A random number seed for deterministic outputs.
     /// </summary>
     [JsonPropertyName("seed")]

--- a/Shared/ConduitLLM.Core/Models/ChatCompletionRequest.cs
+++ b/Shared/ConduitLLM.Core/Models/ChatCompletionRequest.cs
@@ -234,8 +234,9 @@ public class ChatCompletionRequest
     /// Examples include reasoning_effort, min_p, language, timestamp_granularities, etc.
     /// </summary>
     /// <remarks>
-    /// This property captures any JSON properties not explicitly mapped to other properties.
-    /// The router validates these against the model's supported parameters before forwarding.
+    /// This property captures any JSON properties not explicitly mapped to other properties, and they
+    /// are forwarded to the provider as-is (they are not validated against the model's supported
+    /// parameters). Standard mapped parameters take precedence on key collision.
     /// </remarks>
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtensionData { get; set; }

--- a/Shared/ConduitLLM.Core/Models/Configuration/ModelConfiguration.cs
+++ b/Shared/ConduitLLM.Core/Models/Configuration/ModelConfiguration.cs
@@ -82,6 +82,11 @@ namespace ConduitLLM.Core.Models.Configuration
         public bool SupportsTextToSpeech { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the model supports document reranking.
+        /// </summary>
+        public bool SupportsRerank { get; set; }
+
+        /// <summary>
         /// Gets or sets the tokenizer type for the model.
         /// </summary>
         public string? TokenizerType { get; set; }

--- a/Shared/ConduitLLM.Core/Models/Configuration/ModelConfiguration.cs
+++ b/Shared/ConduitLLM.Core/Models/Configuration/ModelConfiguration.cs
@@ -72,6 +72,16 @@ namespace ConduitLLM.Core.Models.Configuration
         public bool SupportsVideoGeneration { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the model supports speech-to-text transcription.
+        /// </summary>
+        public bool SupportsSpeechToText { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the model supports text-to-speech synthesis.
+        /// </summary>
+        public bool SupportsTextToSpeech { get; set; }
+
+        /// <summary>
         /// Gets or sets the tokenizer type for the model.
         /// </summary>
         public string? TokenizerType { get; set; }

--- a/Shared/ConduitLLM.Core/Models/JsonSchemaFormat.cs
+++ b/Shared/ConduitLLM.Core/Models/JsonSchemaFormat.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Core.Models
+{
+    /// <summary>
+    /// A JSON Schema definition for structured outputs, used with
+    /// <see cref="ResponseFormat"/> when the type is <c>json_schema</c>.
+    /// </summary>
+    public class JsonSchemaFormat
+    {
+        /// <summary>
+        /// The name of the schema (required by OpenAI-compatible structured outputs).
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// When true, the provider enforces strict adherence to the schema.
+        /// </summary>
+        [JsonPropertyName("strict")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Strict { get; set; }
+
+        /// <summary>
+        /// The JSON Schema document the output must conform to.
+        /// </summary>
+        [JsonPropertyName("schema")]
+        public JsonElement Schema { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/ProviderCostBillingPolicy.cs
+++ b/Shared/ConduitLLM.Core/Models/ProviderCostBillingPolicy.cs
@@ -1,0 +1,24 @@
+namespace ConduitLLM.Core.Models;
+
+/// <summary>
+/// Billing policy that governs whether a provider's self-reported cost is authoritative for a request.
+/// </summary>
+/// <remarks>
+/// Stamped onto <see cref="Usage.ProviderCostPolicy"/> by the Gateway from the resolved provider
+/// configuration before cost calculation. Kept in <c>ConduitLLM.Core</c> so the cost calculator
+/// (which has no HTTP or Configuration dependency) can consume it via the <see cref="Usage"/> object.
+/// </remarks>
+public sealed class ProviderCostBillingPolicy
+{
+    /// <summary>
+    /// When true, the provider-reported cost (<see cref="Usage.ProviderReportedCostUsd"/>) is
+    /// authoritative for billing; ModelCost calculation is only a fallback when no cost is reported.
+    /// </summary>
+    public bool TrustProviderReportedCost { get; init; }
+
+    /// <summary>
+    /// Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).
+    /// Only consulted when <see cref="TrustProviderReportedCost"/> is true.
+    /// </summary>
+    public decimal MarkupMultiplier { get; init; } = 1.0m;
+}

--- a/Shared/ConduitLLM.Core/Models/ProviderCostRefundContext.cs
+++ b/Shared/ConduitLLM.Core/Models/ProviderCostRefundContext.cs
@@ -1,0 +1,19 @@
+namespace ConduitLLM.Core.Models;
+
+/// <summary>
+/// Context supplied to a refund calculation when the original request was billed from a trusted
+/// provider-reported cost rather than from ModelCost.
+/// </summary>
+/// <remarks>
+/// Provider-cost billing has no per-unit rate breakdown (the provider returns a single amount), so a
+/// refund cannot be recomputed from token rates. Instead it is prorated from the amount actually
+/// charged, by the fraction of billable tokens being refunded.
+/// </remarks>
+public sealed class ProviderCostRefundContext
+{
+    /// <summary>
+    /// The amount (USD) actually charged for the original request — the provider-reported cost times
+    /// the configured markup, as persisted on the original request log.
+    /// </summary>
+    public decimal OriginalChargedCost { get; init; }
+}

--- a/Shared/ConduitLLM.Core/Models/ReasoningConfig.cs
+++ b/Shared/ConduitLLM.Core/Models/ReasoningConfig.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Core.Models;
+
+/// <summary>
+/// Unified reasoning configuration (OpenRouter-style), passed through to providers that support it.
+/// Only the fields that are set are serialized, so providers that don't support reasoning are
+/// unaffected unless the caller explicitly requests it.
+/// </summary>
+public class ReasoningConfig
+{
+    /// <summary>
+    /// Reasoning effort level: <c>max</c>, <c>xhigh</c>, <c>high</c>, <c>medium</c>, <c>low</c>,
+    /// <c>minimal</c>, or <c>none</c> (OpenAI-style models). Maps to thinking levels on some providers.
+    /// </summary>
+    [JsonPropertyName("effort")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Effort { get; set; }
+
+    /// <summary>
+    /// Explicit reasoning-token budget (Anthropic/Gemini-style models).
+    /// </summary>
+    [JsonPropertyName("max_tokens")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxTokens { get; set; }
+
+    /// <summary>
+    /// Enables reasoning with the provider's default parameters.
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Enabled { get; set; }
+
+    /// <summary>
+    /// When true, reasoning is used internally but excluded from the response.
+    /// </summary>
+    [JsonPropertyName("exclude")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Exclude { get; set; }
+}

--- a/Shared/ConduitLLM.Core/Models/Rerank/RerankRequest.cs
+++ b/Shared/ConduitLLM.Core/Models/Rerank/RerankRequest.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Core.Models.Rerank
+{
+    /// <summary>
+    /// A rerank request: score/order a set of documents against a query (Cohere-compatible shape).
+    /// </summary>
+    public class RerankRequest
+    {
+        /// <summary>The rerank model (alias) to use.</summary>
+        [JsonPropertyName("model")]
+        public required string Model { get; set; }
+
+        /// <summary>The search query.</summary>
+        [JsonPropertyName("query")]
+        public required string Query { get; set; }
+
+        /// <summary>The documents to rerank.</summary>
+        [JsonPropertyName("documents")]
+        public required List<string> Documents { get; set; }
+
+        /// <summary>Optional maximum number of results to return.</summary>
+        [JsonPropertyName("top_n")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? TopN { get; set; }
+
+        /// <summary>Whether to echo the document text back in each result.</summary>
+        [JsonPropertyName("return_documents")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? ReturnDocuments { get; set; }
+
+        /// <summary>Provider-specific passthrough fields.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/Rerank/RerankResponse.cs
+++ b/Shared/ConduitLLM.Core/Models/Rerank/RerankResponse.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Core.Models.Rerank
+{
+    /// <summary>
+    /// A rerank response: documents scored and ordered by relevance to the query.
+    /// </summary>
+    public class RerankResponse
+    {
+        /// <summary>The model that produced the ranking.</summary>
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        /// <summary>The ranked results, highest relevance first.</summary>
+        [JsonPropertyName("results")]
+        public required List<RerankResult> Results { get; set; }
+
+        /// <summary>Usage/cost information (search units are the billable unit for rerank).</summary>
+        [JsonPropertyName("usage")]
+        public Usage? Usage { get; set; }
+    }
+
+    /// <summary>
+    /// A single reranked document.
+    /// </summary>
+    public class RerankResult
+    {
+        /// <summary>The index of the document in the original request list.</summary>
+        [JsonPropertyName("index")]
+        public required int Index { get; set; }
+
+        /// <summary>The relevance score (higher is more relevant).</summary>
+        [JsonPropertyName("relevance_score")]
+        public required double RelevanceScore { get; set; }
+
+        /// <summary>The document text, when <c>return_documents</c> was requested.</summary>
+        [JsonPropertyName("document")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Document { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/ResponseFormat.cs
+++ b/Shared/ConduitLLM.Core/Models/ResponseFormat.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace ConduitLLM.Core.Models
@@ -29,6 +30,13 @@ namespace ConduitLLM.Core.Models
         public string? Type { get; set; }
 
         /// <summary>
+        /// The JSON Schema definition, used when <see cref="Type"/> is <c>json_schema</c>.
+        /// </summary>
+        [JsonPropertyName("json_schema")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public JsonSchemaFormat? JsonSchema { get; set; }
+
+        /// <summary>
         /// Creates a new instance of the ResponseFormat class with default values.
         /// </summary>
         public ResponseFormat() { }
@@ -58,6 +66,21 @@ namespace ConduitLLM.Core.Models
         public static ResponseFormat Text()
         {
             return new ResponseFormat("text");
+        }
+
+        /// <summary>
+        /// Creates a new ResponseFormat configured for schema-constrained JSON output.
+        /// </summary>
+        /// <param name="name">The schema name.</param>
+        /// <param name="schema">The JSON Schema document the output must conform to.</param>
+        /// <param name="strict">Whether the provider must strictly enforce the schema.</param>
+        /// <returns>A ResponseFormat with type set to "json_schema".</returns>
+        public static ResponseFormat WithJsonSchema(string name, JsonElement schema, bool? strict = null)
+        {
+            return new ResponseFormat("json_schema")
+            {
+                JsonSchema = new JsonSchemaFormat { Name = name, Schema = schema, Strict = strict }
+            };
         }
     }
 }

--- a/Shared/ConduitLLM.Core/Models/Usage.cs
+++ b/Shared/ConduitLLM.Core/Models/Usage.cs
@@ -185,6 +185,30 @@ public class Usage
     public Dictionary<string, object>? PricingParameters { get; set; }
 
     /// <summary>
+    /// Cost in USD reported by the provider for this request (e.g. OpenRouter's usage.cost — the
+    /// actual credits the operator was charged).
+    /// </summary>
+    /// <remarks>
+    /// Server-only: captured for billing but never serialized to API clients (exposing it would
+    /// leak the operator's upstream cost). It is set programmatically by the provider client's usage
+    /// mapping, not by JSON binding. When present and the provider is configured as trusted,
+    /// <see cref="ProviderCostPolicy"/> makes it authoritative for spend calculation.
+    /// </remarks>
+    [JsonIgnore]
+    public decimal? ProviderReportedCostUsd { get; set; }
+
+    /// <summary>
+    /// Billing policy stamped by the Gateway before cost calculation. Never serialized.
+    /// </summary>
+    /// <remarks>
+    /// When <see cref="ProviderCostBillingPolicy.TrustProviderReportedCost"/> is true and
+    /// <see cref="ProviderReportedCostUsd"/> is present, the cost calculator bills
+    /// <c>ProviderReportedCostUsd * MarkupMultiplier</c> instead of computing from ModelCost.
+    /// </remarks>
+    [JsonIgnore]
+    public ProviderCostBillingPolicy? ProviderCostPolicy { get; set; }
+
+    /// <summary>
     /// Extension data to capture additional provider-specific fields not defined in the model.
     /// </summary>
     /// <remarks>

--- a/Shared/ConduitLLM.Core/Models/Usage.cs
+++ b/Shared/ConduitLLM.Core/Models/Usage.cs
@@ -154,6 +154,20 @@ public class Usage
     public int? ReasoningTokens { get; set; }
 
     /// <summary>
+    /// Duration of transcribed audio in seconds (speech-to-text). Billed per minute.
+    /// </summary>
+    [JsonPropertyName("audio_duration_seconds")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? AudioDurationSeconds { get; set; }
+
+    /// <summary>
+    /// Number of input characters synthesized (text-to-speech). Billed per thousand characters.
+    /// </summary>
+    [JsonPropertyName("tts_characters")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? TtsCharacters { get; set; }
+
+    /// <summary>
     /// Optional metadata for provider-specific usage information.
     /// </summary>
     /// <remarks>

--- a/Shared/ConduitLLM.Core/Services/ConfigurationModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Services/ConfigurationModelCapabilityService.cs
@@ -64,6 +64,18 @@ namespace ConduitLLM.Core.Services
             return capability?.SupportsVideoGeneration ?? false;
         }
 
+        public async Task<bool> SupportsSpeechToTextAsync(string model)
+        {
+            var capability = await GetModelCapabilityAsync(model);
+            return capability?.SupportsSpeechToText ?? false;
+        }
+
+        public async Task<bool> SupportsTextToSpeechAsync(string model)
+        {
+            var capability = await GetModelCapabilityAsync(model);
+            return capability?.SupportsTextToSpeech ?? false;
+        }
+
         public async Task<string?> GetTokenizerTypeAsync(string model)
         {
             var capability = await GetModelCapabilityAsync(model);

--- a/Shared/ConduitLLM.Core/Services/ConfigurationModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Services/ConfigurationModelCapabilityService.cs
@@ -76,6 +76,12 @@ namespace ConduitLLM.Core.Services
             return capability?.SupportsTextToSpeech ?? false;
         }
 
+        public async Task<bool> SupportsRerankAsync(string model)
+        {
+            var capability = await GetModelCapabilityAsync(model);
+            return capability?.SupportsRerank ?? false;
+        }
+
         public async Task<string?> GetTokenizerTypeAsync(string model)
         {
             var capability = await GetModelCapabilityAsync(model);

--- a/Shared/ConduitLLM.Core/Services/CostCalculationService.Refunds.cs
+++ b/Shared/ConduitLLM.Core/Services/CostCalculationService.Refunds.cs
@@ -37,6 +37,7 @@ public partial class CostCalculationService
         Usage refundUsage,
         string refundReason,
         string? originalTransactionId = null,
+        ProviderCostRefundContext? providerCostContext = null,
         CancellationToken cancellationToken = default)
     {
         var result = new RefundResult
@@ -79,6 +80,19 @@ public partial class CostCalculationService
             _logger.LogWarning(
                 "Refund rejected for model {ModelId}: refund usage exceeds original or is invalid. {ValidationMessages}",
                 modelId, string.Join("; ", validationMessages));
+            return result;
+        }
+
+        // Provider-cost-billed requests have no per-unit rates to recompute from. Refund proportionally
+        // from the amount actually charged, by the fraction of billable tokens being refunded.
+        if (providerCostContext != null)
+        {
+            var ratio = ComputeRefundTokenRatio(originalUsage, refundUsage);
+            result.RefundAmount = decimal.Round(providerCostContext.OriginalChargedCost * ratio, 8);
+            result.Breakdown = new RefundBreakdown();
+            _logger.LogInformation(
+                "Calculated proportional provider-cost refund for model {ModelId}: charged {Charged} * ratio {Ratio} = {RefundAmount}. Reason: {RefundReason}. Original Transaction: {OriginalTransactionId}",
+                modelId, providerCostContext.OriginalChargedCost, ratio, result.RefundAmount, refundReason, originalTransactionId ?? "N/A");
             return result;
         }
 
@@ -272,5 +286,30 @@ public partial class CostCalculationService
         }
 
         return messages;
+    }
+
+    /// <summary>
+    /// Computes the fraction of the original charge to refund for a provider-cost-billed request,
+    /// based on the share of billable (prompt + completion + reasoning) tokens being refunded.
+    /// Clamped to [0, 1]. When the original request has no token basis (e.g. image/video only), any
+    /// refund request is treated as a full refund.
+    /// </summary>
+    private static decimal ComputeRefundTokenRatio(Usage originalUsage, Usage refundUsage)
+    {
+        var originalTokens = (originalUsage.PromptTokens ?? 0)
+            + (originalUsage.CompletionTokens ?? 0)
+            + (originalUsage.ReasoningTokens ?? 0);
+
+        if (originalTokens <= 0)
+        {
+            return 1.0m;
+        }
+
+        var refundTokens = (refundUsage.PromptTokens ?? 0)
+            + (refundUsage.CompletionTokens ?? 0)
+            + (refundUsage.ReasoningTokens ?? 0);
+
+        var ratio = (decimal)refundTokens / originalTokens;
+        return Math.Clamp(ratio, 0m, 1.0m);
     }
 }

--- a/Shared/ConduitLLM.Core/Services/CostCalculationService.Refunds.cs
+++ b/Shared/ConduitLLM.Core/Services/CostCalculationService.Refunds.cs
@@ -198,6 +198,24 @@ public partial class CostCalculationService
                 searchRefund);
         }
 
+        // Handle audio transcription (speech-to-text) refunds, billed per minute.
+        if (refundUsage.AudioDurationSeconds is > 0 && modelCost.AudioCostPerMinute.HasValue)
+        {
+            var audioRefund = ((decimal)refundUsage.AudioDurationSeconds.Value / 60m) * modelCost.AudioCostPerMinute.Value;
+            totalRefund += audioRefund;
+            _logger.LogDebug("Audio transcription refund for model {ModelId}: {Seconds}s = ${Total}",
+                modelId, refundUsage.AudioDurationSeconds.Value, audioRefund);
+        }
+
+        // Handle text-to-speech refunds, billed per thousand characters.
+        if (refundUsage.TtsCharacters is > 0 && modelCost.AudioCostPerThousandCharacters.HasValue)
+        {
+            var ttsRefund = (refundUsage.TtsCharacters.Value / 1000m) * modelCost.AudioCostPerThousandCharacters.Value;
+            totalRefund += ttsRefund;
+            _logger.LogDebug("Text-to-speech refund for model {ModelId}: {Chars} chars = ${Total}",
+                modelId, refundUsage.TtsCharacters.Value, ttsRefund);
+        }
+
         // Inference step refunds are now handled via RulesBased pricing configuration
 
         // Apply batch processing discount if applicable
@@ -271,6 +289,29 @@ public partial class CostCalculationService
         if (refundUsage.SearchUnits.HasValue && refundUsage.SearchUnits.Value < 0)
         {
             messages.Add("Refund search units must be non-negative.");
+        }
+
+        // Validate audio refund amounts
+        if (refundUsage.AudioDurationSeconds.HasValue && originalUsage.AudioDurationSeconds.HasValue &&
+            refundUsage.AudioDurationSeconds.Value > originalUsage.AudioDurationSeconds.Value)
+        {
+            messages.Add($"Refund audio duration ({refundUsage.AudioDurationSeconds.Value}s) cannot exceed original ({originalUsage.AudioDurationSeconds.Value}s).");
+        }
+
+        if (refundUsage.AudioDurationSeconds is < 0)
+        {
+            messages.Add("Refund audio duration must be non-negative.");
+        }
+
+        if (refundUsage.TtsCharacters.HasValue && originalUsage.TtsCharacters.HasValue &&
+            refundUsage.TtsCharacters.Value > originalUsage.TtsCharacters.Value)
+        {
+            messages.Add($"Refund TTS characters ({refundUsage.TtsCharacters.Value}) cannot exceed original ({originalUsage.TtsCharacters.Value}).");
+        }
+
+        if (refundUsage.TtsCharacters is < 0)
+        {
+            messages.Add("Refund TTS characters must be non-negative.");
         }
 
         // Validate inference steps refund amounts

--- a/Shared/ConduitLLM.Core/Services/CostCalculationService.StandardPricing.cs
+++ b/Shared/ConduitLLM.Core/Services/CostCalculationService.StandardPricing.cs
@@ -92,6 +92,28 @@ public partial class CostCalculationService
                 searchCost);
         }
 
+        // Add audio transcription (speech-to-text) cost, billed per minute of audio.
+        if (usage.AudioDurationSeconds is > 0 && modelCost.AudioCostPerMinute.HasValue)
+        {
+            var audioCost = ((decimal)usage.AudioDurationSeconds.Value / 60m) * modelCost.AudioCostPerMinute.Value;
+            calculatedCost += audioCost;
+
+            _logger.LogDebug(
+                "Audio transcription cost for model {ModelId}: {Seconds}s = ${Total}",
+                modelId, usage.AudioDurationSeconds.Value, audioCost);
+        }
+
+        // Add text-to-speech cost, billed per thousand input characters.
+        if (usage.TtsCharacters is > 0 && modelCost.AudioCostPerThousandCharacters.HasValue)
+        {
+            var ttsCost = (usage.TtsCharacters.Value / 1000m) * modelCost.AudioCostPerThousandCharacters.Value;
+            calculatedCost += ttsCost;
+
+            _logger.LogDebug(
+                "Text-to-speech cost for model {ModelId}: {Chars} chars = ${Total}",
+                modelId, usage.TtsCharacters.Value, ttsCost);
+        }
+
         // Inference step costs are now handled via RulesBased pricing configuration
         // Use PricingModel.InferenceSteps instead
 

--- a/Shared/ConduitLLM.Core/Services/CostCalculationService.cs
+++ b/Shared/ConduitLLM.Core/Services/CostCalculationService.cs
@@ -92,6 +92,13 @@ public partial class CostCalculationService : ICostCalculationService
             return 0m;
         }
 
+        // Provider-reported cost is authoritative when the provider is configured as trusted.
+        // Checked before the ModelCost lookup so a missing/stale ModelCost row still bills correctly.
+        if (TryBillProviderReportedCost(usage, modelId, out var providerBilledCost))
+        {
+            return providerBilledCost;
+        }
+
         var modelCost = await _modelCostService.GetCostForModelAsync(modelId, cancellationToken);
 
         if (modelCost == null)
@@ -176,6 +183,13 @@ public partial class CostCalculationService : ICostCalculationService
             return 0m;
         }
 
+        // Provider-reported cost is authoritative when the provider is configured as trusted.
+        // Checked before the ModelCost lookup so a missing/stale ModelCost row still bills correctly.
+        if (TryBillProviderReportedCost(usage, $"ModelCostId:{modelCostId}", out var providerBilledCost))
+        {
+            return providerBilledCost;
+        }
+
         var modelCost = await _modelCostService.GetCostByIdAsync(modelCostId, cancellationToken);
 
         if (modelCost == null)
@@ -253,5 +267,37 @@ public partial class CostCalculationService : ICostCalculationService
         }
 
         return calculatedCost;
+    }
+
+    /// <summary>
+    /// When the usage carries a trusted provider-reported cost, computes the authoritative billed
+    /// amount (provider cost times the configured markup) and returns true, bypassing ModelCost
+    /// calculation. Returns false when the provider is not trusted or reported no cost.
+    /// </summary>
+    /// <remarks>
+    /// The batch-processing multiplier is deliberately NOT applied here: the provider-reported cost
+    /// is the actual amount the operator was charged, so applying the list-price batch discount on
+    /// top would double-discount. A trusted cost of 0 (e.g. free model variants) bills as 0.
+    /// </remarks>
+    private bool TryBillProviderReportedCost(Usage usage, string modelIdentifier, out decimal billedCost)
+    {
+        billedCost = 0m;
+
+        if (usage.ProviderCostPolicy is not { TrustProviderReportedCost: true } policy ||
+            usage.ProviderReportedCostUsd is not decimal providerCost ||
+            providerCost < 0m)
+        {
+            return false;
+        }
+
+        var markup = policy.MarkupMultiplier > 0m ? policy.MarkupMultiplier : 1.0m;
+        billedCost = providerCost * markup;
+
+        _logger.LogInformation(
+            "Billing provider-reported cost for {ModelIdentifier}: provider cost {ProviderCost}, " +
+            "markup {Markup}, billed {BilledCost}. ModelCost calculation bypassed.",
+            modelIdentifier, providerCost, markup, billedCost);
+
+        return true;
     }
 }

--- a/Shared/ConduitLLM.Core/Services/DatabaseModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Services/DatabaseModelCapabilityService.cs
@@ -147,6 +147,31 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <inheritdoc/>
+        public async Task<bool> SupportsRerankAsync(string model)
+        {
+            var cacheKey = $"{CacheKeyPrefix}Rerank:{model}";
+
+            var cachedResult = await GetFromHybridCacheAsync<bool?>(cacheKey);
+            if (cachedResult.HasValue)
+            {
+                return cachedResult.Value;
+            }
+
+            try
+            {
+                var mapping = await GetMappingByModelNameAsync(model);
+                var result = mapping?.ModelProviderTypeAssociation?.Model?.SupportsRerank ?? false;
+                await SetInHybridCacheAsync(cacheKey, result);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking rerank capability for model {Model}", model);
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<string?> GetTokenizerTypeAsync(string model)
         {
             var cacheKey = $"{CacheKeyPrefix}Tokenizer:{model}";

--- a/Shared/ConduitLLM.Core/Services/DatabaseModelCapabilityService.cs
+++ b/Shared/ConduitLLM.Core/Services/DatabaseModelCapabilityService.cs
@@ -97,6 +97,56 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <inheritdoc/>
+        public async Task<bool> SupportsSpeechToTextAsync(string model)
+        {
+            var cacheKey = $"{CacheKeyPrefix}SpeechToText:{model}";
+
+            var cachedResult = await GetFromHybridCacheAsync<bool?>(cacheKey);
+            if (cachedResult.HasValue)
+            {
+                return cachedResult.Value;
+            }
+
+            try
+            {
+                var mapping = await GetMappingByModelNameAsync(model);
+                var result = mapping?.ModelProviderTypeAssociation?.Model?.SupportsSpeechToText ?? false;
+                await SetInHybridCacheAsync(cacheKey, result);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking speech-to-text capability for model {Model}", model);
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> SupportsTextToSpeechAsync(string model)
+        {
+            var cacheKey = $"{CacheKeyPrefix}TextToSpeech:{model}";
+
+            var cachedResult = await GetFromHybridCacheAsync<bool?>(cacheKey);
+            if (cachedResult.HasValue)
+            {
+                return cachedResult.Value;
+            }
+
+            try
+            {
+                var mapping = await GetMappingByModelNameAsync(model);
+                var result = mapping?.ModelProviderTypeAssociation?.Model?.SupportsTextToSpeech ?? false;
+                await SetInHybridCacheAsync(cacheKey, result);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking text-to-speech capability for model {Model}", model);
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<string?> GetTokenizerTypeAsync(string model)
         {
             var cacheKey = $"{CacheKeyPrefix}Tokenizer:{model}";

--- a/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
+++ b/Shared/ConduitLLM.Core/Services/VideoGenerationOrchestrator.cs
@@ -108,10 +108,11 @@ namespace ConduitLLM.Core.Services
                 throw new NotSupportedException($"Provider for model {modelInfo.ModelAlias} does not support video generation");
             }
 
-            // Set up progress callback if the provider client is MiniMax
-            if (innermostType.Name == "MiniMaxClient")
+            // Set up the progress callback for any provider client that exposes SetProgressCallback
+            // (e.g. MiniMax, OpenRouter), not just MiniMax by name.
+            if (innermostType.GetMethod("SetProgressCallback") != null)
             {
-                SetupMiniMaxProgressCallback(innermostClient, request.Model, cancellationToken);
+                SetupProgressCallback(innermostClient, request.Model, cancellationToken);
             }
 
             // Invoke through the outermost client in the chain that exposes CreateVideoAsync so
@@ -148,10 +149,10 @@ namespace ConduitLLM.Core.Services
             return await task;
         }
 
-        private void SetupMiniMaxProgressCallback(object client, string requestId, CancellationToken cancellationToken)
+        private void SetupProgressCallback(object client, string requestId, CancellationToken cancellationToken)
         {
             var clientType = client.GetType();
-            var setCallbackMethod = clientType.GetMethod("SetVideoProgressCallback");
+            var setCallbackMethod = clientType.GetMethod("SetProgressCallback");
             if (setCallbackMethod != null)
             {
                 Func<string, string, int, Task> progressCallback = async (taskId, status, progressPercentage) =>

--- a/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
@@ -55,6 +55,12 @@ namespace ConduitLLM.Providers.Configuration
         /// Optional default models configuration.
         /// </summary>
         public ProviderDefaultModels? DefaultModels { get; init; }
+
+        /// <summary>
+        /// Optional per-mapping provider options JSON (see ModelProviderMapping.ProviderOptions),
+        /// merged into outgoing requests by providers that support it (currently OpenRouter).
+        /// </summary>
+        public string? ProviderOptionsJson { get; init; }
     }
 
     /// <summary>
@@ -321,7 +327,8 @@ namespace ConduitLLM.Providers.Configuration
                 modelId,
                 logger,
                 context.HttpClientFactory,
-                context.DefaultModels);
+                context.DefaultModels,
+                context.ProviderOptionsJson);
         }
 
         private static ILLMClient CreateMetaClient(

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -85,7 +85,7 @@ namespace ConduitLLM.Providers
             }
 
             var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
-            return CreateClientForProvider(provider, primaryKey, mapping.ProviderModelId);
+            return CreateClientForProvider(provider, primaryKey, mapping.ProviderModelId, mapping.ProviderOptions);
         }
 
         /// <inheritdoc />
@@ -193,7 +193,7 @@ namespace ConduitLLM.Providers
             return primaryKey;
         }
 
-        private ILLMClient CreateClientForProvider(Provider provider, ProviderKeyCredential keyCredential, string modelId)
+        private ILLMClient CreateClientForProvider(Provider provider, ProviderKeyCredential keyCredential, string modelId, string? providerOptionsJson = null)
         {
             var providerName = provider.ProviderType.ToString().ToLowerInvariant();
 
@@ -206,7 +206,8 @@ namespace ConduitLLM.Providers
                 LoggerFactory = _loggerFactory,
                 HttpClientFactory = _httpClientFactory,
                 CapabilityService = _capabilityService,
-                DefaultModels = null // TODO: Get default models configuration from somewhere (database?)
+                DefaultModels = null, // TODO: Get default models configuration from somewhere (database?)
+                ProviderOptionsJson = providerOptionsJson
             };
 
             // Create the base client using the registry

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Audio.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Audio.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models.Audio;
+using CoreModels = ConduitLLM.Core.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.OpenAICompatible
+{
+    /// <summary>
+    /// OpenAICompatibleClient partial adding OpenAI-compatible audio: speech-to-text
+    /// (<c>/audio/transcriptions</c>, multipart) and text-to-speech (<c>/audio/speech</c>, raw bytes).
+    /// Every OpenAI-compatible provider (including OpenRouter by inheritance) gains these; whether a
+    /// given model actually serves them is gated at the controller by the DB capability flags.
+    /// </summary>
+    public abstract partial class OpenAICompatibleClient : IAudioTranscriptionClient, ITextToSpeechClient
+    {
+        /// <inheritdoc />
+        public async Task<AudioTranscriptionResponse> TranscribeAudioAsync(
+            AudioTranscriptionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var client = CreateHttpClient(apiKey);
+
+                using var form = new MultipartFormDataContent();
+                var fileContent = new ByteArrayContent(request.AudioData);
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue(request.ContentType ?? "application/octet-stream");
+                form.Add(fileContent, "file", request.FileName);
+                form.Add(new StringContent(string.IsNullOrEmpty(request.Model) ? ProviderModelId : request.Model), "model");
+                if (!string.IsNullOrEmpty(request.Language))
+                    form.Add(new StringContent(request.Language), "language");
+                if (!string.IsNullOrEmpty(request.Prompt))
+                    form.Add(new StringContent(request.Prompt), "prompt");
+                if (request.Temperature.HasValue)
+                    form.Add(new StringContent(request.Temperature.Value.ToString(CultureInfo.InvariantCulture)), "temperature");
+                form.Add(new StringContent(request.ResponseFormat ?? "json"), "response_format");
+                if (request.ExtensionData != null)
+                {
+                    foreach (var kvp in request.ExtensionData)
+                        form.Add(new StringContent(kvp.Value.ToString()), kvp.Key);
+                }
+
+                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, GetAudioTranscriptionEndpoint())
+                {
+                    Content = form
+                };
+                foreach (var header in CreateStandardHeaders(apiKey))
+                    httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+                using var httpResponse = await client.SendAsync(httpRequest, cancellationToken);
+                var responseText = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    throw new LLMCommunicationException(
+                        $"{ProviderName} transcription failed ({(int)httpResponse.StatusCode}): {responseText}");
+                }
+
+                AudioTranscriptionResponse result;
+                if ((request.ResponseFormat ?? "json").Equals("text", StringComparison.OrdinalIgnoreCase))
+                {
+                    result = new AudioTranscriptionResponse { Text = responseText };
+                }
+                else
+                {
+                    result = JsonSerializer.Deserialize<AudioTranscriptionResponse>(responseText, DefaultJsonOptions)
+                        ?? new AudioTranscriptionResponse { Text = string.Empty };
+                }
+
+                // Capture provider-reported cost (and strip it) for authoritative billing.
+                ExtractProviderUsageFromExtensionData(result.Usage);
+                if (result.Usage != null && result.DurationSeconds.HasValue)
+                    result.Usage.AudioDurationSeconds ??= result.DurationSeconds;
+
+                CaptureGenerationId(httpResponse, result);
+                return result;
+            }, "CreateTranscription", cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<TextToSpeechResponse> CreateSpeechAsync(
+            TextToSpeechRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var client = CreateHttpClient(apiKey);
+
+                var body = new Dictionary<string, object?>
+                {
+                    ["model"] = string.IsNullOrEmpty(request.Model) ? ProviderModelId : request.Model,
+                    ["input"] = request.Input,
+                    ["voice"] = request.Voice,
+                    ["response_format"] = request.ResponseFormat ?? "mp3"
+                };
+                if (request.Speed.HasValue)
+                    body["speed"] = request.Speed.Value;
+                if (request.ExtensionData != null)
+                {
+                    foreach (var kvp in request.ExtensionData)
+                        if (!body.ContainsKey(kvp.Key))
+                            body[kvp.Key] = kvp.Value;
+                }
+
+                var json = JsonSerializer.Serialize(body, DefaultJsonOptions);
+                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, GetTextToSpeechEndpoint())
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+                foreach (var header in CreateStandardHeaders(apiKey))
+                    httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+                using var httpResponse = await client.SendAsync(httpRequest, cancellationToken);
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    var err = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                    throw new LLMCommunicationException(
+                        $"{ProviderName} speech synthesis failed ({(int)httpResponse.StatusCode}): {err}");
+                }
+
+                var audioBytes = await httpResponse.Content.ReadAsByteArrayAsync(cancellationToken);
+                var contentType = httpResponse.Content.Headers.ContentType?.ToString() ?? "audio/mpeg";
+
+                // Characters are the billable unit for TTS (the byte response carries no usage JSON).
+                var usage = new CoreModels.Usage { TtsCharacters = request.Input?.Length ?? 0 };
+                if (httpResponse.Headers.TryGetValues("X-Generation-Id", out var genIds))
+                    (usage.Metadata ??= new Dictionary<string, object>())["generation_id"] = genIds.FirstOrDefault() ?? string.Empty;
+
+                return new TextToSpeechResponse
+                {
+                    AudioData = audioBytes,
+                    ContentType = contentType,
+                    Model = request.Model,
+                    Usage = usage
+                };
+            }, "CreateSpeech", cancellationToken);
+        }
+
+        /// <summary>
+        /// Captures the provider's X-Generation-Id header into usage metadata so the provider-cost
+        /// path can later resolve the authoritative cost via the provider's /generation endpoint.
+        /// </summary>
+        private static void CaptureGenerationId(HttpResponseMessage httpResponse, AudioTranscriptionResponse result)
+        {
+            if (httpResponse.Headers.TryGetValues("X-Generation-Id", out var genIds))
+            {
+                result.Usage ??= new CoreModels.Usage();
+                (result.Usage.Metadata ??= new Dictionary<string, object>())["generation_id"] = genIds.FirstOrDefault() ?? string.Empty;
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Endpoints.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Endpoints.cs
@@ -52,5 +52,21 @@ namespace ConduitLLM.Providers.OpenAICompatible
         {
             return $"{BaseUrl}/images/generations";
         }
+
+        /// <summary>
+        /// Gets the audio transcription (speech-to-text) endpoint URL.
+        /// </summary>
+        protected virtual string GetAudioTranscriptionEndpoint()
+        {
+            return $"{BaseUrl}/audio/transcriptions";
+        }
+
+        /// <summary>
+        /// Gets the text-to-speech endpoint URL.
+        /// </summary>
+        protected virtual string GetTextToSpeechEndpoint()
+        {
+            return $"{BaseUrl}/audio/speech";
+        }
     }
 }

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
@@ -107,7 +107,15 @@ namespace ConduitLLM.Providers.OpenAICompatible
             // Only send ResponseFormat if explicitly requested and not "text" (default)
             // Some providers like SambaNova don't support response_format with type "text"
             if (request.ResponseFormat != null && request.ResponseFormat.Type != "text")
-                openAiRequest["response_format"] = new ResponseFormat { Type = request.ResponseFormat.Type ?? "text" };
+            {
+                // For json_schema, forward the Core ResponseFormat as-is so the schema payload
+                // ({ type, json_schema: { name, strict, schema } }) reaches the provider. For other
+                // types (e.g. json_object) send only { type } to match providers that reject extras.
+                openAiRequest["response_format"] =
+                    request.ResponseFormat.Type == "json_schema" && request.ResponseFormat.JsonSchema != null
+                        ? (object)request.ResponseFormat
+                        : new ResponseFormat { Type = request.ResponseFormat.Type ?? "text" };
+            }
             // Unified reasoning config — only forwarded when the caller set it (providers that don't
             // support it simply ignore/return an error, same as any explicit unsupported parameter).
             if (request.Reasoning != null)

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
@@ -338,41 +338,72 @@ namespace ConduitLLM.Providers.OpenAICompatible
                 ReasoningTokens = openAiUsage.ReasoningTokens
             };
 
-            if (openAiUsage.ExtensionData == null)
-                return usage;
+            if (openAiUsage.ExtensionData != null)
+            {
+                PopulateProviderUsageFields(openAiUsage.ExtensionData, usage);
+            }
 
-            // OpenAI format: usage.prompt_tokens_details.cached_tokens
-            if (openAiUsage.ExtensionData.TryGetValue("prompt_tokens_details", out var promptDetails) &&
+            return usage;
+        }
+
+        /// <summary>
+        /// Populates provider-agnostic <see cref="CoreModels.Usage"/> fields (cached tokens,
+        /// cache-write tokens, and provider-reported cost) from a provider usage extension-data
+        /// dictionary. Shared by the non-streaming mapper (<see cref="MapUsageFromOpenAI"/>) and the
+        /// streaming post-processor so both paths capture the same provider-specific fields.
+        /// </summary>
+        /// <remarks>
+        /// Uses null-coalescing assignment so the first non-null value wins; callers pass a freshly
+        /// constructed usage on the non-streaming path, so this is equivalent to plain assignment there.
+        /// </remarks>
+        private static void PopulateProviderUsageFields(
+            IDictionary<string, System.Text.Json.JsonElement> extensionData,
+            CoreModels.Usage usage)
+        {
+            // OpenAI / OpenRouter format: prompt_tokens_details.{cached_tokens, cache_write_tokens}
+            if (extensionData.TryGetValue("prompt_tokens_details", out var promptDetails) &&
                 promptDetails.ValueKind == System.Text.Json.JsonValueKind.Object)
             {
                 if (promptDetails.TryGetProperty("cached_tokens", out var cachedTokens) &&
                     cachedTokens.TryGetInt32(out var cached))
                 {
-                    usage.CachedInputTokens = cached;
+                    usage.CachedInputTokens ??= cached;
+                }
+
+                if (promptDetails.TryGetProperty("cache_write_tokens", out var cacheWriteTokens) &&
+                    cacheWriteTokens.TryGetInt32(out var cacheWritten))
+                {
+                    usage.CachedWriteTokens ??= cacheWritten;
                 }
             }
 
-            // Anthropic format: usage.cache_read_input_tokens / usage.cache_creation_input_tokens
-            if (openAiUsage.ExtensionData.TryGetValue("cache_read_input_tokens", out var cacheRead) &&
+            // Anthropic format: cache_read_input_tokens / cache_creation_input_tokens
+            if (extensionData.TryGetValue("cache_read_input_tokens", out var cacheRead) &&
                 cacheRead.TryGetInt32(out var cacheReadCount))
             {
-                usage.CachedInputTokens = cacheReadCount;
+                usage.CachedInputTokens ??= cacheReadCount;
             }
 
-            if (openAiUsage.ExtensionData.TryGetValue("cache_creation_input_tokens", out var cacheWrite) &&
+            if (extensionData.TryGetValue("cache_creation_input_tokens", out var cacheWrite) &&
                 cacheWrite.TryGetInt32(out var cacheWriteCount))
             {
-                usage.CachedWriteTokens = cacheWriteCount;
+                usage.CachedWriteTokens ??= cacheWriteCount;
             }
 
-            // Deepseek format: usage.prompt_cache_hit_tokens / usage.prompt_cache_miss_tokens
-            if (openAiUsage.ExtensionData.TryGetValue("prompt_cache_hit_tokens", out var cacheHit) &&
+            // Deepseek format: prompt_cache_hit_tokens
+            if (extensionData.TryGetValue("prompt_cache_hit_tokens", out var cacheHit) &&
                 cacheHit.TryGetInt32(out var cacheHitCount))
             {
-                usage.CachedInputTokens = cacheHitCount;
+                usage.CachedInputTokens ??= cacheHitCount;
             }
 
-            return usage;
+            // OpenRouter (and compatible): usage.cost = actual credits charged (USD).
+            if (extensionData.TryGetValue("cost", out var cost) &&
+                cost.ValueKind == System.Text.Json.JsonValueKind.Number &&
+                cost.TryGetDecimal(out var costValue))
+            {
+                usage.ProviderReportedCostUsd ??= costValue;
+            }
         }
 
         /// <summary>
@@ -394,46 +425,23 @@ namespace ConduitLLM.Providers.OpenAICompatible
         }
 
         /// <summary>
-        /// Post-processes a deserialized Usage object to extract cached token counts
-        /// from provider-specific extension data fields.
-        /// Call this after deserializing a Usage object from provider JSON.
+        /// Post-processes a deserialized Usage object to extract cached token counts and the
+        /// provider-reported cost from provider-specific extension data, then strips the raw
+        /// <c>cost</c> key so it is never re-serialized back to API clients.
+        /// Call this after deserializing a Usage object from provider JSON (e.g. streaming chunks).
         /// </summary>
         /// <param name="usage">The deserialized Usage object to post-process.</param>
-        internal static void ExtractCachedTokensFromExtensionData(CoreModels.Usage? usage)
+        internal static void ExtractProviderUsageFromExtensionData(CoreModels.Usage? usage)
         {
             if (usage?.ExtensionData == null)
                 return;
 
-            // OpenAI format: prompt_tokens_details.cached_tokens
-            if (usage.ExtensionData.TryGetValue("prompt_tokens_details", out var promptDetails) &&
-                promptDetails.ValueKind == System.Text.Json.JsonValueKind.Object)
-            {
-                if (promptDetails.TryGetProperty("cached_tokens", out var cachedTokens) &&
-                    cachedTokens.TryGetInt32(out var cached))
-                {
-                    usage.CachedInputTokens ??= cached;
-                }
-            }
+            PopulateProviderUsageFields(usage.ExtensionData, usage);
 
-            // Anthropic format: cache_read_input_tokens / cache_creation_input_tokens
-            if (usage.ExtensionData.TryGetValue("cache_read_input_tokens", out var cacheRead) &&
-                cacheRead.TryGetInt32(out var cacheReadCount))
-            {
-                usage.CachedInputTokens ??= cacheReadCount;
-            }
-
-            if (usage.ExtensionData.TryGetValue("cache_creation_input_tokens", out var cacheWrite) &&
-                cacheWrite.TryGetInt32(out var cacheWriteCount))
-            {
-                usage.CachedWriteTokens ??= cacheWriteCount;
-            }
-
-            // Deepseek format: prompt_cache_hit_tokens
-            if (usage.ExtensionData.TryGetValue("prompt_cache_hit_tokens", out var cacheHit) &&
-                cacheHit.TryGetInt32(out var cacheHitCount))
-            {
-                usage.CachedInputTokens ??= cacheHitCount;
-            }
+            // The provider-reported cost is captured onto ProviderReportedCostUsd (server-only) above.
+            // Remove it from ExtensionData so the operator's upstream cost is never leaked back to API
+            // clients when the chunk/response is re-serialized.
+            usage.ExtensionData.Remove("cost");
         }
 
         private static object? ConvertJsonElement(System.Text.Json.JsonElement element) =>

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Mapping.cs
@@ -108,6 +108,10 @@ namespace ConduitLLM.Providers.OpenAICompatible
             // Some providers like SambaNova don't support response_format with type "text"
             if (request.ResponseFormat != null && request.ResponseFormat.Type != "text")
                 openAiRequest["response_format"] = new ResponseFormat { Type = request.ResponseFormat.Type ?? "text" };
+            // Unified reasoning config — only forwarded when the caller set it (providers that don't
+            // support it simply ignore/return an error, same as any explicit unsupported parameter).
+            if (request.Reasoning != null)
+                openAiRequest["reasoning"] = request.Reasoning;
             if (request.Stream != null)
                 openAiRequest["stream"] = request.Stream;
             if (request.StreamOptions != null)

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Rerank.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Rerank.cs
@@ -1,0 +1,72 @@
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models.Rerank;
+using CoreModels = ConduitLLM.Core.Models;
+using CoreUtils = ConduitLLM.Core.Utilities;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.OpenAICompatible
+{
+    /// <summary>
+    /// OpenAICompatibleClient partial adding document reranking against a Cohere-compatible
+    /// <c>/rerank</c> endpoint (the de-facto standard across Cohere/Jina/Voyage/TEI and OpenRouter).
+    /// Whether a given model serves it is gated at the controller by the DB capability flag.
+    /// </summary>
+    public abstract partial class OpenAICompatibleClient : IRerankClient
+    {
+        /// <summary>
+        /// Gets the rerank endpoint URL. Override if a provider uses a non-standard path.
+        /// </summary>
+        protected virtual string GetRerankEndpoint()
+        {
+            return $"{BaseUrl}/rerank";
+        }
+
+        /// <inheritdoc />
+        public async Task<RerankResponse> CreateRerankAsync(
+            RerankRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var client = CreateHttpClient(apiKey);
+
+                var body = new Dictionary<string, object?>
+                {
+                    ["model"] = string.IsNullOrEmpty(request.Model) ? ProviderModelId : request.Model,
+                    ["query"] = request.Query,
+                    ["documents"] = request.Documents
+                };
+                if (request.TopN.HasValue)
+                    body["top_n"] = request.TopN.Value;
+                if (request.ReturnDocuments.HasValue)
+                    body["return_documents"] = request.ReturnDocuments.Value;
+                if (request.ExtensionData != null)
+                {
+                    foreach (var kvp in request.ExtensionData)
+                        if (!body.ContainsKey(kvp.Key))
+                            body[kvp.Key] = kvp.Value;
+                }
+
+                var response = await CoreUtils.HttpClientHelper.SendJsonRequestAsync<Dictionary<string, object?>, RerankResponse>(
+                    client,
+                    HttpMethod.Post,
+                    GetRerankEndpoint(),
+                    body,
+                    CreateStandardHeaders(apiKey),
+                    DefaultJsonOptions,
+                    Logger,
+                    cancellationToken);
+
+                response.Usage ??= new CoreModels.Usage();
+                // Capture any provider-reported cost for authoritative billing.
+                ExtractProviderUsageFromExtensionData(response.Usage);
+                // Synthesize search units when the provider doesn't report them (Cohere convention:
+                // 1 search unit = 1 query + up to 100 documents).
+                response.Usage.SearchUnits ??= Math.Max(1, (int)Math.Ceiling(request.Documents.Count / 100.0));
+                return response;
+            }, "CreateRerank", cancellationToken);
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Streaming.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Streaming.cs
@@ -140,8 +140,9 @@ namespace ConduitLLM.Providers.OpenAICompatible
                                 mappedChunk.OriginalModelAlias = request.Model;
                             }
 
-                            // Extract cached token counts from provider-specific extension data
-                            ExtractCachedTokensFromExtensionData(mappedChunk.Usage);
+                            // Extract cached token counts + provider-reported cost from provider-specific
+                            // extension data (and strip the raw cost so it is not leaked to clients).
+                            ExtractProviderUsageFromExtensionData(mappedChunk.Usage);
 
                             instrumentation.RecordChunk();
 

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Images.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Images.cs
@@ -1,0 +1,139 @@
+using System.Text.Json.Serialization;
+
+using CoreModels = ConduitLLM.Core.Models;
+using CoreUtils = ConduitLLM.Core.Utilities;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.OpenRouter
+{
+    public partial class OpenRouterClient
+    {
+        /// <summary>
+        /// Generates images via OpenRouter's native image API (<c>POST /api/v1/images</c>), which
+        /// differs from the OpenAI <c>/images/generations</c> schema the base client posts to (that
+        /// endpoint does not exist on OpenRouter, so the inherited implementation 404s).
+        /// </summary>
+        /// <remarks>
+        /// OpenRouter returns images as base64 <c>b64_json</c> plus a usage block carrying the actual
+        /// USD cost, which is captured for authoritative billing. Output defaults to PNG so the stored
+        /// bytes are labeled <c>image/png</c> correctly by the images controller; other formats can be
+        /// requested via extension data (the stored content-type label is a known limitation there).
+        /// </remarks>
+        public override async Task<CoreModels.ImageGenerationResponse> CreateImageAsync(
+            CoreModels.ImageGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateRequest(request, "CreateImage");
+
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var client = CreateHttpClient(apiKey);
+
+                var body = new Dictionary<string, object?>
+                {
+                    ["prompt"] = request.Prompt,
+                    ["model"] = request.Model ?? ProviderModelId,
+                    ["n"] = Math.Clamp(request.N, 1, 10)
+                };
+
+                if (!string.IsNullOrEmpty(request.Size))
+                    body["size"] = request.Size;
+
+                var quality = MapQuality(request.Quality);
+                if (quality != null)
+                    body["quality"] = quality;
+
+                // Image-to-image: map the base64 input image to OpenRouter's input_references.
+                if (!string.IsNullOrEmpty(request.Image))
+                    body["input_references"] = new[] { $"data:image/png;base64,{request.Image}" };
+
+                // Pass through extension data, excluding parameters OpenRouter's image endpoint does not
+                // use (stream / response_format) and anything already mapped above.
+                if (request.ExtensionData != null)
+                {
+                    foreach (var kvp in request.ExtensionData)
+                    {
+                        if (kvp.Key is "stream" or "response_format")
+                            continue;
+                        if (!body.ContainsKey(kvp.Key))
+                            body[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                if (!body.ContainsKey("output_format"))
+                    body["output_format"] = "png";
+
+                var endpoint = $"{BaseUrl}/images";
+                Logger.LogInformation("Creating images via {Provider} at {Endpoint} with model {Model}",
+                    ProviderName, endpoint, body["model"]);
+
+                var response = await CoreUtils.HttpClientHelper.SendJsonRequestAsync<Dictionary<string, object?>, OpenRouterImageResponse>(
+                    client,
+                    HttpMethod.Post,
+                    endpoint,
+                    body,
+                    CreateStandardHeaders(apiKey),
+                    DefaultJsonOptions,
+                    Logger,
+                    cancellationToken);
+
+                var data = response.Data?
+                    .Select(d => new CoreModels.ImageData { B64Json = d.B64Json })
+                    .ToList() ?? new List<CoreModels.ImageData>();
+
+                var usage = response.Usage ?? new CoreModels.Usage();
+                // Capture the provider-reported cost (and strip it from extension data) so billing can
+                // use it authoritatively; then annotate image request-shape for cost/logging.
+                ExtractProviderUsageFromExtensionData(usage);
+                usage.ImageCount = data.Count;
+                usage.ImageQuality = request.Quality;
+                usage.ImageResolution = request.Size;
+
+                return new CoreModels.ImageGenerationResponse
+                {
+                    Created = response.Created != 0 ? response.Created : DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    Data = data,
+                    Usage = usage
+                };
+            }, "CreateImage", cancellationToken);
+        }
+
+        /// <summary>
+        /// Maps OpenAI-style quality tiers to OpenRouter's (auto/low/medium/high); unknown values are
+        /// omitted rather than forwarded so OpenRouter doesn't reject the request.
+        /// </summary>
+        private static string? MapQuality(string? quality) => quality?.ToLowerInvariant() switch
+        {
+            "hd" => "high",
+            "standard" => "medium",
+            "auto" => "auto",
+            "low" => "low",
+            "medium" => "medium",
+            "high" => "high",
+            _ => null
+        };
+
+        private record OpenRouterImageResponse
+        {
+            [JsonPropertyName("created")]
+            public long Created { get; init; }
+
+            [JsonPropertyName("data")]
+            public List<OpenRouterImageData>? Data { get; init; }
+
+            [JsonPropertyName("usage")]
+            public CoreModels.Usage? Usage { get; init; }
+        }
+
+        private record OpenRouterImageData
+        {
+            [JsonPropertyName("b64_json")]
+            public string? B64Json { get; init; }
+
+            [JsonPropertyName("media_type")]
+            public string? MediaType { get; init; }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Mapping.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Mapping.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+
+using CoreModels = ConduitLLM.Core.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.OpenRouter
+{
+    public partial class OpenRouterClient
+    {
+        /// <summary>
+        /// Per-mapping provider options (provider/plugins/transforms/models/route), parsed once from
+        /// <c>ModelProviderMapping.ProviderOptions</c>. Null when none configured or the JSON is invalid.
+        /// </summary>
+        private readonly Dictionary<string, JsonElement>? _mappingOptions;
+
+        /// <summary>
+        /// Merges the per-mapping provider options into the outgoing request. Precedence:
+        /// standard mapped parameters &gt; caller-supplied ExtensionData (merged by the base) &gt; mapping
+        /// options — so a per-request choice always beats a per-mapping default, and neither can
+        /// clobber a standard parameter. Whole-key merge (no deep merge of nested objects in v1).
+        /// </summary>
+        protected override object MapToOpenAIRequest(CoreModels.ChatCompletionRequest request)
+        {
+            var mapped = base.MapToOpenAIRequest(request);
+            if (_mappingOptions is null || mapped is not IDictionary<string, object?> dict)
+            {
+                return mapped;
+            }
+
+            foreach (var (key, value) in _mappingOptions)
+            {
+                if (!dict.ContainsKey(key))
+                {
+                    dict[key] = value;
+                }
+            }
+
+            return mapped;
+        }
+
+        private Dictionary<string, JsonElement>? ParseProviderOptions(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+                return parsed is { Count: > 0 } ? parsed : null;
+            }
+            catch (JsonException ex)
+            {
+                Logger.LogWarning(ex, "Ignoring malformed OpenRouter ProviderOptions JSON for a mapping.");
+                return null;
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Videos.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.Videos.cs
@@ -1,0 +1,174 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Helpers;
+using CoreModels = ConduitLLM.Core.Models;
+using CoreUtils = ConduitLLM.Core.Utilities;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.OpenRouter
+{
+    public partial class OpenRouterClient
+    {
+        private Func<string, string, int, Task>? _progressCallback;
+
+        /// <summary>
+        /// Sets a progress callback invoked as the async video job advances. Discovered by the video
+        /// orchestrator via reflection (same <c>SetProgressCallback</c> contract MiniMax uses).
+        /// </summary>
+        public void SetProgressCallback(Func<string, string, int, Task> callback) => _progressCallback = callback;
+
+        /// <summary>
+        /// Generates a video via OpenRouter's async video API: <c>POST /api/v1/videos</c> (202 + job id),
+        /// poll <c>GET /api/v1/videos/{id}</c> until completed, then return the unsigned download URL for
+        /// the media pipeline (UrlMediaProcessor) to fetch and store.
+        /// </summary>
+        /// <remarks>
+        /// Duck-typed (not on ILLMClient) so the video orchestrator discovers it by reflection
+        /// (Name == "CreateVideoAsync" with 3 parameters), matching the MiniMax/Replicate pattern.
+        /// OpenRouter's unsigned URLs require no auth header, so UrlMediaProcessor can download them.
+        /// </remarks>
+        public async Task<CoreModels.VideoGenerationResponse> CreateVideoAsync(
+            CoreModels.VideoGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateRequest(request, "CreateVideo");
+
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var client = CreateHttpClient(apiKey);
+                var headers = CreateStandardHeaders(apiKey);
+
+                var submitBody = new Dictionary<string, object?>
+                {
+                    ["model"] = request.Model ?? ProviderModelId,
+                    ["prompt"] = request.Prompt
+                };
+                if (request.Duration.HasValue) submitBody["duration"] = request.Duration.Value;
+                if (request.Seed.HasValue) submitBody["seed"] = request.Seed.Value;
+                if (!string.IsNullOrEmpty(request.Size)) submitBody["size"] = request.Size;
+                if (request.ExtensionData != null)
+                {
+                    foreach (var kvp in request.ExtensionData)
+                    {
+                        if (kvp.Key == "stream") continue;
+                        if (!submitBody.ContainsKey(kvp.Key)) submitBody[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                var submit = await CoreUtils.HttpClientHelper.SendJsonRequestAsync<Dictionary<string, object?>, OpenRouterVideoSubmitResponse>(
+                    client, HttpMethod.Post, $"{BaseUrl}/videos", submitBody, headers, DefaultJsonOptions, Logger, cancellationToken);
+
+                var jobId = submit.Id;
+                if (string.IsNullOrEmpty(jobId))
+                    throw new LLMCommunicationException("OpenRouter video generation did not return a job id.");
+
+                var options = new PollingOptions(
+                    InitialDelay: TimeSpan.FromSeconds(2),
+                    MaxDelay: TimeSpan.FromSeconds(30),
+                    Timeout: TimeSpan.FromSeconds(ResolveVideoPollingTimeoutSeconds()),
+                    Backoff: BackoffStrategy.ExponentialWithJitter,
+                    MaxConsecutiveTransientErrors: 3,
+                    BackoffMultiplier: 1.5,
+                    JitterMilliseconds: 500);
+
+                using var pollScope = BeginPollingScope("CreateVideo");
+                var status = await AsyncJobPoller.PollAsync(
+                    fetchStatus: ct => CoreUtils.HttpClientHelper.GetJsonAsync<OpenRouterVideoStatus>(
+                        client, $"{BaseUrl}/videos/{jobId}", headers, DefaultJsonOptions, Logger, ct),
+                    classify: ClassifyVideoStatus,
+                    extractSuccess: s => s,
+                    extractFailure: s => new LLMCommunicationException($"OpenRouter video generation failed for job {jobId}."),
+                    options: options,
+                    logger: Logger,
+                    cancellationToken: cancellationToken,
+                    onProgress: async (poll, s) =>
+                    {
+                        if (_progressCallback is not null && poll.State == JobState.InProgress)
+                            await _progressCallback(jobId, s.Status ?? "in_progress", 0);
+                    },
+                    operationName: $"OpenRouter video generation {jobId}",
+                    instrumentation: pollScope);
+
+                var url = status.UnsignedUrls?.FirstOrDefault();
+                if (string.IsNullOrEmpty(url))
+                    throw new LLMCommunicationException($"OpenRouter video job {jobId} completed without a downloadable URL.");
+
+                return new CoreModels.VideoGenerationResponse
+                {
+                    Created = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    Model = request.Model,
+                    Data = new List<CoreModels.VideoData>
+                    {
+                        new()
+                        {
+                            Url = url,
+                            Metadata = new CoreModels.VideoMetadata
+                            {
+                                Format = "mp4",
+                                MimeType = "video/mp4",
+                                Duration = request.Duration ?? 0
+                            }
+                        }
+                    },
+                    Usage = new CoreModels.VideoGenerationUsage
+                    {
+                        VideosGenerated = 1,
+                        TotalDurationSeconds = request.Duration ?? 0,
+                        EstimatedCost = status.Usage?.Cost
+                    }
+                };
+            }, "CreateVideo", cancellationToken);
+        }
+
+        private static JobState ClassifyVideoStatus(OpenRouterVideoStatus status) =>
+            status.Status?.ToLowerInvariant() switch
+            {
+                "completed" => JobState.Succeeded,
+                "failed" => JobState.Failed,
+                _ => JobState.InProgress   // pending / in_progress / queued / unknown → keep polling
+            };
+
+        private static int ResolveVideoPollingTimeoutSeconds()
+        {
+            const int defaultSeconds = 600;
+            var env = Environment.GetEnvironmentVariable("CONDUITLLM__TIMEOUTS__VIDEO_POLLING__SECONDS");
+            return !string.IsNullOrEmpty(env) && int.TryParse(env, out var parsed) && parsed > 0 ? parsed : defaultSeconds;
+        }
+
+        private record OpenRouterVideoSubmitResponse
+        {
+            [JsonPropertyName("id")]
+            public string? Id { get; init; }
+        }
+
+        private record OpenRouterVideoStatus
+        {
+            [JsonPropertyName("id")]
+            public string? Id { get; init; }
+
+            [JsonPropertyName("status")]
+            public string? Status { get; init; }
+
+            [JsonPropertyName("generation_id")]
+            public string? GenerationId { get; init; }
+
+            [JsonPropertyName("unsigned_urls")]
+            public List<string>? UnsignedUrls { get; init; }
+
+            [JsonPropertyName("usage")]
+            public OpenRouterVideoUsage? Usage { get; init; }
+        }
+
+        private record OpenRouterVideoUsage
+        {
+            [JsonPropertyName("cost")]
+            public decimal? Cost { get; init; }
+
+            [JsonPropertyName("is_byok")]
+            public bool? IsByok { get; init; }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
@@ -67,7 +67,8 @@ namespace ConduitLLM.Providers.OpenRouter
             string providerModelId,
             ILogger logger,
             IHttpClientFactory? httpClientFactory = null,
-            ProviderDefaultModels? defaultModels = null)
+            ProviderDefaultModels? defaultModels = null,
+            string? providerOptionsJson = null)
             : base(
                 provider,
                 keyCredential,
@@ -78,6 +79,7 @@ namespace ConduitLLM.Providers.OpenRouter
                 baseUrl: ProviderConfigurationRegistry.GetDefaultBaseUrl(ProviderType.OpenRouter),
                 defaultModels: defaultModels)
         {
+            _mappingOptions = ParseProviderOptions(providerOptionsJson);
         }
 
         /// <summary>

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
@@ -38,10 +38,19 @@ namespace ConduitLLM.Providers.OpenRouter
     /// - "models": string[] with "route": "fallback" for multi-model fallback
     /// </para>
     /// </remarks>
-    public class OpenRouterClient : ConduitLLM.Providers.OpenAICompatible.OpenAICompatibleClient
+    public partial class OpenRouterClient : ConduitLLM.Providers.OpenAICompatible.OpenAICompatibleClient
     {
         private static ProviderErrorMessages OpenRouterErrorMessages =>
             ProviderConfigurationRegistry.GetErrorMessages(ProviderType.OpenRouter);
+
+        // OpenRouter's recommended app-attribution headers. Configurable via env vars because the
+        // static client-creator delegates have no access to IConfiguration.
+        private static readonly string AttributionReferer =
+            Environment.GetEnvironmentVariable("CONDUIT_OPENROUTER_HTTP_REFERER")
+                ?? "https://github.com/nickna/Conduit";
+
+        private static readonly string AttributionTitle =
+            Environment.GetEnvironmentVariable("CONDUIT_OPENROUTER_X_TITLE") ?? "Conduit";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenRouterClient"/> class.
@@ -69,6 +78,18 @@ namespace ConduitLLM.Providers.OpenRouter
                 baseUrl: ProviderConfigurationRegistry.GetDefaultBaseUrl(ProviderType.OpenRouter),
                 defaultModels: defaultModels)
         {
+        }
+
+        /// <summary>
+        /// Adds OpenRouter's recommended app-attribution headers (HTTP-Referer + X-Title) to every
+        /// outgoing request so Conduit is identified in OpenRouter analytics/leaderboards.
+        /// </summary>
+        protected override Dictionary<string, string> CreateStandardHeaders(string? apiKey = null)
+        {
+            var headers = base.CreateStandardHeaders(apiKey);
+            headers["HTTP-Referer"] = AttributionReferer;
+            headers["X-Title"] = AttributionTitle;
+            return headers;
         }
 
         /// <summary>
@@ -114,7 +135,7 @@ namespace ConduitLLM.Providers.OpenRouter
                         cancellationToken);
 
                     return response.Data
-                        .Select(m => InternalModels.ExtendedModelInfo.Create(m.Id, ProviderName, m.Id))
+                        .Select(MapModelInfo)
                         .ToList();
                 }, "GetModels", cancellationToken);
             }
@@ -123,6 +144,51 @@ namespace ConduitLLM.Providers.OpenRouter
                 Logger.LogError(ex, "Failed to retrieve models from {Provider} API.", ProviderName);
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Projects an OpenRouter /models entry into an <see cref="InternalModels.ExtendedModelInfo"/>,
+        /// deriving capabilities from <c>supported_parameters</c> + <c>architecture</c> modalities and
+        /// token limits from <c>context_length</c> + <c>top_provider.max_completion_tokens</c>. All
+        /// fields are nullable-tolerant so schema drift cannot break model listing.
+        /// </summary>
+        private InternalModels.ExtendedModelInfo MapModelInfo(OpenRouterModelData m)
+        {
+            var info = InternalModels.ExtendedModelInfo.Create(m.Id, ProviderName, m.Id);
+
+            if (!string.IsNullOrEmpty(m.Name))
+            {
+                info.WithName(m.Name);
+            }
+
+            var supported = m.SupportedParameters ?? new List<string>();
+            var inputModalities = m.Architecture?.InputModalities ?? new List<string>();
+            var outputModalities = m.Architecture?.OutputModalities ?? new List<string>();
+
+            var toolsSupported = supported.Contains("tools", StringComparer.OrdinalIgnoreCase);
+
+            info.WithCapabilities(new InternalModels.ModelCapabilities
+            {
+                Chat = true,
+                TextGeneration = true,
+                FunctionCalling = toolsSupported,
+                ToolUsage = toolsSupported,
+                JsonMode = supported.Contains("response_format", StringComparer.OrdinalIgnoreCase)
+                    || supported.Contains("structured_outputs", StringComparer.OrdinalIgnoreCase),
+                Vision = inputModalities.Contains("image", StringComparer.OrdinalIgnoreCase),
+                ImageGeneration = outputModalities.Contains("image", StringComparer.OrdinalIgnoreCase)
+            });
+
+            if (m.ContextLength.HasValue || m.TopProvider?.MaxCompletionTokens != null)
+            {
+                info.WithTokenLimits(new InternalModels.ModelTokenLimits
+                {
+                    Context = m.ContextLength ?? m.TopProvider?.ContextLength,
+                    Output = m.TopProvider?.MaxCompletionTokens
+                });
+            }
+
+            return info;
         }
 
         /// <summary>
@@ -288,5 +354,77 @@ namespace ConduitLLM.Providers.OpenRouter
 
         [JsonPropertyName("name")]
         public string? Name { get; init; }
+
+        [JsonPropertyName("description")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("context_length")]
+        public int? ContextLength { get; init; }
+
+        [JsonPropertyName("architecture")]
+        public OpenRouterArchitecture? Architecture { get; init; }
+
+        [JsonPropertyName("pricing")]
+        public OpenRouterPricing? Pricing { get; init; }
+
+        [JsonPropertyName("top_provider")]
+        public OpenRouterTopProvider? TopProvider { get; init; }
+
+        [JsonPropertyName("supported_parameters")]
+        public List<string>? SupportedParameters { get; init; }
+    }
+
+    /// <summary>Architecture block from OpenRouter's /models: modalities + tokenizer.</summary>
+    internal record OpenRouterArchitecture
+    {
+        [JsonPropertyName("input_modalities")]
+        public List<string>? InputModalities { get; init; }
+
+        [JsonPropertyName("output_modalities")]
+        public List<string>? OutputModalities { get; init; }
+
+        [JsonPropertyName("tokenizer")]
+        public string? Tokenizer { get; init; }
+    }
+
+    /// <summary>
+    /// Per-model pricing from OpenRouter's /models. Values are USD-per-unit strings (per docs) and are
+    /// carried through for the admin-reviewed pricing sync; not consumed at request time.
+    /// </summary>
+    internal record OpenRouterPricing
+    {
+        [JsonPropertyName("prompt")]
+        public string? Prompt { get; init; }
+
+        [JsonPropertyName("completion")]
+        public string? Completion { get; init; }
+
+        [JsonPropertyName("request")]
+        public string? Request { get; init; }
+
+        [JsonPropertyName("image")]
+        public string? Image { get; init; }
+
+        [JsonPropertyName("web_search")]
+        public string? WebSearch { get; init; }
+
+        [JsonPropertyName("internal_reasoning")]
+        public string? InternalReasoning { get; init; }
+
+        [JsonPropertyName("input_cache_read")]
+        public string? InputCacheRead { get; init; }
+
+        [JsonPropertyName("input_cache_write")]
+        public string? InputCacheWrite { get; init; }
+    }
+
+    /// <summary>Top-provider metadata from OpenRouter's /models (max completion + context length).</summary>
+    internal record OpenRouterTopProvider
+    {
+        [JsonPropertyName("max_completion_tokens")]
+        public int? MaxCompletionTokens { get; init; }
+
+        [JsonPropertyName("context_length")]
+        public int? ContextLength { get; init; }
     }
 }

--- a/Tests/ConduitLLM.Tests/Admin/Services/OpenRouterDriftDetectionServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/OpenRouterDriftDetectionServiceTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+
+using ConduitLLM.Admin.Services;
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Data;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Enums;
+using ConduitLLM.Configuration.Options;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+using Moq.Protected;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Admin.Services
+{
+    /// <summary>
+    /// Tests for OpenRouter drift detection: pricing/capability drift, model-removed, and idempotent
+    /// re-detection. Uses an in-memory DbContext and a mocked catalog fetch.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Admin")]
+    public class OpenRouterDriftDetectionServiceTests
+    {
+        private readonly DbContextOptions<ConduitDbContext> _dbOptions;
+        private readonly Mock<IDbContextFactory<ConduitDbContext>> _dbFactory;
+
+        public OpenRouterDriftDetectionServiceTests()
+        {
+            _dbOptions = new DbContextOptionsBuilder<ConduitDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+            _dbFactory = new Mock<IDbContextFactory<ConduitDbContext>>();
+            _dbFactory.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new ConduitDbContext(_dbOptions));
+        }
+
+        private void SeedOpenRouterMapping(bool withCost = true)
+        {
+            using var db = new ConduitDbContext(_dbOptions);
+            db.Providers.Add(new Provider { Id = 1, ProviderType = ProviderType.OpenRouter, ProviderName = "OpenRouter", IsEnabled = true });
+            db.Models.Add(new Model { Id = 1, Name = "Claude 3.5 Sonnet", SupportsVision = false, SupportsFunctionCalling = false, SupportsImageGeneration = false });
+            if (withCost)
+            {
+                db.ModelCosts.Add(new ModelCost { Id = 1, CostName = "claude", InputCostPerMillionTokens = 3.0m, OutputCostPerMillionTokens = 15.0m, IsActive = true });
+            }
+            db.ModelProviderTypeAssociations.Add(new ModelProviderTypeAssociation
+            {
+                Id = 1,
+                ModelId = 1,
+                ModelCostId = withCost ? 1 : null,
+                Identifier = "anthropic/claude-3.5-sonnet"
+            });
+            db.ModelProviderMappings.Add(new ModelProviderMapping
+            {
+                Id = 1,
+                ProviderId = 1,
+                ProviderModelId = "anthropic/claude-3.5-sonnet",
+                ModelAlias = "claude",
+                ModelProviderTypeAssociationId = 1,
+                IsEnabled = true
+            });
+            db.SaveChanges();
+        }
+
+        private OpenRouterDriftDetectionService CreateService(string catalogJson)
+        {
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(catalogJson) });
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(() => new HttpClient(handler.Object));
+
+            var options = Options.Create(new OpenRouterSyncOptions { ModelsEndpoint = "https://test.invalid/models" });
+            var logger = new Mock<ILogger<OpenRouterDriftDetectionService>>();
+            return new OpenRouterDriftDetectionService(_dbFactory.Object, httpFactory.Object, options, logger.Object);
+        }
+
+        [Fact]
+        public async Task RunSyncAsync_DetectsPricingAndCapabilityDrift()
+        {
+            // Arrange — provider raised prompt price to $4/M and now reports image input (vision)
+            SeedOpenRouterMapping();
+            var catalog = "{\"data\":[{\"id\":\"anthropic/claude-3.5-sonnet\"," +
+                          "\"pricing\":{\"prompt\":\"0.000004\",\"completion\":\"0.000015\"}," +
+                          "\"architecture\":{\"input_modalities\":[\"text\",\"image\"],\"output_modalities\":[\"text\"]}," +
+                          "\"supported_parameters\":[\"tools\"]}]}";
+            var service = CreateService(catalog);
+
+            // Act
+            var run = await service.RunSyncAsync("Manual");
+
+            // Assert
+            run.Status.Should().Be("Completed");
+            using var db = new ConduitDbContext(_dbOptions);
+            var items = db.ProviderMetadataDriftItems.ToList();
+            items.Select(i => i.DriftType).Should().Contain(DriftType.Pricing);
+            items.Select(i => i.DriftType).Should().Contain(DriftType.Capabilities);
+            items.Should().OnlyContain(i => i.Status == DriftStatus.Pending);
+        }
+
+        [Fact]
+        public async Task RunSyncAsync_ModelNotInCatalog_CreatesModelRemovedDrift()
+        {
+            // Arrange — catalog does not contain the mapped model
+            SeedOpenRouterMapping();
+            var service = CreateService("{\"data\":[{\"id\":\"some/other-model\",\"pricing\":{\"prompt\":\"0.000001\",\"completion\":\"0.000002\"}}]}");
+
+            // Act
+            await service.RunSyncAsync("Manual");
+
+            // Assert
+            using var db = new ConduitDbContext(_dbOptions);
+            db.ProviderMetadataDriftItems.Select(i => i.DriftType).Should().Contain(DriftType.ModelRemoved);
+        }
+
+        [Fact]
+        public async Task RunSyncAsync_RunTwice_DoesNotDuplicatePendingItems()
+        {
+            // Arrange
+            SeedOpenRouterMapping();
+            var catalog = "{\"data\":[{\"id\":\"anthropic/claude-3.5-sonnet\"," +
+                          "\"pricing\":{\"prompt\":\"0.000004\",\"completion\":\"0.000015\"}}]}";
+            var service = CreateService(catalog);
+
+            // Act
+            await service.RunSyncAsync("Manual");
+            var secondRun = await service.RunSyncAsync("Manual");
+
+            // Assert — the second run refreshes the existing pending pricing item, not duplicates it
+            using var db = new ConduitDbContext(_dbOptions);
+            db.ProviderMetadataDriftItems.Count(i => i.DriftType == DriftType.Pricing && i.Status == DriftStatus.Pending)
+                .Should().Be(1);
+            secondRun.ItemsUpdated.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task RunSyncAsync_NoModelCost_DetectsMissingCost()
+        {
+            // Arrange — mapping has no ModelCost but the provider publishes pricing
+            SeedOpenRouterMapping(withCost: false);
+            var service = CreateService("{\"data\":[{\"id\":\"anthropic/claude-3.5-sonnet\",\"pricing\":{\"prompt\":\"0.000003\",\"completion\":\"0.000015\"}}]}");
+
+            // Act
+            await service.RunSyncAsync("Manual");
+
+            // Assert
+            using var db = new ConduitDbContext(_dbOptions);
+            db.ProviderMetadataDriftItems.Select(i => i.DriftType).Should().Contain(DriftType.MissingCost);
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/Services/RefundServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/RefundServiceTests.cs
@@ -52,7 +52,8 @@ public class RefundServiceTests
         _mockGroupRepository.Setup(x => x.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(group);
         _mockCostCalculationService.Setup(x => x.CalculateRefundAsync(
-                modelId, originalUsage, refundUsage, "Incorrect response", null, It.IsAny<CancellationToken>()))
+                modelId, originalUsage, refundUsage, "Incorrect response", null,
+                It.IsAny<ProviderCostRefundContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(refundResult);
         _mockContext.Setup(x => x.VirtualKeyGroups).Returns(Mock.Of<Microsoft.EntityFrameworkCore.DbSet<VirtualKeyGroup>>());
         _mockContext.Setup(x => x.VirtualKeyGroupTransactions).Returns(Mock.Of<Microsoft.EntityFrameworkCore.DbSet<VirtualKeyGroupTransaction>>());
@@ -103,7 +104,8 @@ public class RefundServiceTests
             .ReturnsAsync(group);
         _mockCostCalculationService.Setup(x => x.CalculateRefundAsync(
                 It.IsAny<string>(), It.IsAny<Usage>(), It.IsAny<Usage>(),
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<ProviderCostRefundContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(refundResult);
 
         // Act
@@ -135,7 +137,8 @@ public class RefundServiceTests
             .ReturnsAsync(group);
         _mockCostCalculationService.Setup(x => x.CalculateRefundAsync(
                 It.IsAny<string>(), It.IsAny<Usage>(), It.IsAny<Usage>(),
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<ProviderCostRefundContext?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(refundResult);
         _mockContext.Setup(x => x.VirtualKeyGroups).Returns(Mock.Of<Microsoft.EntityFrameworkCore.DbSet<VirtualKeyGroup>>());
         _mockContext.Setup(x => x.VirtualKeyGroupTransactions).Returns(Mock.Of<Microsoft.EntityFrameworkCore.DbSet<VirtualKeyGroupTransaction>>());

--- a/Tests/ConduitLLM.Tests/Core/Models/ReasoningConfigTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/ReasoningConfigTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+using ConduitLLM.Core.Models;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Core.Models
+{
+    /// <summary>
+    /// Tests the wire shape of ReasoningConfig and its placement on ChatCompletionRequest.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Core")]
+    public class ReasoningConfigTests
+    {
+        [Fact]
+        public void ReasoningConfig_EffortOnly_SerializesOnlyEffort()
+        {
+            var json = JsonSerializer.Serialize(new ReasoningConfig { Effort = "high" });
+
+            json.Should().Be("{\"effort\":\"high\"}");
+        }
+
+        [Fact]
+        public void ReasoningConfig_MaxTokensAndExclude_SerializeSetFieldsOnly()
+        {
+            var json = JsonSerializer.Serialize(new ReasoningConfig { MaxTokens = 2000, Exclude = true });
+
+            json.Should().Contain("\"max_tokens\":2000");
+            json.Should().Contain("\"exclude\":true");
+            json.Should().NotContain("effort");
+            json.Should().NotContain("enabled");
+        }
+
+        [Fact]
+        public void ChatCompletionRequest_WithReasoning_SerializesReasoningObject()
+        {
+            var request = new ChatCompletionRequest
+            {
+                Model = "openrouter/some-model",
+                Messages = new List<Message> { new() { Role = "user", Content = "hi" } },
+                Reasoning = new ReasoningConfig { Effort = "medium" }
+            };
+
+            var json = JsonSerializer.Serialize(request);
+
+            json.Should().Contain("\"reasoning\":{\"effort\":\"medium\"}");
+        }
+
+        [Fact]
+        public void ChatCompletionRequest_WithoutReasoning_OmitsReasoningKey()
+        {
+            var request = new ChatCompletionRequest
+            {
+                Model = "openrouter/some-model",
+                Messages = new List<Message> { new() { Role = "user", Content = "hi" } }
+            };
+
+            var json = JsonSerializer.Serialize(request);
+
+            json.Should().NotContain("reasoning");
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Models/ResponseFormatTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/ResponseFormatTests.cs
@@ -209,5 +209,52 @@ namespace ConduitLLM.Tests.Core.Models
             json.Should().Contain("\"type\":\"test\"");
             json.Should().NotContain("\"Type\"");
         }
+
+        [Fact]
+        public void WithJsonSchema_FactoryMethod_CreatesJsonSchemaFormat()
+        {
+            // Arrange
+            var schema = JsonDocument.Parse("{\"type\":\"object\"}").RootElement;
+
+            // Act
+            var format = ResponseFormat.WithJsonSchema("my_schema", schema, strict: true);
+
+            // Assert
+            format.Type.Should().Be("json_schema");
+            format.JsonSchema.Should().NotBeNull();
+            format.JsonSchema!.Name.Should().Be("my_schema");
+            format.JsonSchema.Strict.Should().BeTrue();
+        }
+
+        [Fact]
+        public void JsonSerialization_WithJsonSchema_ProducesSchemaPayload()
+        {
+            // Arrange
+            var schema = JsonDocument.Parse("{\"type\":\"object\",\"properties\":{\"x\":{\"type\":\"number\"}}}").RootElement;
+            var format = ResponseFormat.WithJsonSchema("my_schema", schema, strict: true);
+
+            // Act
+            var json = JsonSerializer.Serialize(format);
+
+            // Assert
+            json.Should().Contain("\"type\":\"json_schema\"");
+            json.Should().Contain("\"json_schema\":{");
+            json.Should().Contain("\"name\":\"my_schema\"");
+            json.Should().Contain("\"strict\":true");
+            json.Should().Contain("\"schema\":{");
+        }
+
+        [Fact]
+        public void JsonSerialization_WithoutJsonSchema_OmitsJsonSchemaKey()
+        {
+            // Arrange — a plain json_object format has no schema payload
+            var format = ResponseFormat.Json();
+
+            // Act
+            var json = JsonSerializer.Serialize(format);
+
+            // Assert
+            json.Should().NotContain("json_schema");
+        }
     }
 }

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Audio.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Audio.cs
@@ -1,0 +1,84 @@
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Models;
+
+using FluentAssertions;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Tests for audio (speech-to-text per-minute, text-to-speech per-thousand-characters) billing.
+    /// </summary>
+    public partial class CostCalculationServiceBasicTests
+    {
+        [Fact]
+        public async Task CalculateCostAsync_AudioTranscription_BillsPerMinute()
+        {
+            // Arrange — 2 minutes of audio at $0.006/min
+            var usage = new Usage { AudioDurationSeconds = 120 };
+            var modelCost = new ModelCost
+            {
+                CostName = "whisper",
+                AudioCostPerMinute = 0.006m,
+                IsActive = true,
+                EffectiveDate = DateTime.UtcNow.AddDays(-1)
+            };
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/whisper-1", usage);
+
+            // Assert
+            result.Should().Be(0.012m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_TextToSpeech_BillsPerThousandCharacters()
+        {
+            // Arrange — 500 characters at $0.015 per 1,000
+            var usage = new Usage { TtsCharacters = 500 };
+            var modelCost = new ModelCost
+            {
+                CostName = "tts",
+                AudioCostPerThousandCharacters = 0.015m,
+                IsActive = true,
+                EffectiveDate = DateTime.UtcNow.AddDays(-1)
+            };
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/tts-1", usage);
+
+            // Assert
+            result.Should().Be(0.0075m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_AudioWithoutConfiguredCost_BillsZero()
+        {
+            // Arrange — audio usage but no audio cost configured
+            var usage = new Usage { AudioDurationSeconds = 120, TtsCharacters = 500 };
+            var modelCost = new ModelCost
+            {
+                CostName = "chat-only",
+                InputCostPerMillionTokens = 10m,
+                IsActive = true,
+                EffectiveDate = DateTime.UtcNow.AddDays(-1)
+            };
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var result = await _service.CalculateCostAsync("some/model", usage);
+
+            // Assert — no token usage, no audio cost configured
+            result.Should().Be(0m);
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ProviderReportedCost.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ProviderReportedCost.cs
@@ -1,0 +1,236 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Models;
+
+using FluentAssertions;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Tests for provider-reported cost billing (the authoritative-cost short-circuit) in both
+    /// CalculateCostAsync and CalculateCostByIdAsync.
+    /// </summary>
+    public partial class CostCalculationServiceBasicTests
+    {
+        private static Usage TrustedUsage(decimal? providerCost, decimal markup = 1.0m, bool isBatch = false) => new()
+        {
+            PromptTokens = 1000,
+            CompletionTokens = 500,
+            TotalTokens = 1500,
+            IsBatch = isBatch,
+            ProviderReportedCostUsd = providerCost,
+            ProviderCostPolicy = new ProviderCostBillingPolicy
+            {
+                TrustProviderReportedCost = true,
+                MarkupMultiplier = markup
+            }
+        };
+
+        private static ModelCost StandardModelCost(int? id = null) => new()
+        {
+            Id = id ?? 42,
+            CostName = "test-model-cost",
+            InputCostPerMillionTokens = 10.00m,
+            OutputCostPerMillionTokens = 30.00m,
+            IsActive = true,
+            EffectiveDate = DateTime.UtcNow.AddDays(-1)
+        };
+
+        [Fact]
+        public async Task CalculateCostAsync_TrustedProviderCost_BillsProviderCostAndBypassesModelCostLookup()
+        {
+            // Arrange
+            var usage = TrustedUsage(providerCost: 0.005m);
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StandardModelCost());
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert — provider cost wins, ModelCost math (which would be 0.025) never runs
+            result.Should().Be(0.005m);
+            _modelCostServiceMock.Verify(
+                x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_TrustedProviderCost_WithNoModelCostRow_StillBills()
+        {
+            // Arrange — no ModelCost configured; historically this billed at $0 (free)
+            var usage = TrustedUsage(providerCost: 0.007m);
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelCost?)null);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert
+            result.Should().Be(0.007m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_UntrustedProvider_UsesModelCost()
+        {
+            // Arrange — provider reports a cost, but the provider is not trusted
+            var usage = new Usage
+            {
+                PromptTokens = 1000,
+                CompletionTokens = 500,
+                TotalTokens = 1500,
+                ProviderReportedCostUsd = 0.005m,
+                ProviderCostPolicy = new ProviderCostBillingPolicy { TrustProviderReportedCost = false }
+            };
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StandardModelCost());
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert — computed from ModelCost, not the reported 0.005
+            result.Should().Be(0.025m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_TrustedButNoReportedCost_FallsBackToModelCost()
+        {
+            // Arrange — trusted, but the provider reported no cost this request
+            var usage = new Usage
+            {
+                PromptTokens = 1000,
+                CompletionTokens = 500,
+                TotalTokens = 1500,
+                ProviderReportedCostUsd = null,
+                ProviderCostPolicy = new ProviderCostBillingPolicy { TrustProviderReportedCost = true }
+            };
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StandardModelCost());
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert
+            result.Should().Be(0.025m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_TrustedZeroCost_ReturnsZeroWithoutLookup()
+        {
+            // Arrange — free variant reports cost: 0; must bill 0, not fall back to ModelCost
+            var usage = TrustedUsage(providerCost: 0m);
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StandardModelCost());
+
+            // Act
+            var result = await _service.CalculateCostAsync("openrouter/free-model:free", usage);
+
+            // Assert
+            result.Should().Be(0m);
+            _modelCostServiceMock.Verify(
+                x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_AppliesMarkupMultiplier()
+        {
+            // Arrange
+            var usage = TrustedUsage(providerCost: 0.01m, markup: 1.25m);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert
+            result.Should().Be(0.0125m);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-2)]
+        public async Task CalculateCostAsync_NonPositiveMarkup_TreatedAsPassThrough(double markup)
+        {
+            // Arrange — a misconfigured 0/negative markup must not zero out or invert billing
+            var usage = TrustedUsage(providerCost: 0.01m, markup: (decimal)markup);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert
+            result.Should().Be(0.01m);
+        }
+
+        [Fact]
+        public async Task CalculateCostAsync_TrustedCostWithBatch_DoesNotApplyBatchMultiplier()
+        {
+            // Arrange — provider cost is the actual charge; the list-price batch discount must not stack
+            var usage = TrustedUsage(providerCost: 0.01m, isBatch: true);
+            var modelCost = StandardModelCost();
+            modelCost.SupportsBatchProcessing = true;
+            modelCost.BatchProcessingMultiplier = 0.5m;
+            _modelCostServiceMock
+                .Setup(x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(modelCost);
+
+            // Act
+            var result = await _service.CalculateCostAsync("openai/gpt-4o", usage);
+
+            // Assert — full provider cost, not 0.005
+            result.Should().Be(0.01m);
+        }
+
+        [Fact]
+        public async Task CalculateCostByIdAsync_TrustedProviderCost_BillsProviderCostAndBypassesLookup()
+        {
+            // Arrange
+            var usage = TrustedUsage(providerCost: 0.005m);
+            _modelCostServiceMock
+                .Setup(x => x.GetCostByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StandardModelCost());
+
+            // Act
+            var result = await _service.CalculateCostByIdAsync(42, usage);
+
+            // Assert
+            result.Should().Be(0.005m);
+            _modelCostServiceMock.Verify(
+                x => x.GetCostByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CalculateCostByIdAsync_TrustedProviderCost_WithNoModelCostRow_StillBills()
+        {
+            // Arrange
+            var usage = TrustedUsage(providerCost: 0.009m);
+            _modelCostServiceMock
+                .Setup(x => x.GetCostByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ModelCost?)null);
+
+            // Act
+            var result = await _service.CalculateCostByIdAsync(999, usage);
+
+            // Assert
+            result.Should().Be(0.009m);
+        }
+
+        [Fact]
+        public async Task CalculateCostByIdAsync_AppliesMarkupMultiplier()
+        {
+            // Arrange
+            var usage = TrustedUsage(providerCost: 0.02m, markup: 1.5m);
+
+            // Act
+            var result = await _service.CalculateCostByIdAsync(42, usage);
+
+            // Assert
+            result.Should().Be(0.03m);
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.ProviderCost.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.ProviderCost.cs
@@ -1,0 +1,99 @@
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Models;
+
+using FluentAssertions;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Tests for proportional refunds of requests that were billed from a trusted provider-reported
+    /// cost (via ProviderCostRefundContext).
+    /// </summary>
+    public partial class CostCalculationServiceRefundTests
+    {
+        [Fact]
+        public async Task CalculateRefundAsync_ProviderCost_FullTokenRefund_RefundsFullChargedAmount()
+        {
+            // Arrange
+            var originalUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var refundUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var context = new ProviderCostRefundContext { OriginalChargedCost = 0.02m };
+
+            // Act
+            var result = await _service.CalculateRefundAsync(
+                "openrouter/model", originalUsage, refundUsage, "full refund", "txn-1", context);
+
+            // Assert
+            result.RefundAmount.Should().Be(0.02m);
+        }
+
+        [Fact]
+        public async Task CalculateRefundAsync_ProviderCost_HalfTokenRefund_RefundsHalfChargedAmount()
+        {
+            // Arrange — refunding half the billable tokens
+            var originalUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var refundUsage = new Usage { PromptTokens = 500, CompletionTokens = 250, TotalTokens = 750 };
+            var context = new ProviderCostRefundContext { OriginalChargedCost = 0.02m };
+
+            // Act
+            var result = await _service.CalculateRefundAsync(
+                "openrouter/model", originalUsage, refundUsage, "partial refund", "txn-2", context);
+
+            // Assert
+            result.RefundAmount.Should().Be(0.01m);
+        }
+
+        [Fact]
+        public async Task CalculateRefundAsync_ProviderCost_DoesNotConsultModelCost()
+        {
+            // Arrange
+            var originalUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var refundUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var context = new ProviderCostRefundContext { OriginalChargedCost = 0.02m };
+
+            // Act
+            await _service.CalculateRefundAsync(
+                "openrouter/model", originalUsage, refundUsage, "reason", "txn-3", context);
+
+            // Assert — the ModelCost lookup is never performed for provider-cost refunds
+            _modelCostServiceMock.Verify(
+                x => x.GetCostForModelAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CalculateRefundAsync_ProviderCost_NoTokenBasis_RefundsFullChargedAmount()
+        {
+            // Arrange — image-only original (no billable tokens) → any refund is a full refund
+            var originalUsage = new Usage { ImageCount = 1 };
+            var refundUsage = new Usage { ImageCount = 1 };
+            var context = new ProviderCostRefundContext { OriginalChargedCost = 0.04m };
+
+            // Act
+            var result = await _service.CalculateRefundAsync(
+                "openrouter/image", originalUsage, refundUsage, "reason", "txn-4", context);
+
+            // Assert
+            result.RefundAmount.Should().Be(0.04m);
+        }
+
+        [Fact]
+        public async Task CalculateRefundAsync_ProviderCost_ExcessRefund_StillRejectedByValidation()
+        {
+            // Arrange — refund tokens exceed original; validation must reject before proration
+            var originalUsage = new Usage { PromptTokens = 500, CompletionTokens = 250, TotalTokens = 750 };
+            var refundUsage = new Usage { PromptTokens = 1000, CompletionTokens = 500, TotalTokens = 1500 };
+            var context = new ProviderCostRefundContext { OriginalChargedCost = 0.02m };
+
+            // Act
+            var result = await _service.CalculateRefundAsync(
+                "openrouter/model", originalUsage, refundUsage, "reason", "txn-5", context);
+
+            // Assert
+            result.RefundAmount.Should().Be(0m);
+            result.ValidationMessages.Should().NotBeEmpty();
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetCapabilitiesTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetCapabilitiesTests.cs
@@ -45,7 +45,7 @@ namespace ConduitLLM.Tests.Http.Controllers.Discovery
             var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
             dynamic response = okResult.Value!;
             var capabilities = (string[])response.capabilities;
-            Assert.Equal(9, capabilities.Length);
+            Assert.Equal(11, capabilities.Length);
         }
 
         // NOTE: GetCapabilities_WhenExceptionOccurs_Returns500Error test was removed

--- a/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetCapabilitiesTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Controllers/Discovery/DiscoveryControllerGetCapabilitiesTests.cs
@@ -45,7 +45,7 @@ namespace ConduitLLM.Tests.Http.Controllers.Discovery
             var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
             dynamic response = okResult.Value!;
             var capabilities = (string[])response.capabilities;
-            Assert.Equal(11, capabilities.Length);
+            Assert.Equal(12, capabilities.Length);
         }
 
         // NOTE: GetCapabilities_WhenExceptionOccurs_Returns500Error test was removed

--- a/Tests/ConduitLLM.Tests/Integration/RefundServiceIntegrationTests.cs
+++ b/Tests/ConduitLLM.Tests/Integration/RefundServiceIntegrationTests.cs
@@ -108,6 +108,7 @@ namespace ConduitLLM.Tests.Integration
                     refundUsage,
                     refundReason,
                     It.IsAny<string?>(),
+                    It.IsAny<ProviderCostRefundContext?>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockRefundResult);
 
@@ -215,6 +216,7 @@ namespace ConduitLLM.Tests.Integration
                     refundUsage,
                     refundReason,
                     It.IsAny<string?>(),
+                    It.IsAny<ProviderCostRefundContext?>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockRefundResult);
 
@@ -257,7 +259,7 @@ namespace ConduitLLM.Tests.Integration
             _mockCostCalculationService
                 .Setup(s => s.CalculateRefundAsync(
                     modelId, originalUsage, refundUsage, refundReason,
-                    It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                    It.IsAny<string?>(), It.IsAny<ProviderCostRefundContext?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new RefundResult
                 {
                     ModelId = modelId,

--- a/Tests/ConduitLLM.Tests/Providers/OpenAICompatibleMappingTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenAICompatibleMappingTests.cs
@@ -7,13 +7,14 @@ using Xunit;
 namespace ConduitLLM.Tests.Providers;
 
 /// <summary>
-/// Tests for cached token extraction from provider-specific usage formats.
-/// Tests the internal static ExtractCachedTokensFromExtensionData method.
+/// Tests for provider-specific usage extraction (cached tokens, cache-write tokens, and
+/// provider-reported cost) from provider usage formats.
+/// Tests the internal static ExtractProviderUsageFromExtensionData method.
 /// </summary>
 public class OpenAICompatibleMappingTests
 {
     [Fact]
-    public void ExtractCachedTokens_OpenAIFormat_MapsCachedInputTokens()
+    public void ExtractProviderUsage_OpenAIFormat_MapsCachedInputTokens()
     {
         // Arrange — OpenAI returns prompt_tokens_details.cached_tokens
         var usageJson = """
@@ -29,7 +30,7 @@ public class OpenAICompatibleMappingTests
         var usage = JsonSerializer.Deserialize<Usage>(usageJson);
 
         // Act
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
 
         // Assert
         usage!.CachedInputTokens.Should().Be(80);
@@ -37,7 +38,7 @@ public class OpenAICompatibleMappingTests
     }
 
     [Fact]
-    public void ExtractCachedTokens_AnthropicFormat_MapsBothCachedFields()
+    public void ExtractProviderUsage_AnthropicFormat_MapsBothCachedFields()
     {
         // Arrange — Anthropic returns cache_read_input_tokens and cache_creation_input_tokens
         var usageJson = """
@@ -52,7 +53,7 @@ public class OpenAICompatibleMappingTests
         var usage = JsonSerializer.Deserialize<Usage>(usageJson);
 
         // Act
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
 
         // Assert
         usage!.CachedInputTokens.Should().Be(150);
@@ -60,7 +61,7 @@ public class OpenAICompatibleMappingTests
     }
 
     [Fact]
-    public void ExtractCachedTokens_DeepseekFormat_MapsCachedInputTokens()
+    public void ExtractProviderUsage_DeepseekFormat_MapsCachedInputTokens()
     {
         // Arrange — Deepseek returns prompt_cache_hit_tokens
         var usageJson = """
@@ -74,21 +75,119 @@ public class OpenAICompatibleMappingTests
         var usage = JsonSerializer.Deserialize<Usage>(usageJson);
 
         // Act
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
 
         // Assert
         usage!.CachedInputTokens.Should().Be(60);
     }
 
     [Fact]
-    public void ExtractCachedTokens_NullUsage_DoesNotThrow()
+    public void ExtractProviderUsage_OpenRouterCacheWriteTokens_MapsCacheWrite()
     {
-        // Act & Assert — should not throw
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(null);
+        // Arrange — OpenRouter nests cache write under prompt_tokens_details.cache_write_tokens
+        var usageJson = """
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "prompt_tokens_details": {
+                "cached_tokens": 40,
+                "cache_write_tokens": 25
+            }
+        }
+        """;
+        var usage = JsonSerializer.Deserialize<Usage>(usageJson);
+
+        // Act
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
+
+        // Assert
+        usage!.CachedInputTokens.Should().Be(40);
+        usage.CachedWriteTokens.Should().Be(25);
     }
 
     [Fact]
-    public void ExtractCachedTokens_NoExtensionData_DoesNotModifyUsage()
+    public void ExtractProviderUsage_OpenRouterCost_CapturesAndStripsCost()
+    {
+        // Arrange — OpenRouter returns usage.cost (USD credits charged)
+        var usageJson = """
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "cost": 0.00123
+        }
+        """;
+        var usage = JsonSerializer.Deserialize<Usage>(usageJson);
+
+        // Act
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
+
+        // Assert — captured onto the server-only field and removed from ExtensionData
+        usage!.ProviderReportedCostUsd.Should().Be(0.00123m);
+        (usage.ExtensionData == null || !usage.ExtensionData.ContainsKey("cost")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExtractProviderUsage_ZeroCost_CapturedAsZero()
+    {
+        // Arrange — free variants report cost: 0; we must bill 0, not fall back to ModelCost
+        var usageJson = """
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "cost": 0
+        }
+        """;
+        var usage = JsonSerializer.Deserialize<Usage>(usageJson);
+
+        // Act
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
+
+        // Assert
+        usage!.ProviderReportedCostUsd.Should().Be(0m);
+    }
+
+    [Fact]
+    public void ExtractProviderUsage_Cost_NotSerializedBackToClient()
+    {
+        // Arrange — a streaming final chunk carrying usage.cost, as OpenRouter sends it
+        var chunkJson = """
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "openai/gpt-4o",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cost": 0.0042
+            }
+        }
+        """;
+        var chunk = JsonSerializer.Deserialize<ChatCompletionChunk>(chunkJson);
+
+        // Act — the streaming code path post-processes usage before yielding the chunk
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(chunk!.Usage);
+        var reserialized = JsonSerializer.Serialize(chunk);
+
+        // Assert — cost captured for billing but never re-serialized to the client
+        chunk.Usage!.ProviderReportedCostUsd.Should().Be(0.0042m);
+        reserialized.Should().NotContain("cost");
+    }
+
+    [Fact]
+    public void ExtractProviderUsage_NullUsage_DoesNotThrow()
+    {
+        // Act & Assert — should not throw
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(null);
+    }
+
+    [Fact]
+    public void ExtractProviderUsage_NoExtensionData_DoesNotModifyUsage()
     {
         // Arrange — standard usage without any provider-specific fields
         var usage = new Usage
@@ -99,15 +198,16 @@ public class OpenAICompatibleMappingTests
         };
 
         // Act
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
 
         // Assert
         usage.CachedInputTokens.Should().BeNull();
         usage.CachedWriteTokens.Should().BeNull();
+        usage.ProviderReportedCostUsd.Should().BeNull();
     }
 
     [Fact]
-    public void ExtractCachedTokens_ExistingCachedTokens_DoesNotOverwrite()
+    public void ExtractProviderUsage_ExistingCachedTokens_DoesNotOverwrite()
     {
         // Arrange — Usage already has cached_input_tokens set (e.g., from direct JSON deserialization)
         // plus provider-specific extension data that would also map
@@ -123,14 +223,14 @@ public class OpenAICompatibleMappingTests
         var usage = JsonSerializer.Deserialize<Usage>(usageJson);
 
         // Act
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(usage);
 
         // Assert — the named property (42) should be preserved, not overwritten by extension data (99)
         usage!.CachedInputTokens.Should().Be(42);
     }
 
     [Fact]
-    public void ExtractCachedTokens_StreamingChunkUsage_MapsCorrectly()
+    public void ExtractProviderUsage_StreamingChunkUsage_MapsCorrectly()
     {
         // Arrange — simulate a streaming final chunk with usage data (as providers send it)
         var chunkJson = """
@@ -153,7 +253,7 @@ public class OpenAICompatibleMappingTests
         var chunk = JsonSerializer.Deserialize<ChatCompletionChunk>(chunkJson);
 
         // Act — this is what the streaming code path does
-        OpenAICompatibleClient.ExtractCachedTokensFromExtensionData(chunk!.Usage);
+        OpenAICompatibleClient.ExtractProviderUsageFromExtensionData(chunk!.Usage);
 
         // Assert
         chunk.Usage!.CachedInputTokens.Should().Be(80);

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.OpenRouter;
 
 using FluentAssertions;
@@ -25,7 +26,9 @@ namespace ConduitLLM.Tests.Providers
         private readonly Mock<HttpMessageHandler> _handlerMock;
         private readonly HttpClient _httpClient;
         private readonly List<Dictionary<string, string>> _capturedHeaders = new();
+        private readonly List<(string Method, string Path, string Body)> _capturedRequests = new();
         private string _modelsJson = "{\"data\":[]}";
+        private string _imagesJson = "{\"created\":0,\"data\":[]}";
 
         public OpenRouterClientTests(ITestOutputHelper output) : base(output)
         {
@@ -46,11 +49,18 @@ namespace ConduitLLM.Tests.Providers
                 .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
                 {
                     _capturedHeaders.Add(req.Headers.ToDictionary(h => h.Key, h => string.Join(",", h.Value)));
+                    var reqBody = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
                     var path = req.RequestUri!.AbsolutePath;
-                    var body = path.EndsWith("/key") ? "{\"data\":{}}" : _modelsJson;
+                    _capturedRequests.Add((req.Method.Method, path, reqBody));
+
+                    string responseBody;
+                    if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
+                    else if (path.EndsWith("/images")) responseBody = _imagesJson;
+                    else responseBody = _modelsJson;
+
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(body, Encoding.UTF8, "application/json")
+                        Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
                     });
                 });
         }
@@ -140,6 +150,64 @@ namespace ConduitLLM.Tests.Providers
             model.Capabilities.Should().NotBeNull();      // chat defaults still applied
             model.Capabilities!.Chat.Should().BeTrue();
             model.TokenLimits.Should().BeNull();          // no context/limits reported
+        }
+
+        [Fact]
+        public async Task CreateImageAsync_PostsToNativeImagesEndpoint_NotImagesGenerations()
+        {
+            // Arrange
+            _imagesJson = "{\"created\":1,\"data\":[{\"b64_json\":\"aGVsbG8=\"}]}";
+            var client = CreateClient();
+            var request = new ImageGenerationRequest { Prompt = "a cat", Model = "black-forest-labs/flux-1.1-pro", N = 1 };
+
+            // Act
+            await client.CreateImageAsync(request);
+
+            // Assert — hits /api/v1/images, not the OpenAI /images/generations path
+            var imageCall = _capturedRequests.Single(r => r.Method == "POST");
+            imageCall.Path.Should().EndWith("/images");
+            imageCall.Path.Should().NotContain("/images/generations");
+        }
+
+        [Fact]
+        public async Task CreateImageAsync_MapsQualityHdToHigh_AndDefaultsOutputFormatPng()
+        {
+            // Arrange
+            _imagesJson = "{\"created\":1,\"data\":[{\"b64_json\":\"aGVsbG8=\"}]}";
+            var client = CreateClient();
+            var request = new ImageGenerationRequest
+            {
+                Prompt = "a cat", Model = "openai/gpt-image-1", N = 1, Quality = "hd", Size = "1024x1024"
+            };
+
+            // Act
+            await client.CreateImageAsync(request);
+
+            // Assert
+            var body = _capturedRequests.Single(r => r.Method == "POST").Body;
+            body.Should().Contain("\"quality\":\"high\"");
+            body.Should().Contain("\"output_format\":\"png\"");
+            body.Should().NotContain("response_format");
+        }
+
+        [Fact]
+        public async Task CreateImageAsync_CapturesProviderCost_AndImageCount()
+        {
+            // Arrange — response carries b64 image + usage with cost
+            _imagesJson = "{\"created\":1,\"data\":[{\"b64_json\":\"aGVsbG8=\"}],\"usage\":{\"prompt_tokens\":10,\"cost\":0.003}}";
+            var client = CreateClient();
+            var request = new ImageGenerationRequest { Prompt = "a cat", Model = "openai/gpt-image-1", N = 1, Quality = "standard", Size = "1024x1024" };
+
+            // Act
+            var result = await client.CreateImageAsync(request);
+
+            // Assert
+            result.Data.Should().ContainSingle();
+            result.Data[0].B64Json.Should().Be("aGVsbG8=");
+            result.Usage.Should().NotBeNull();
+            result.Usage!.ProviderReportedCostUsd.Should().Be(0.003m);
+            result.Usage.ImageCount.Should().Be(1);
+            result.Usage.ImageResolution.Should().Be("1024x1024");
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Models.Audio;
 using ConduitLLM.Providers.OpenRouter;
 
 using FluentAssertions;
@@ -31,6 +32,7 @@ namespace ConduitLLM.Tests.Providers
         private string _imagesJson = "{\"created\":0,\"data\":[]}";
         private string _videoSubmitJson = "{\"id\":\"vid_1\"}";
         private string _videoStatusJson = "{\"status\":\"completed\",\"unsigned_urls\":[\"https://openrouter.ai/videos/vid_1.mp4\"]}";
+        private string _transcriptionJson = "{\"text\":\"hello\"}";
 
         public OpenRouterClientTests(ITestOutputHelper output) : base(output)
         {
@@ -55,9 +57,18 @@ namespace ConduitLLM.Tests.Providers
                     var path = req.RequestUri!.AbsolutePath;
                     _capturedRequests.Add((req.Method.Method, path, reqBody));
 
+                    // TTS returns raw audio bytes, not JSON.
+                    if (path.EndsWith("/audio/speech"))
+                    {
+                        var audio = new ByteArrayContent(new byte[] { 1, 2, 3, 4 });
+                        audio.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/mpeg");
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = audio });
+                    }
+
                     string responseBody;
                     if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
                     else if (path.EndsWith("/images")) responseBody = _imagesJson;
+                    else if (path.EndsWith("/audio/transcriptions")) responseBody = _transcriptionJson;
                     else if (path.Contains("/videos/")) responseBody = _videoStatusJson;  // GET status
                     else if (path.EndsWith("/videos")) responseBody = _videoSubmitJson;    // POST submit
                     else responseBody = _modelsJson;
@@ -259,6 +270,47 @@ namespace ConduitLLM.Tests.Providers
                 .Any(m => m.Name == "CreateVideoAsync" && m.GetParameters().Length == 3);
 
             hasContract.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task TranscribeAudioAsync_PostsToTranscriptionsEndpoint_MapsTextAndCost()
+        {
+            // Arrange
+            _transcriptionJson = "{\"text\":\"hello world\",\"duration\":12.5,\"usage\":{\"cost\":0.02}}";
+            var client = CreateClient();
+            var request = new AudioTranscriptionRequest
+            {
+                Model = "openai/whisper-1",
+                AudioData = new byte[] { 1, 2, 3 },
+                FileName = "audio.mp3",
+                ContentType = "audio/mpeg"
+            };
+
+            // Act
+            var result = await client.TranscribeAudioAsync(request);
+
+            // Assert
+            _capturedRequests.Single(r => r.Method == "POST").Path.Should().EndWith("/audio/transcriptions");
+            result.Text.Should().Be("hello world");
+            result.DurationSeconds.Should().Be(12.5);
+            result.Usage!.ProviderReportedCostUsd.Should().Be(0.02m);
+        }
+
+        [Fact]
+        public async Task CreateSpeechAsync_ReturnsAudioBytes_AndCharacterUsage()
+        {
+            // Arrange
+            var client = CreateClient();
+            var request = new TextToSpeechRequest { Model = "openai/tts-1", Input = "hello", Voice = "alloy" };
+
+            // Act
+            var result = await client.CreateSpeechAsync(request);
+
+            // Assert
+            _capturedRequests.Single(r => r.Method == "POST").Path.Should().EndWith("/audio/speech");
+            result.AudioData.Should().NotBeEmpty();
+            result.ContentType.Should().Contain("audio");
+            result.Usage!.TtsCharacters.Should().Be(5); // "hello".Length
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text;
+
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Providers.OpenRouter;
+
+using FluentAssertions;
+
+using Moq;
+using Moq.Protected;
+
+using Xunit.Abstractions;
+
+namespace ConduitLLM.Tests.Providers
+{
+    /// <summary>
+    /// Unit tests for OpenRouterClient: attribution headers and rich /models metadata mapping.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Component", "Providers")]
+    public class OpenRouterClientTests : TestBase
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+        private readonly Mock<HttpMessageHandler> _handlerMock;
+        private readonly HttpClient _httpClient;
+        private readonly List<Dictionary<string, string>> _capturedHeaders = new();
+        private string _modelsJson = "{\"data\":[]}";
+
+        public OpenRouterClientTests(ITestOutputHelper output) : base(output)
+        {
+            _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            _handlerMock = new Mock<HttpMessageHandler>();
+            _httpClient = new HttpClient(_handlerMock.Object)
+            {
+                BaseAddress = new Uri("https://openrouter.ai/api/v1/")
+            };
+            _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(_httpClient);
+
+            _handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+                {
+                    _capturedHeaders.Add(req.Headers.ToDictionary(h => h.Key, h => string.Join(",", h.Value)));
+                    var path = req.RequestUri!.AbsolutePath;
+                    var body = path.EndsWith("/key") ? "{\"data\":{}}" : _modelsJson;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(body, Encoding.UTF8, "application/json")
+                    });
+                });
+        }
+
+        private OpenRouterClient CreateClient()
+        {
+            var provider = new Provider { Id = 1, ProviderType = ProviderType.OpenRouter };
+            var keyCredential = new ProviderKeyCredential { Id = 1, ProviderId = 1, ApiKey = "test-api-key" };
+            var logger = CreateLogger<OpenRouterClient>();
+            return new OpenRouterClient(provider, keyCredential, "openai/gpt-4o", logger.Object, _httpClientFactoryMock.Object);
+        }
+
+        [Fact]
+        public async Task GetModelsAsync_SendsAttributionHeaders_OnEveryRequest()
+        {
+            // Arrange
+            var client = CreateClient();
+
+            // Act — this makes both the GET /key and GET /models calls
+            await client.GetModelsAsync();
+
+            // Assert — HTTP-Referer + X-Title present on every outgoing request
+            _capturedHeaders.Should().NotBeEmpty();
+            _capturedHeaders.Should().OnlyContain(h =>
+                h.ContainsKey("HTTP-Referer") && h.ContainsKey("X-Title"));
+        }
+
+        [Fact]
+        public async Task GetModelsAsync_FullMetadata_PopulatesCapabilitiesAndTokenLimits()
+        {
+            // Arrange — a rich model entry + a bare minimal one
+            _modelsJson = """
+            {
+                "data": [
+                    {
+                        "id": "anthropic/claude-3.5-sonnet",
+                        "name": "Anthropic: Claude 3.5 Sonnet",
+                        "context_length": 200000,
+                        "architecture": {
+                            "input_modalities": ["text", "image"],
+                            "output_modalities": ["text"],
+                            "tokenizer": "Claude"
+                        },
+                        "pricing": { "prompt": "0.000003", "completion": "0.000015" },
+                        "top_provider": { "max_completion_tokens": 8192, "context_length": 200000 },
+                        "supported_parameters": ["tools", "response_format", "reasoning"]
+                    },
+                    { "id": "minimal/model" }
+                ]
+            }
+            """;
+            var client = CreateClient();
+
+            // Act
+            var models = await client.GetModelsAsync();
+
+            // Assert
+            models.Should().HaveCount(2);
+
+            var claude = models.First(m => m.Id == "anthropic/claude-3.5-sonnet");
+            claude.Name.Should().Be("Anthropic: Claude 3.5 Sonnet");
+            claude.Capabilities.Should().NotBeNull();
+            claude.Capabilities!.Vision.Should().BeTrue();          // image input modality
+            claude.Capabilities.FunctionCalling.Should().BeTrue();  // supported_parameters contains "tools"
+            claude.Capabilities.ToolUsage.Should().BeTrue();
+            claude.Capabilities.JsonMode.Should().BeTrue();         // supported_parameters contains "response_format"
+            claude.Capabilities.ImageGeneration.Should().BeFalse(); // no image output modality
+            claude.TokenLimits.Should().NotBeNull();
+            claude.TokenLimits!.Context.Should().Be(200000);
+            claude.TokenLimits.Output.Should().Be(8192);
+        }
+
+        [Fact]
+        public async Task GetModelsAsync_MinimalModel_StillParses()
+        {
+            // Arrange — only the required id field present (schema-drift tolerance)
+            _modelsJson = "{\"data\":[{\"id\":\"minimal/model\"}]}";
+            var client = CreateClient();
+
+            // Act
+            var models = await client.GetModelsAsync();
+
+            // Assert
+            models.Should().ContainSingle();
+            var model = models[0];
+            model.Id.Should().Be("minimal/model");
+            model.Capabilities.Should().NotBeNull();      // chat defaults still applied
+            model.Capabilities!.Chat.Should().BeTrue();
+            model.TokenLimits.Should().BeNull();          // no context/limits reported
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.Json;
 
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
@@ -35,6 +36,9 @@ namespace ConduitLLM.Tests.Providers
         private string _videoStatusJson = "{\"status\":\"completed\",\"unsigned_urls\":[\"https://openrouter.ai/videos/vid_1.mp4\"]}";
         private string _transcriptionJson = "{\"text\":\"hello\"}";
         private string _rerankJson = "{\"results\":[]}";
+        private const string ChatJson = "{\"id\":\"c\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"openai/gpt-4o\"," +
+            "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":\"stop\"}]," +
+            "\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
 
         public OpenRouterClientTests(ITestOutputHelper output) : base(output)
         {
@@ -68,7 +72,8 @@ namespace ConduitLLM.Tests.Providers
                     }
 
                     string responseBody;
-                    if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
+                    if (path.EndsWith("/chat/completions")) responseBody = ChatJson;
+                    else if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
                     else if (path.EndsWith("/images")) responseBody = _imagesJson;
                     else if (path.EndsWith("/audio/transcriptions")) responseBody = _transcriptionJson;
                     else if (path.EndsWith("/rerank")) responseBody = _rerankJson;
@@ -83,12 +88,12 @@ namespace ConduitLLM.Tests.Providers
                 });
         }
 
-        private OpenRouterClient CreateClient()
+        private OpenRouterClient CreateClient(string? providerOptionsJson = null)
         {
             var provider = new Provider { Id = 1, ProviderType = ProviderType.OpenRouter };
             var keyCredential = new ProviderKeyCredential { Id = 1, ProviderId = 1, ApiKey = "test-api-key" };
             var logger = CreateLogger<OpenRouterClient>();
-            return new OpenRouterClient(provider, keyCredential, "openai/gpt-4o", logger.Object, _httpClientFactoryMock.Object);
+            return new OpenRouterClient(provider, keyCredential, "openai/gpt-4o", logger.Object, _httpClientFactoryMock.Object, null, providerOptionsJson);
         }
 
         [Fact]
@@ -338,6 +343,69 @@ namespace ConduitLLM.Tests.Providers
             result.Results[0].Index.Should().Be(1);
             result.Results[0].RelevanceScore.Should().Be(0.9);
             result.Usage!.SearchUnits.Should().Be(1); // ceil(2 / 100)
+        }
+
+        [Fact]
+        public async Task CreateChatCompletionAsync_WithMappingOptions_MergesIntoRequest()
+        {
+            // Arrange — per-mapping routing options configured on the client
+            var client = CreateClient(providerOptionsJson: "{\"provider\":{\"order\":[\"anthropic\"]},\"transforms\":[\"middle-out\"]}");
+            var request = new ChatCompletionRequest
+            {
+                Model = "openai/gpt-4o",
+                Messages = new List<Message> { new() { Role = "user", Content = "hi" } }
+            };
+
+            // Act
+            await client.CreateChatCompletionAsync(request);
+
+            // Assert — the mapping options were merged into the outgoing request body
+            var body = _capturedRequests.Single(r => r.Path.EndsWith("/chat/completions")).Body;
+            body.Should().Contain("\"provider\"");
+            body.Should().Contain("\"order\"");
+            body.Should().Contain("\"transforms\"");
+        }
+
+        [Fact]
+        public async Task CreateChatCompletionAsync_CallerExtensionData_WinsOverMappingOptions()
+        {
+            // Arrange — mapping sets provider.sort=price; caller sends its own provider object
+            var client = CreateClient(providerOptionsJson: "{\"provider\":{\"sort\":\"price\"}}");
+            var request = new ChatCompletionRequest
+            {
+                Model = "openai/gpt-4o",
+                Messages = new List<Message> { new() { Role = "user", Content = "hi" } },
+                ExtensionData = new Dictionary<string, JsonElement>
+                {
+                    ["provider"] = JsonDocument.Parse("{\"sort\":\"throughput\"}").RootElement
+                }
+            };
+
+            // Act
+            await client.CreateChatCompletionAsync(request);
+
+            // Assert — the caller's provider object wins (whole-key precedence)
+            var body = _capturedRequests.Single(r => r.Path.EndsWith("/chat/completions")).Body;
+            body.Should().Contain("throughput");
+            body.Should().NotContain("price");
+        }
+
+        [Fact]
+        public async Task CreateChatCompletionAsync_MalformedMappingOptions_IgnoredAndRequestSucceeds()
+        {
+            // Arrange — invalid JSON must not break the request
+            var client = CreateClient(providerOptionsJson: "not valid json");
+            var request = new ChatCompletionRequest
+            {
+                Model = "openai/gpt-4o",
+                Messages = new List<Message> { new() { Role = "user", Content = "hi" } }
+            };
+
+            // Act
+            var response = await client.CreateChatCompletionAsync(request);
+
+            // Assert
+            response.Should().NotBeNull();
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -29,6 +29,8 @@ namespace ConduitLLM.Tests.Providers
         private readonly List<(string Method, string Path, string Body)> _capturedRequests = new();
         private string _modelsJson = "{\"data\":[]}";
         private string _imagesJson = "{\"created\":0,\"data\":[]}";
+        private string _videoSubmitJson = "{\"id\":\"vid_1\"}";
+        private string _videoStatusJson = "{\"status\":\"completed\",\"unsigned_urls\":[\"https://openrouter.ai/videos/vid_1.mp4\"]}";
 
         public OpenRouterClientTests(ITestOutputHelper output) : base(output)
         {
@@ -56,6 +58,8 @@ namespace ConduitLLM.Tests.Providers
                     string responseBody;
                     if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
                     else if (path.EndsWith("/images")) responseBody = _imagesJson;
+                    else if (path.Contains("/videos/")) responseBody = _videoStatusJson;  // GET status
+                    else if (path.EndsWith("/videos")) responseBody = _videoSubmitJson;    // POST submit
                     else responseBody = _modelsJson;
 
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
@@ -208,6 +212,53 @@ namespace ConduitLLM.Tests.Providers
             result.Usage!.ProviderReportedCostUsd.Should().Be(0.003m);
             result.Usage.ImageCount.Should().Be(1);
             result.Usage.ImageResolution.Should().Be("1024x1024");
+        }
+
+        [Fact]
+        public async Task CreateVideoAsync_SubmitsThenPolls_ReturnsUnsignedUrlAndCost()
+        {
+            // Arrange — job completes on first poll with an unsigned URL + cost
+            _videoStatusJson = "{\"status\":\"completed\",\"unsigned_urls\":[\"https://openrouter.ai/videos/out.mp4\"],\"usage\":{\"cost\":0.5,\"is_byok\":false}}";
+            var client = CreateClient();
+            var request = new VideoGenerationRequest { Prompt = "a dog running", Model = "some/video-model", Duration = 5 };
+
+            // Act
+            var result = await client.CreateVideoAsync(request);
+
+            // Assert
+            result.Data.Should().ContainSingle();
+            result.Data[0].Url.Should().Be("https://openrouter.ai/videos/out.mp4");
+            result.Data[0].Metadata!.Format.Should().Be("mp4");
+            result.Usage.Should().NotBeNull();
+            result.Usage!.EstimatedCost.Should().Be(0.5m);
+            result.Usage.VideosGenerated.Should().Be(1);
+            result.Usage.TotalDurationSeconds.Should().Be(5);
+        }
+
+        [Fact]
+        public async Task CreateVideoAsync_FailedJob_ThrowsLLMCommunicationException()
+        {
+            // Arrange
+            _videoStatusJson = "{\"status\":\"failed\"}";
+            var client = CreateClient();
+            var request = new VideoGenerationRequest { Prompt = "a dog running", Model = "some/video-model", Duration = 5 };
+
+            // Act
+            var act = () => client.CreateVideoAsync(request);
+
+            // Assert
+            await act.Should().ThrowAsync<ConduitLLM.Core.Exceptions.LLMCommunicationException>();
+        }
+
+        [Fact]
+        public void CreateVideoAsync_SignatureMatchesOrchestratorReflectionContract()
+        {
+            // The video orchestrator discovers video support by looking for a 3-parameter
+            // method named "CreateVideoAsync"; guard that contract.
+            var hasContract = typeof(OpenRouterClient).GetMethods()
+                .Any(m => m.Name == "CreateVideoAsync" && m.GetParameters().Length == 3);
+
+            hasContract.Should().BeTrue();
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -5,6 +5,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Models.Audio;
+using ConduitLLM.Core.Models.Rerank;
 using ConduitLLM.Providers.OpenRouter;
 
 using FluentAssertions;
@@ -33,6 +34,7 @@ namespace ConduitLLM.Tests.Providers
         private string _videoSubmitJson = "{\"id\":\"vid_1\"}";
         private string _videoStatusJson = "{\"status\":\"completed\",\"unsigned_urls\":[\"https://openrouter.ai/videos/vid_1.mp4\"]}";
         private string _transcriptionJson = "{\"text\":\"hello\"}";
+        private string _rerankJson = "{\"results\":[]}";
 
         public OpenRouterClientTests(ITestOutputHelper output) : base(output)
         {
@@ -69,6 +71,7 @@ namespace ConduitLLM.Tests.Providers
                     if (path.EndsWith("/key")) responseBody = "{\"data\":{}}";
                     else if (path.EndsWith("/images")) responseBody = _imagesJson;
                     else if (path.EndsWith("/audio/transcriptions")) responseBody = _transcriptionJson;
+                    else if (path.EndsWith("/rerank")) responseBody = _rerankJson;
                     else if (path.Contains("/videos/")) responseBody = _videoStatusJson;  // GET status
                     else if (path.EndsWith("/videos")) responseBody = _videoSubmitJson;    // POST submit
                     else responseBody = _modelsJson;
@@ -311,6 +314,30 @@ namespace ConduitLLM.Tests.Providers
             result.AudioData.Should().NotBeEmpty();
             result.ContentType.Should().Contain("audio");
             result.Usage!.TtsCharacters.Should().Be(5); // "hello".Length
+        }
+
+        [Fact]
+        public async Task CreateRerankAsync_PostsToRerankEndpoint_MapsResultsAndSynthesizesSearchUnits()
+        {
+            // Arrange — provider returns ranked results but no usage; the client synthesizes search units
+            _rerankJson = "{\"model\":\"cohere/rerank-v3.5\",\"results\":[{\"index\":1,\"relevance_score\":0.9},{\"index\":0,\"relevance_score\":0.4}]}";
+            var client = CreateClient();
+            var request = new RerankRequest
+            {
+                Model = "cohere/rerank-v3.5",
+                Query = "best language model",
+                Documents = new List<string> { "doc a", "doc b" }
+            };
+
+            // Act
+            var result = await client.CreateRerankAsync(request);
+
+            // Assert
+            _capturedRequests.Single(r => r.Method == "POST").Path.Should().EndWith("/rerank");
+            result.Results.Should().HaveCount(2);
+            result.Results[0].Index.Should().Be(1);
+            result.Results[0].RelevanceScore.Should().Be(0.9);
+            result.Usage!.SearchUnits.Should().Be(1); // ceil(2 / 100)
         }
     }
 }

--- a/WebAdmin/src/app/provider-sync/components/DriftDiffView.tsx
+++ b/WebAdmin/src/app/provider-sync/components/DriftDiffView.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Table, Text, Alert, Stack, Badge, Group } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import type { DriftItemDto } from '@knn_labs/conduit-admin-client';
+import {
+  parseDriftPayload,
+  fieldLabel,
+  formatDriftValue,
+  driftWarnings,
+  driftTypeColor,
+  driftTypeLabel,
+} from '../utils/driftHelpers';
+
+interface DriftDiffViewProps {
+  item: DriftItemDto;
+}
+
+/**
+ * Renders a single drift item's current-vs-proposed comparison, with warning banners
+ * for capability drift (shared-flag fan-out) and zero-price proposals.
+ */
+export function DriftDiffView({ item }: DriftDiffViewProps) {
+  const current = parseDriftPayload(item.currentValuesJson);
+  const proposed = parseDriftPayload(item.proposedValuesJson);
+  const warnings = driftWarnings(item);
+
+  // Union of keys across both sides, preserving a stable order.
+  const keys = Array.from(new Set([...Object.keys(current), ...Object.keys(proposed)]));
+
+  return (
+    <Stack gap="md">
+      <Group gap="xs">
+        <Badge color={driftTypeColor(item.driftType)} variant="light">
+          {driftTypeLabel(item.driftType)}
+        </Badge>
+        <Text size="sm" fw={500}>
+          {item.modelAlias}
+        </Text>
+        <Text size="sm" c="dimmed">
+          {item.providerName} · {item.openRouterModelId}
+        </Text>
+      </Group>
+
+      {warnings.map((warning, idx) => (
+        <Alert
+          key={idx}
+          color={warning.color}
+          icon={<IconAlertTriangle size={16} />}
+          variant="light"
+        >
+          {warning.message}
+        </Alert>
+      ))}
+
+      {keys.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No field-level detail for this drift type.
+        </Text>
+      ) : (
+        <Table withTableBorder withColumnBorders>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Field</Table.Th>
+              <Table.Th>Current (Conduit)</Table.Th>
+              <Table.Th>Proposed (OpenRouter)</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {keys.map((key) => {
+              const currentValue = formatDriftValue(current[key]);
+              const proposedValue = formatDriftValue(proposed[key]);
+              const changed = currentValue !== proposedValue;
+              return (
+                <Table.Tr key={key}>
+                  <Table.Td>
+                    <Text size="sm">{fieldLabel(key)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm" c={changed ? 'dimmed' : undefined}>
+                      {currentValue}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm" fw={changed ? 600 : 400} c={changed ? 'teal' : undefined}>
+                      {proposedValue}
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      )}
+    </Stack>
+  );
+}

--- a/WebAdmin/src/app/provider-sync/components/DriftFilters.tsx
+++ b/WebAdmin/src/app/provider-sync/components/DriftFilters.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Group, Select } from '@mantine/core';
+
+interface DriftFiltersProps {
+  status: string | null;
+  driftType: string | null;
+  onStatusChange: (value: string | null) => void;
+  onDriftTypeChange: (value: string | null) => void;
+}
+
+const STATUS_OPTIONS = [
+  { value: 'Pending', label: 'Pending' },
+  { value: 'Applied', label: 'Applied' },
+  { value: 'Dismissed', label: 'Dismissed' },
+  { value: 'AutoResolved', label: 'Auto-resolved' },
+];
+
+const DRIFT_TYPE_OPTIONS = [
+  { value: 'Pricing', label: 'Pricing' },
+  { value: 'MissingCost', label: 'Missing cost' },
+  { value: 'ContextWindow', label: 'Context window' },
+  { value: 'Capabilities', label: 'Capabilities' },
+  { value: 'ModelRemoved', label: 'Model removed' },
+  { value: 'ModelDeprecated', label: 'Model deprecated' },
+];
+
+export function DriftFilters({
+  status,
+  driftType,
+  onStatusChange,
+  onDriftTypeChange,
+}: DriftFiltersProps) {
+  return (
+    <Group gap="sm">
+      <Select
+        label="Status"
+        placeholder="Pending"
+        data={STATUS_OPTIONS}
+        value={status}
+        onChange={onStatusChange}
+        clearable
+        w={180}
+      />
+      <Select
+        label="Drift type"
+        placeholder="All types"
+        data={DRIFT_TYPE_OPTIONS}
+        value={driftType}
+        onChange={onDriftTypeChange}
+        clearable
+        w={200}
+      />
+    </Group>
+  );
+}

--- a/WebAdmin/src/app/provider-sync/components/DriftTable.tsx
+++ b/WebAdmin/src/app/provider-sync/components/DriftTable.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Table,
+  ScrollArea,
+  Checkbox,
+  Badge,
+  Text,
+  Group,
+  Button,
+  ActionIcon,
+  Menu,
+  LoadingOverlay,
+  Center,
+  Stack,
+  Card,
+  Divider,
+  Modal,
+  Box,
+} from '@mantine/core';
+import { IconDots, IconEye, IconCheck, IconX } from '@tabler/icons-react';
+import { modals } from '@mantine/modals';
+import type { DriftItemDto, DriftItemFilter } from '@knn_labs/conduit-admin-client';
+import { formatters } from '@/lib/utils/formatters';
+import {
+  fetchDrift,
+  DRIFT_QUERY_KEY,
+  useApplyDrift,
+  useDismissDrift,
+  useBulkApplyDrift,
+  useBulkDismissDrift,
+} from '../hooks/useProviderSyncApi';
+import {
+  driftTypeColor,
+  driftTypeLabel,
+  driftStatusColor,
+  driftWarnings,
+} from '../utils/driftHelpers';
+import { DriftDiffView } from './DriftDiffView';
+import { DriftFilters } from './DriftFilters';
+
+export function DriftTable() {
+  const [status, setStatus] = useState<string | null>('Pending');
+  const [driftType, setDriftType] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [viewingItem, setViewingItem] = useState<DriftItemDto | null>(null);
+
+  const filter: DriftItemFilter = useMemo(
+    () => ({
+      status: status ?? undefined,
+      driftType: driftType ?? undefined,
+      pageSize: 200,
+    }),
+    [status, driftType]
+  );
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [DRIFT_QUERY_KEY, status, driftType],
+    queryFn: () => fetchDrift(filter),
+  });
+
+  const items = data ?? [];
+
+  const applyMutation = useApplyDrift();
+  const dismissMutation = useDismissDrift();
+  const bulkApplyMutation = useBulkApplyDrift();
+  const bulkDismissMutation = useBulkDismissDrift();
+
+  // Only Pending items are actionable (apply/dismiss).
+  const actionableItems = items.filter((i) => i.status === 'Pending');
+  const allSelected =
+    actionableItems.length > 0 && actionableItems.every((i) => selectedIds.has(i.id));
+  const someSelected = selectedIds.size > 0 && !allSelected;
+  const busy =
+    applyMutation.isPending ||
+    dismissMutation.isPending ||
+    bulkApplyMutation.isPending ||
+    bulkDismissMutation.isPending;
+
+  const toggleOne = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedIds((prev) =>
+      prev.size === actionableItems.length && actionableItems.length > 0
+        ? new Set()
+        : new Set(actionableItems.map((i) => i.id))
+    );
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const deselect = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const applyItem = (item: DriftItemDto) => {
+    const warnings = driftWarnings(item);
+    const run = () =>
+      applyMutation.mutate(item.id, {
+        onSuccess: () => {
+          deselect(item.id);
+          setViewingItem(null);
+        },
+      });
+    if (warnings.length > 0) {
+      modals.openConfirmModal({
+        title: 'Apply drift with warnings',
+        children: (
+          <Stack gap="xs">
+            {warnings.map((w, idx) => (
+              <Text key={idx} size="sm">
+                {w.message}
+              </Text>
+            ))}
+          </Stack>
+        ),
+        labels: { confirm: 'Apply anyway', cancel: 'Cancel' },
+        confirmProps: { color: 'orange' },
+        onConfirm: run,
+      });
+    } else {
+      run();
+    }
+  };
+
+  const dismissItem = (item: DriftItemDto) => {
+    dismissMutation.mutate(item.id, {
+      onSuccess: () => {
+        deselect(item.id);
+        setViewingItem(null);
+      },
+    });
+  };
+
+  const handleBulkApply = () => {
+    const ids = Array.from(selectedIds);
+    const hasWarnings = actionableItems
+      .filter((i) => selectedIds.has(i.id))
+      .some((i) => driftWarnings(i).length > 0);
+    modals.openConfirmModal({
+      title: `Apply ${ids.length} drift item${ids.length > 1 ? 's' : ''}`,
+      children: (
+        <Text size="sm">
+          {hasWarnings
+            ? 'Some selected items carry warnings (zero-price or capability drift). '
+            : ''}
+          Apply the proposed changes for {ids.length} item{ids.length > 1 ? 's' : ''}?
+        </Text>
+      ),
+      labels: { confirm: 'Apply', cancel: 'Cancel' },
+      confirmProps: { color: hasWarnings ? 'orange' : undefined },
+      onConfirm: () => bulkApplyMutation.mutate(ids, { onSuccess: clearSelection }),
+    });
+  };
+
+  const handleBulkDismiss = () => {
+    const ids = Array.from(selectedIds);
+    modals.openConfirmModal({
+      title: `Dismiss ${ids.length} drift item${ids.length > 1 ? 's' : ''}`,
+      children: (
+        <Text size="sm">
+          Dismiss {ids.length} item{ids.length > 1 ? 's' : ''} without applying?
+        </Text>
+      ),
+      labels: { confirm: 'Dismiss', cancel: 'Cancel' },
+      onConfirm: () => bulkDismissMutation.mutate(ids, { onSuccess: clearSelection }),
+    });
+  };
+
+  return (
+    <Card withBorder padding={0}>
+      <Card.Section p="md">
+        <DriftFilters
+          status={status}
+          driftType={driftType}
+          onStatusChange={setStatus}
+          onDriftTypeChange={setDriftType}
+        />
+      </Card.Section>
+
+      {selectedIds.size > 0 && (
+        <Group
+          p="md"
+          style={{
+            backgroundColor: 'var(--mantine-color-blue-light)',
+          }}
+        >
+          <Text fw={500} size="sm">
+            {selectedIds.size} selected
+          </Text>
+          <Divider orientation="vertical" />
+          <Button
+            size="xs"
+            variant="light"
+            color="green"
+            leftSection={<IconCheck size={14} />}
+            onClick={handleBulkApply}
+            loading={bulkApplyMutation.isPending}
+          >
+            Apply selected
+          </Button>
+          <Button
+            size="xs"
+            variant="light"
+            color="gray"
+            leftSection={<IconX size={14} />}
+            onClick={handleBulkDismiss}
+            loading={bulkDismissMutation.isPending}
+          >
+            Dismiss selected
+          </Button>
+          <Button size="xs" variant="subtle" onClick={clearSelection} ml="auto">
+            Clear
+          </Button>
+        </Group>
+      )}
+
+      <Card.Section p="md" pt="sm">
+        <Box pos="relative">
+          <LoadingOverlay visible={isLoading} />
+
+          {error && (
+            <Center py="xl">
+              <Text c="red">Failed to load drift items</Text>
+            </Center>
+          )}
+
+          {!error && items.length === 0 && !isLoading && (
+            <Center py="xl">
+              <Text c="dimmed">No drift items for this filter</Text>
+            </Center>
+          )}
+
+          {!error && items.length > 0 && (
+            <ScrollArea>
+              <Table verticalSpacing="sm">
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th w={40}>
+                      <Checkbox
+                        checked={allSelected}
+                        indeterminate={someSelected}
+                        onChange={toggleAll}
+                        disabled={actionableItems.length === 0}
+                        aria-label="Select all"
+                      />
+                    </Table.Th>
+                    <Table.Th>Model</Table.Th>
+                    <Table.Th>Provider</Table.Th>
+                    <Table.Th>Drift</Table.Th>
+                    <Table.Th>Status</Table.Th>
+                    <Table.Th>First detected</Table.Th>
+                    <Table.Th w={60}></Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {items.map((item) => {
+                    const pending = item.status === 'Pending';
+                    const warnings = driftWarnings(item);
+                    return (
+                      <Table.Tr key={item.id}>
+                        <Table.Td>
+                          <Checkbox
+                            checked={selectedIds.has(item.id)}
+                            onChange={() => toggleOne(item.id)}
+                            disabled={!pending}
+                            aria-label={`Select ${item.modelAlias}`}
+                          />
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm" fw={500}>
+                            {item.modelAlias}
+                          </Text>
+                          <Text size="xs" c="dimmed">
+                            {item.openRouterModelId}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="sm">{item.providerName}</Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Group gap={6}>
+                            <Badge color={driftTypeColor(item.driftType)} variant="light" size="sm">
+                              {driftTypeLabel(item.driftType)}
+                            </Badge>
+                            {warnings.length > 0 && (
+                              <Badge color="red" variant="outline" size="sm">
+                                warning
+                              </Badge>
+                            )}
+                          </Group>
+                        </Table.Td>
+                        <Table.Td>
+                          <Badge color={driftStatusColor(item.status)} variant="light" size="sm">
+                            {item.status}
+                          </Badge>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text size="xs" c="dimmed">
+                            {formatters.date(item.firstDetectedAt)}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Menu position="bottom-end" withinPortal>
+                            <Menu.Target>
+                              <ActionIcon variant="subtle" size="sm">
+                                <IconDots size={16} />
+                              </ActionIcon>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                              <Menu.Item
+                                leftSection={<IconEye size={14} />}
+                                onClick={() => setViewingItem(item)}
+                              >
+                                View details
+                              </Menu.Item>
+                              {pending && (
+                                <>
+                                  <Menu.Divider />
+                                  <Menu.Item
+                                    leftSection={<IconCheck size={14} />}
+                                    color="green"
+                                    disabled={busy}
+                                    onClick={() => applyItem(item)}
+                                  >
+                                    Apply
+                                  </Menu.Item>
+                                  <Menu.Item
+                                    leftSection={<IconX size={14} />}
+                                    disabled={busy}
+                                    onClick={() => dismissItem(item)}
+                                  >
+                                    Dismiss
+                                  </Menu.Item>
+                                </>
+                              )}
+                            </Menu.Dropdown>
+                          </Menu>
+                        </Table.Td>
+                      </Table.Tr>
+                    );
+                  })}
+                </Table.Tbody>
+              </Table>
+            </ScrollArea>
+          )}
+        </Box>
+      </Card.Section>
+
+      <Modal
+        opened={viewingItem !== null}
+        onClose={() => setViewingItem(null)}
+        title="Drift details"
+        size="lg"
+      >
+        {viewingItem && (
+          <Stack gap="lg">
+            <DriftDiffView item={viewingItem} />
+            {viewingItem.status === 'Pending' && (
+              <Group justify="flex-end">
+                <Button
+                  variant="light"
+                  color="gray"
+                  leftSection={<IconX size={16} />}
+                  onClick={() => dismissItem(viewingItem)}
+                  loading={dismissMutation.isPending}
+                >
+                  Dismiss
+                </Button>
+                <Button
+                  color="green"
+                  leftSection={<IconCheck size={16} />}
+                  onClick={() => applyItem(viewingItem)}
+                  loading={applyMutation.isPending}
+                >
+                  Apply
+                </Button>
+              </Group>
+            )}
+          </Stack>
+        )}
+      </Modal>
+    </Card>
+  );
+}

--- a/WebAdmin/src/app/provider-sync/components/SyncRunsPanel.tsx
+++ b/WebAdmin/src/app/provider-sync/components/SyncRunsPanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  Table,
+  ScrollArea,
+  Badge,
+  Text,
+  LoadingOverlay,
+  Center,
+  Card,
+  Box,
+  Tooltip,
+} from '@mantine/core';
+import { formatters } from '@/lib/utils/formatters';
+import { fetchSyncRuns, RUNS_QUERY_KEY } from '../hooks/useProviderSyncApi';
+
+function runStatusColor(status: string): string {
+  switch (status) {
+    case 'Completed':
+      return 'green';
+    case 'Running':
+      return 'blue';
+    case 'Failed':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}
+
+export function SyncRunsPanel() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [RUNS_QUERY_KEY],
+    queryFn: () => fetchSyncRuns(1, 25),
+  });
+
+  const runs = data ?? [];
+
+  return (
+    <Card withBorder padding={0}>
+      <Card.Section p="md">
+        <Box pos="relative">
+          <LoadingOverlay visible={isLoading} />
+
+          {error && (
+            <Center py="xl">
+              <Text c="red">Failed to load sync runs</Text>
+            </Center>
+          )}
+
+          {!error && runs.length === 0 && !isLoading && (
+            <Center py="xl">
+              <Text c="dimmed">No sync runs yet</Text>
+            </Center>
+          )}
+
+          {!error && runs.length > 0 && (
+            <ScrollArea>
+              <Table verticalSpacing="sm">
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Started</Table.Th>
+                    <Table.Th>Status</Table.Th>
+                    <Table.Th>Trigger</Table.Th>
+                    <Table.Th>Models</Table.Th>
+                    <Table.Th>Mappings</Table.Th>
+                    <Table.Th>New</Table.Th>
+                    <Table.Th>Updated</Table.Th>
+                    <Table.Th>Auto-resolved</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {runs.map((run) => (
+                    <Table.Tr key={run.id}>
+                      <Table.Td>
+                        <Text size="xs">{formatters.date(run.startedAt)}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        {run.errorMessage ? (
+                          <Tooltip label={run.errorMessage} multiline maw={320}>
+                            <Badge color={runStatusColor(run.status)} variant="light" size="sm">
+                              {run.status}
+                            </Badge>
+                          </Tooltip>
+                        ) : (
+                          <Badge color={runStatusColor(run.status)} variant="light" size="sm">
+                            {run.status}
+                          </Badge>
+                        )}
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.triggeredBy}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.modelsFetched}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.mappingsChecked}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.itemsCreated}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.itemsUpdated}</Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Text size="sm">{run.itemsAutoResolved}</Text>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </ScrollArea>
+          )}
+        </Box>
+      </Card.Section>
+    </Card>
+  );
+}

--- a/WebAdmin/src/app/provider-sync/hooks/useProviderSyncApi.ts
+++ b/WebAdmin/src/app/provider-sync/hooks/useProviderSyncApi.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { withAdminClient } from '@/lib/client/adminClient';
+import { useAdminMutation } from '@/hooks/useAdminMutation';
+import type {
+  DriftItemDto,
+  DriftItemFilter,
+  DriftActionResultDto,
+  BulkDriftActionResponse,
+  ProviderSyncRunDto,
+} from '@knn_labs/conduit-admin-client';
+
+export const DRIFT_QUERY_KEY = 'provider-sync-drift';
+export const RUNS_QUERY_KEY = 'provider-sync-runs';
+
+/**
+ * Fetch drift items (defaults to Pending on the server), optionally filtered.
+ * Standalone async function for use inside useQuery.
+ */
+export async function fetchDrift(filter?: DriftItemFilter): Promise<DriftItemDto[]> {
+  return withAdminClient((client) => client.providerSync.listDrift(filter));
+}
+
+/**
+ * Fetch recent sync runs for the history panel.
+ */
+export async function fetchSyncRuns(page = 1, pageSize = 25): Promise<ProviderSyncRunDto[]> {
+  return withAdminClient((client) => client.providerSync.listRuns(page, pageSize));
+}
+
+// --- Mutation hooks using useAdminMutation ---
+
+function applyResultMessage(result: DriftActionResultDto): string {
+  if (result.success) return 'Drift applied';
+  if (result.stale) return 'Skipped: values changed since detection — re-run sync';
+  return `Not applied: ${result.error ?? 'unknown error'}`;
+}
+
+export function useApplyDrift() {
+  return useAdminMutation<DriftActionResultDto, number>({
+    mutationFn: (id) => (client) => client.providerSync.apply(id),
+    successMessage: applyResultMessage,
+    invalidateKeys: [DRIFT_QUERY_KEY],
+  });
+}
+
+export function useDismissDrift() {
+  return useAdminMutation<DriftActionResultDto, number>({
+    mutationFn: (id) => (client) => client.providerSync.dismiss(id),
+    successMessage: 'Drift item dismissed',
+    invalidateKeys: [DRIFT_QUERY_KEY],
+  });
+}
+
+export function useBulkApplyDrift() {
+  return useAdminMutation<BulkDriftActionResponse, number[]>({
+    mutationFn: (ids) => (client) => client.providerSync.applyBulk(ids),
+    successMessage: (result) =>
+      `Applied ${result.succeededCount}${result.failedCount > 0 ? `, ${result.failedCount} skipped/failed` : ''}`,
+    invalidateKeys: [DRIFT_QUERY_KEY],
+  });
+}
+
+export function useBulkDismissDrift() {
+  return useAdminMutation<BulkDriftActionResponse, number[]>({
+    mutationFn: (ids) => (client) => client.providerSync.dismissBulk(ids),
+    successMessage: (result) =>
+      `Dismissed ${result.succeededCount}${result.failedCount > 0 ? `, ${result.failedCount} failed` : ''}`,
+    invalidateKeys: [DRIFT_QUERY_KEY],
+  });
+}
+
+export function useRunSync() {
+  return useAdminMutation<ProviderSyncRunDto, void>({
+    mutationFn: () => (client) => client.providerSync.run(),
+    successMessage: (run) =>
+      `Sync ${run.status.toLowerCase()}: ${run.itemsCreated} new, ${run.itemsUpdated} updated, ${run.itemsAutoResolved} auto-resolved`,
+    invalidateKeys: [DRIFT_QUERY_KEY, RUNS_QUERY_KEY],
+  });
+}

--- a/WebAdmin/src/app/provider-sync/page.tsx
+++ b/WebAdmin/src/app/provider-sync/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Container, Title, Text, Button, Group, Stack, Tabs } from '@mantine/core';
+import { IconRefresh, IconGitCompare, IconHistory } from '@tabler/icons-react';
+import { DriftTable } from './components/DriftTable';
+import { SyncRunsPanel } from './components/SyncRunsPanel';
+import { useRunSync } from './hooks/useProviderSyncApi';
+
+export default function ProviderSyncPage() {
+  const [activeTab, setActiveTab] = useState<string | null>('drift');
+  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set(['drift']));
+  const runSync = useRunSync();
+
+  const handleTabChange = useCallback((value: string | null) => {
+    setActiveTab(value);
+    if (value) {
+      setVisitedTabs((prev) => {
+        if (prev.has(value)) return prev;
+        const next = new Set(prev);
+        next.add(value);
+        return next;
+      });
+    }
+  }, []);
+
+  return (
+    <Container size="xl">
+      <Stack gap="md">
+        <Group justify="space-between">
+          <div>
+            <Title order={2}>Provider Sync</Title>
+            <Text c="dimmed" size="sm">
+              Review pricing, context-window, and capability drift detected against OpenRouter&apos;s
+              published catalog, then apply or dismiss each change.
+            </Text>
+          </div>
+          <Button
+            leftSection={<IconRefresh size={16} />}
+            onClick={() => runSync.mutate()}
+            loading={runSync.isPending}
+          >
+            Run sync now
+          </Button>
+        </Group>
+
+        <Tabs value={activeTab} onChange={handleTabChange}>
+          <Tabs.List>
+            <Tabs.Tab value="drift" leftSection={<IconGitCompare size={16} />}>
+              Drift Review
+            </Tabs.Tab>
+            <Tabs.Tab value="runs" leftSection={<IconHistory size={16} />}>
+              Sync Runs
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="drift" pt="md">
+            <DriftTable />
+          </Tabs.Panel>
+
+          <Tabs.Panel value="runs" pt="md">
+            {visitedTabs.has('runs') && <SyncRunsPanel />}
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Container>
+  );
+}

--- a/WebAdmin/src/app/provider-sync/utils/driftHelpers.ts
+++ b/WebAdmin/src/app/provider-sync/utils/driftHelpers.ts
@@ -1,0 +1,136 @@
+import type { DriftItemDto } from '@knn_labs/conduit-admin-client';
+
+/** Mantine color for each drift type badge. */
+export function driftTypeColor(driftType: string): string {
+  switch (driftType) {
+    case 'Pricing':
+      return 'blue';
+    case 'MissingCost':
+      return 'orange';
+    case 'ContextWindow':
+      return 'cyan';
+    case 'Capabilities':
+      return 'grape';
+    case 'ModelRemoved':
+      return 'red';
+    case 'ModelDeprecated':
+      return 'yellow';
+    default:
+      return 'gray';
+  }
+}
+
+/** Human-readable label for a drift type. */
+export function driftTypeLabel(driftType: string): string {
+  switch (driftType) {
+    case 'MissingCost':
+      return 'Missing cost';
+    case 'ContextWindow':
+      return 'Context window';
+    case 'ModelRemoved':
+      return 'Model removed';
+    case 'ModelDeprecated':
+      return 'Model deprecated';
+    default:
+      return driftType;
+  }
+}
+
+/** Mantine color for each drift status badge. */
+export function driftStatusColor(status: string): string {
+  switch (status) {
+    case 'Pending':
+      return 'blue';
+    case 'Applied':
+      return 'green';
+    case 'Dismissed':
+      return 'gray';
+    case 'AutoResolved':
+      return 'teal';
+    default:
+      return 'gray';
+  }
+}
+
+/** Friendly labels for the known drift payload fields; falls back to a de-camelCased key. */
+const FIELD_LABELS: Record<string, string> = {
+  inputPerMillion: 'Input ($/M tokens)',
+  outputPerMillion: 'Output ($/M tokens)',
+  cachedInputPerMillion: 'Cached input ($/M)',
+  cachedWritePerMillion: 'Cache write ($/M)',
+  maxInputTokens: 'Max input tokens',
+  maxOutputTokens: 'Max output tokens',
+  supportsVision: 'Vision',
+  supportsFunctionCalling: 'Function calling',
+  supportsImageGeneration: 'Image generation',
+};
+
+export function fieldLabel(key: string): string {
+  if (FIELD_LABELS[key]) return FIELD_LABELS[key];
+  // De-camelCase fallback: "someKey" -> "Some key"
+  const spaced = key.replace(/([A-Z])/g, ' $1').trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/** Render a payload value for display (booleans as Yes/No, null as an em dash). */
+export function formatDriftValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'string') return value;
+  // Objects/arrays — render as compact JSON rather than "[object Object]".
+  return JSON.stringify(value);
+}
+
+/** Safely parse a drift payload JSON string into a keyed record. */
+export function parseDriftPayload(json: string | null | undefined): Record<string, unknown> {
+  if (!json) return {};
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+export interface DriftWarning {
+  color: string;
+  message: string;
+}
+
+/**
+ * Compute review warnings for a drift item. Capability drift mutates shared model flags,
+ * and zero-price proposals will zero out billing — both deserve an explicit admin warning.
+ */
+export function driftWarnings(item: DriftItemDto): DriftWarning[] {
+  const warnings: DriftWarning[] = [];
+
+  if (item.driftType === 'Capabilities') {
+    warnings.push({
+      color: 'orange',
+      message:
+        'Applying writes shared model capability flags — this affects every provider whose mappings route this model, not just this one.',
+    });
+  }
+
+  if (item.driftType === 'Pricing' || item.driftType === 'MissingCost') {
+    const proposed = parseDriftPayload(item.proposedValuesJson);
+    const priceFields = ['inputPerMillion', 'outputPerMillion'];
+    const hasZeroPrice = priceFields.some((f) => {
+      const v = proposed[f];
+      return typeof v === 'number' && v === 0;
+    });
+    if (hasZeroPrice) {
+      warnings.push({
+        color: 'red',
+        message:
+          'Proposed pricing is $0 (a free variant). Applying will zero out billing for this model — confirm this is intended.',
+      });
+    }
+  }
+
+  return warnings;
+}

--- a/WebAdmin/src/components/modelmappings/EditModelMappingModalWithHooks.tsx
+++ b/WebAdmin/src/components/modelmappings/EditModelMappingModalWithHooks.tsx
@@ -9,12 +9,13 @@ import {
   NumberInput,
   Button,
   Select,
+  JsonInput,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useEffect, useState, useCallback } from 'react';
 import { useUpdateModelMapping, useModelMappings } from '@/hooks/useModelMappingsApi';
 import { useProviders } from '@/hooks/useProviderApi';
-import type { ProviderDto, ModelProviderMappingDto, UpdateModelProviderMappingDto } from '@knn_labs/conduit-admin-client';
+import { ProviderType, type ProviderDto, type ModelProviderMappingDto, type UpdateModelProviderMappingDto } from '@knn_labs/conduit-admin-client';
 import { getProviderTypeFromDto, getProviderDisplayName } from '@/lib/utils/providerTypeUtils';
 
 interface EditModelMappingModalProps {
@@ -32,6 +33,7 @@ interface FormValues {
   priority: number;
   isEnabled: boolean;
   notes?: string;
+  providerOptions?: string;
 }
 
 export function EditModelMappingModal({
@@ -52,6 +54,7 @@ export function EditModelMappingModal({
     priority: 100,
     isEnabled: true,
     notes: undefined,
+    providerOptions: undefined,
   }));
 
   const form = useForm<FormValues>({
@@ -97,6 +100,7 @@ export function EditModelMappingModal({
         priority: mapping.priority ?? 100,
         isEnabled: mapping.isEnabled,
         notes: mapping.notes,
+        providerOptions: mapping.providerOptions,
       };
       
       updateForm(newFormValues);
@@ -119,6 +123,7 @@ export function EditModelMappingModal({
       priority: values.priority,
       isEnabled: values.isEnabled,
       notes: values.notes,
+      providerOptions: values.providerOptions?.trim() ? values.providerOptions : undefined,
     };
 
     try {
@@ -148,6 +153,16 @@ export function EditModelMappingModal({
       };
     }
   }).filter(opt => opt.value !== '') || [];
+
+  const selectedProvider = providers?.find((p: ProviderDto) => p.id?.toString() === form.values.providerId);
+  let isOpenRouter = false;
+  if (selectedProvider) {
+    try {
+      isOpenRouter = getProviderTypeFromDto(selectedProvider) === ProviderType.OpenRouter;
+    } catch {
+      isOpenRouter = false;
+    }
+  }
 
   return (
     <Modal
@@ -203,6 +218,19 @@ export function EditModelMappingModal({
             description="Additional notes about this mapping"
             {...form.getInputProps('notes')}
           />
+
+          {isOpenRouter && (
+            <JsonInput
+              label="Provider request options (JSON)"
+              placeholder='{"provider": {"order": ["anthropic"]}, "plugins": [...]}'
+              description="OpenRouter routing options merged into every request for this mapping (provider, plugins, transforms, models, route). Must be a JSON object; model/messages/stream are not allowed."
+              validationError="Invalid JSON"
+              formatOnBlur
+              autosize
+              minRows={3}
+              {...form.getInputProps('providerOptions')}
+            />
+          )}
 
           <Group justify="flex-end" mt="md">
             <Button variant="subtle" onClick={handleClose}>

--- a/WebAdmin/src/components/providers/ProviderForm.tsx
+++ b/WebAdmin/src/components/providers/ProviderForm.tsx
@@ -18,6 +18,7 @@ import {
   LoadingOverlay,
   ThemeIcon,
   Switch,
+  NumberInput,
 } from '@mantine/core';
 import { IconAlertCircle, IconInfoCircle, IconCircleCheck, IconArrowLeft, IconServer, IconSparkles, IconEdit } from '@tabler/icons-react';
 import { 
@@ -225,6 +226,25 @@ export function ProviderForm({ mode, providerId }: ProviderFormProps) {
                     {...form.getInputProps('isEnabled', { type: 'checkbox' })}
                     size="md"
                   />
+
+                  <Switch
+                    label="Trust provider-reported cost"
+                    description="Bill from the cost this provider reports per request (e.g. OpenRouter usage.cost) instead of the configured ModelCost. Falls back to ModelCost when no cost is reported."
+                    {...form.getInputProps('trustProviderReportedCosts', { type: 'checkbox' })}
+                    size="md"
+                  />
+
+                  {form.values.trustProviderReportedCosts && (
+                    <NumberInput
+                      label="Cost markup multiplier"
+                      description="Multiplier applied to the provider-reported cost when billing (1.0 = pass-through)."
+                      min={0}
+                      step={0.05}
+                      decimalScale={4}
+                      {...form.getInputProps('providerCostMarkupMultiplier')}
+                      size="md"
+                    />
+                  )}
                 </Stack>
               </Card>
 

--- a/WebAdmin/src/components/providers/ProviderFormHandlers.ts
+++ b/WebAdmin/src/components/providers/ProviderFormHandlers.ts
@@ -36,6 +36,8 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
           providerName: providerName,
           baseUrl: values.apiEndpoint ?? undefined,
           isEnabled: values.isEnabled,
+          trustProviderReportedCosts: values.trustProviderReportedCosts,
+          providerCostMarkupMultiplier: values.providerCostMarkupMultiplier,
         };
 
         const createdProvider = await withAdminClient(client => 
@@ -71,6 +73,8 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
           baseUrl: values.apiEndpoint ?? undefined,
           organization: values.organizationId ?? undefined,
           isEnabled: values.isEnabled,
+          trustProviderReportedCosts: values.trustProviderReportedCosts,
+          providerCostMarkupMultiplier: values.providerCostMarkupMultiplier,
         };
 
         await withAdminClient(client => 

--- a/WebAdmin/src/components/providers/ProviderFormLogic.ts
+++ b/WebAdmin/src/components/providers/ProviderFormLogic.ts
@@ -16,6 +16,8 @@ export interface ProviderFormData {
   apiEndpoint?: string;
   organizationId?: string;
   isEnabled: boolean;
+  trustProviderReportedCosts: boolean;
+  providerCostMarkupMultiplier: number;
 }
 
 export interface ProviderOption {
@@ -64,6 +66,8 @@ export function useProviderFormLogic(
     apiEndpoint: '',
     organizationId: '',
     isEnabled: true,
+    trustProviderReportedCosts: false,
+    providerCostMarkupMultiplier: 1,
   }));
 
   const form = useForm<ProviderFormData>({
@@ -138,9 +142,11 @@ export function useProviderFormLogic(
             providerName: typeof apiProvider.providerName === 'string' ? apiProvider.providerName : '',
             apiKey: '', // Don't show existing key for security
             apiEndpoint: apiProvider.baseUrl ?? '',
-            organizationId: (provider as { organization?: string; organizationId?: string }).organization ?? 
+            organizationId: (provider as { organization?: string; organizationId?: string }).organization ??
                           (provider as { organization?: string; organizationId?: string }).organizationId ?? '',
             isEnabled: provider.isEnabled === true,
+            trustProviderReportedCosts: provider.trustProviderReportedCosts === true,
+            providerCostMarkupMultiplier: provider.providerCostMarkupMultiplier ?? 1,
           };
           
           // Update initial values - form will reinitialize via key prop

--- a/WebAdmin/src/lib/navigation/items.ts
+++ b/WebAdmin/src/lib/navigation/items.ts
@@ -14,6 +14,7 @@ import {
   IconBrain,
   IconAlertCircle,
   IconListDetails,
+  IconRefresh,
 } from '@tabler/icons-react';
 import { NavigationSection } from '@/types/navigation';
 
@@ -88,6 +89,14 @@ export const navigationSections: NavigationSection[] = [
         href: '/model-mappings',
         description: 'Configure model provider mappings',
         color: 'indigo',
+      },
+      {
+        id: 'provider-sync',
+        label: 'Provider Sync',
+        icon: IconRefresh,
+        href: '/provider-sync',
+        description: 'Review and apply OpenRouter metadata drift',
+        color: 'teal',
       },
       {
         id: 'ip-filtering',


### PR DESCRIPTION
## OpenRouter modernization

The OpenRouter provider was written when OpenRouter was a chat-only OpenAI-compatible multiplexer. It's now a full platform, and our abstraction had drifted badly. This branch modernizes the integration and, where the fix belongs at the abstraction layer, upgrades the shared OpenAI-compatible path so **every** provider benefits.

Delivered as 14 dependency-ordered commits on a single branch (per the agreed plan). Each commit builds and tests green on its own.

### What was broken
- **Billing left money on the table.** OpenRouter returns `usage.cost` (the exact credits charged) on every response; we ignored it and always recomputed from manually-maintained `ModelCost` rows. A missing/stale row billed at **$0 (free)**.
- `GetModelsAsync` threw away all `/models` metadata (pricing, context length, modalities, `supported_parameters`).
- No `HTTP-Referer` / `X-Title` attribution headers anywhere.
- **Latent bug:** inherited `CreateImageAsync` posted to `/images/generations`, which doesn't exist on OpenRouter → silent 404.
- Structured outputs (`json_schema`) were impossible for all OpenAI-compatible providers.
- Reasoning config / provider routing / plugins were reachable only through the untyped `ExtensionData` escape hatch.
- Whole modalities missing: image gen broken, and video / STT / TTS / rerank had no client surface.
- **Streaming leaked** the provider `cost` field to virtual-key holders.

### Key decisions (confirmed before implementation)
1. **Provider `usage.cost` is authoritative for billing**, with a configurable per-provider **markup multiplier**, falling back to `ModelCost` math when no cost is reported. Opt-in per provider (`TrustProviderReportedCosts`, default off) → zero behavior change until enabled.
2. **Provider cost is stripped from client-facing responses** (`[JsonIgnore]` + side-channel billing + streaming `ExtensionData.Remove("cost")`). Fails safe: a missed stash under-bills, never leaks.
3. **Pricing/capability sync is admin-reviewed** — a scheduled job computes drift; nothing is applied without an explicit admin action.
4. **Apply scope is provider-scoped + shared** — context-window drift writes the per-provider MPTA override; capability drift writes the shared `Model` flags, with a UI warning that other providers are affected.

### Commit map
| # | Commit | Summary |
|---|--------|---------|
| 1 | capture provider-reported usage cost | `Usage.ProviderReportedCostUsd` (`[JsonIgnore]`) + `cost` strip in mapping/streaming |
| 2 | per-provider cost-trust + markup config | `Provider` fields + DTOs + WebAdmin form + migration (opt-in, no behavior change) |
| 3 | bill from trusted provider-reported cost | `CostCalculationService` short-circuit + middleware side-channel + `RequestLog.BillingMethod` |
| 4 | provider-cost refund parity | token-proportional refund from charged cost when `ModelCost` row is absent |
| 5 | attribution headers + rich `/models` metadata | `HTTP-Referer`/`X-Title`; capabilities + token limits from the catalog |
| 6 | first-class `reasoning` parameter | typed `ReasoningConfig`; response `reasoning` / `reasoning_details` |
| 7 | `json_schema` structured outputs | Core `ResponseFormat.JsonSchema` forwarded to the wire |
| 8 | native image generation | fixes the 404 — posts to `/api/v1/images`, captures usage/cost |
| 9 | async video generation | duck-typed `CreateVideoAsync`, polls to completion (MiniMax precedent) |
| 10 | STT + TTS | greenfield `IAudioTranscriptionClient` / `ITextToSpeechClient` on the shared client |
| 11 | rerank | greenfield `IRerankClient`; bills via existing `SearchUnits` |
| 12 | metadata drift backend + review API | drift entities, detection service, `BackgroundService`, `ProviderSyncController` |
| 13 | drift review screen + Admin SDK | `client.providerSync` + WebAdmin `/provider-sync` review UI |
| 14 | per-mapping routing config | `ModelProviderMapping.ProviderOptions` merged into OpenRouter requests |

### Migrations
All 6 are PostgreSQL, additive (new nullable/default columns + two new tables with a partial unique index) — expand/contract satisfied, the previous release runs unmodified against the migrated schema.

### Verification
- Full solution `dotnet build`: **0 errors**.
- Targeted suites (OpenRouter, CostCalculation, ProviderSync, DriftDetection): **107 passed, 0 failed**.
- WebAdmin `npm run lint` + `npm run type-check`: clean. Admin SDK builds clean.

### Follow-ups (need a running environment / maintainer)
- **Live E2E billing check:** with `./scripts/dev/start-dev.ps1`, create an OpenRouter provider with `TrustProviderReportedCosts=true` + markup, then confirm streaming/non-streaming spend = `usage.cost × markup`, that `cost` is absent from client responses, and `RequestLog.BillingMethod=ProviderCost`.
- If your Admin SDK drift gate compares `generated/admin-api.ts` against the live spec, regenerate it against a running Admin API — the new `providerSync` client is hand-written and self-contained, so nothing here depends on the generated types.

### Risk notes
- **Billing blast radius (commit 3):** the short-circuit sits before the `ModelCost` lookup in both cost methods; idempotency, RabbitMQ ordering, and spend batching are untouched. Heaviest test coverage here.
- **BYOK under-billing:** for BYOK keys OpenRouter's `cost` is only its ~5% fee. Recommend enabling trust only for non-BYOK OpenRouter providers initially (documented).
