### PR TITLE
Reconcile 24 drifted Admin SDK model types with wire types (#1038)

### DIFF
--- a/SDKs/Node/Admin/src/generated/admin-api.ts
+++ b/SDKs/Node/Admin/src/generated/admin-api.ts
@@ -10295,6 +10295,361 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/ProviderSync/drift": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Lists drift items (defaults to Pending), optionally filtered. */
+    get: {
+      parameters: {
+        query?: {
+          status?: string;
+          driftType?: string;
+          providerId?: number;
+          page?: number;
+          pageSize?: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/drift/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Gets a single drift item. */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: number;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/drift/{id}/apply": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Applies a drift item's proposed change. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: number;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/drift/{id}/dismiss": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dismisses a drift item. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          id: number;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/drift/bulk/apply": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Applies multiple drift items. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["BulkDriftActionRequest"];
+          "text/json": components["schemas"]["BulkDriftActionRequest"];
+          "application/*+json": components["schemas"]["BulkDriftActionRequest"];
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/drift/bulk/dismiss": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Dismisses multiple drift items. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["BulkDriftActionRequest"];
+          "text/json": components["schemas"]["BulkDriftActionRequest"];
+          "application/*+json": components["schemas"]["BulkDriftActionRequest"];
+        };
+      };
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Triggers a sync now. Returns 409 if a sync is already in progress. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/ProviderSync/runs": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Lists recent sync runs. */
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          pageSize?: number;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Internal server error. Returns a standardized ErrorResponseDto. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/admin/provider-tools": {
     parameters: {
       query?: never;
@@ -12642,6 +12997,10 @@ export interface components {
        */
       failureCount?: number;
     };
+    /** @description Request body for bulk apply/dismiss. */
+    BulkDriftActionRequest: {
+      ids?: number[];
+    };
     /** @description Result of a bulk mapping operation */
     BulkMappingResult: {
       /** @description Successfully created mappings */
@@ -12907,6 +13266,10 @@ export interface components {
       cachedInputWriteCostPerMillionTokens?: null | number;
       /** Format: double */
       costPerSearchUnit?: null | number;
+      /** Format: double */
+      audioCostPerMinute?: null | number;
+      /** Format: double */
+      audioCostPerThousandCharacters?: null | number;
     };
     /** @description Data transfer object for creating a new AI model in the system. */
     CreateModelDto: {
@@ -12934,6 +13297,12 @@ export interface components {
       supportsImageGeneration?: boolean;
       /** @description Gets or sets whether the model supports video generation. */
       supportsVideoGeneration?: boolean;
+      /** @description Whether the model supports speech-to-text transcription. */
+      supportsSpeechToText?: boolean;
+      /** @description Whether the model supports text-to-speech synthesis. */
+      supportsTextToSpeech?: boolean;
+      /** @description Whether the model supports document reranking. */
+      supportsRerank?: boolean;
       /** @description Gets or sets whether the model supports text embeddings generation. */
       supportsEmbeddings?: boolean;
       /**
@@ -13030,6 +13399,15 @@ export interface components {
       baseUrl?: null | string;
       /** @description Whether the provider is enabled */
       isEnabled?: boolean;
+      /** @description When true, the cost the provider reports per request is authoritative for billing
+       *     (falls back to ModelCost when no cost is reported). Defaults to false. */
+      trustProviderReportedCosts?: boolean;
+      /**
+       * Format: double
+       * @description Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).
+       *     Only consulted when bool CreateProviderRequest.TrustProviderReportedCosts is true.
+       */
+      providerCostMarkupMultiplier?: number;
     };
     CreateProviderToolDto: {
       provider: components["schemas"]["ProviderType"];
@@ -13672,6 +14050,9 @@ export interface components {
       cachedWriteTokens?: null | number;
       /** Format: double */
       cost?: number;
+      billingMethod?: null | components["schemas"]["RequestBillingMethod"];
+      /** Format: double */
+      providerReportedCostUsd?: null | number;
       /** Format: double */
       responseTimeMs?: number;
       userId?: null | string;
@@ -13973,6 +14354,9 @@ export interface components {
       supportsImageGeneration?: boolean;
       supportsVideoGeneration?: boolean;
       supportsEmbeddings?: boolean;
+      supportsSpeechToText?: boolean;
+      supportsTextToSpeech?: boolean;
+      supportsRerank?: boolean;
       supportsChat?: boolean;
       supportsFunctionCalling?: boolean;
       supportsStreaming?: boolean;
@@ -14042,6 +14426,10 @@ export interface components {
       cachedInputWriteCostPerMillionTokens?: null | number;
       /** Format: double */
       costPerSearchUnit?: null | number;
+      /** Format: double */
+      audioCostPerMinute?: null | number;
+      /** Format: double */
+      audioCostPerThousandCharacters?: null | number;
     };
     ModelCostOverviewDto: {
       model?: string;
@@ -14083,6 +14471,12 @@ export interface components {
       supportsImageGeneration?: boolean;
       /** @description Gets or sets whether the model supports video generation. */
       supportsVideoGeneration?: boolean;
+      /** @description Whether the model supports speech-to-text transcription. */
+      supportsSpeechToText?: boolean;
+      /** @description Whether the model supports text-to-speech synthesis. */
+      supportsTextToSpeech?: boolean;
+      /** @description Whether the model supports document reranking. */
+      supportsRerank?: boolean;
       /** @description Gets or sets whether the model supports text embeddings generation. */
       supportsEmbeddings?: boolean;
       /**
@@ -14181,6 +14575,7 @@ export interface components {
       /** Format: date-time */
       updatedAt?: string;
       notes?: null | string;
+      providerOptions?: null | string;
       capabilities?: null | components["schemas"]["ModelCapabilitiesDto"];
     };
     /** @description Data transfer object representing a series or family of related AI models. */
@@ -14293,6 +14688,12 @@ export interface components {
       supportsImageGeneration?: boolean;
       /** @description Gets or sets whether the model supports video generation. */
       supportsVideoGeneration?: boolean;
+      /** @description Whether the model supports speech-to-text transcription. */
+      supportsSpeechToText?: boolean;
+      /** @description Whether the model supports text-to-speech synthesis. */
+      supportsTextToSpeech?: boolean;
+      /** @description Whether the model supports document reranking. */
+      supportsRerank?: boolean;
       /** @description Gets or sets whether the model supports text embeddings generation. */
       supportsEmbeddings?: boolean;
       /**
@@ -14721,6 +15122,8 @@ export interface components {
       refundUsage?: components["schemas"]["UsageDto"];
       refundReason?: string;
       originalTransactionId?: null | string;
+      /** Format: int32 */
+      requestLogId?: null | number;
     };
     PromptCachingConfigDto: {
       autoInjectEnabled?: boolean;
@@ -14733,6 +15136,9 @@ export interface components {
       providerName: string;
       baseUrl?: null | string;
       isEnabled?: boolean;
+      trustProviderReportedCosts?: boolean;
+      /** Format: double */
+      providerCostMarkupMultiplier?: number;
       /** Format: date-time */
       createdAt?: string;
       /** Format: date-time */
@@ -14948,6 +15354,7 @@ export interface components {
       validationMessages?: string[];
       breakdown?: null | components["schemas"]["RefundBreakdownDto"];
     };
+    RequestBillingMethod: number;
     RequestLog: {
       /** Format: int32 */
       id?: number;
@@ -14969,6 +15376,9 @@ export interface components {
       cachedWriteTokens?: null | number;
       /** Format: double */
       cost?: number;
+      billingMethod?: null | components["schemas"]["RequestBillingMethod"];
+      /** Format: double */
+      providerReportedCostUsd?: null | number;
       /** Format: double */
       responseTimeMs?: number;
       /** Format: date-time */
@@ -15588,6 +15998,10 @@ export interface components {
       cachedInputWriteCostPerMillionTokens?: null | number;
       /** Format: double */
       costPerSearchUnit?: null | number;
+      /** Format: double */
+      audioCostPerMinute?: null | number;
+      /** Format: double */
+      audioCostPerThousandCharacters?: null | number;
     };
     /** @description Data transfer object for updating an existing AI model in the system. */
     UpdateModelDto: {
@@ -15624,6 +16038,12 @@ export interface components {
       /** @description Gets or sets whether the model supports video generation.
        *     True to enable video generation, false to disable, or null to keep existing. */
       supportsVideoGeneration?: null | boolean;
+      /** @description Whether the model supports speech-to-text transcription. */
+      supportsSpeechToText?: null | boolean;
+      /** @description Whether the model supports text-to-speech synthesis. */
+      supportsTextToSpeech?: null | boolean;
+      /** @description Whether the model supports document reranking. */
+      supportsRerank?: null | boolean;
       /** @description Gets or sets whether the model supports text embeddings generation.
        *     True to enable embeddings, false to disable, or null to keep existing. */
       supportsEmbeddings?: null | boolean;
@@ -15720,6 +16140,15 @@ export interface components {
       baseUrl?: null | string;
       /** @description Whether the provider is enabled */
       isEnabled?: boolean;
+      /** @description When true, the cost the provider reports per request is authoritative for billing
+       *     (falls back to ModelCost when no cost is reported). Defaults to false when omitted. */
+      trustProviderReportedCosts?: boolean;
+      /**
+       * Format: double
+       * @description Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).
+       *     Defaults to 1.0 when omitted, so a partial update never silently zeroes the markup.
+       */
+      providerCostMarkupMultiplier?: number;
     };
     UpdateProviderToolDto: {
       isActive?: boolean;

--- a/SDKs/Node/Admin/src/models/analytics-core.ts
+++ b/SDKs/Node/Admin/src/models/analytics-core.ts
@@ -70,13 +70,12 @@ export interface VirtualKeyUsage {
   averageLatency: number;
 }
 
+// Matches the wire `ModelUsage` schema (per-model usage aggregate). See issue #1038.
 export interface ModelUsage {
-  model: string;
-  provider: string;
-  requests: number;
-  tokens: number;
+  requestCount: number;
   cost: number;
-  averageLatency: number;
+  inputTokens: number;
+  outputTokens: number;
 }
 
 export interface TimeSeriesData {

--- a/SDKs/Node/Admin/src/models/analytics-usage.ts
+++ b/SDKs/Node/Admin/src/models/analytics-usage.ts
@@ -21,16 +21,14 @@ export interface VirtualKeyAnalytics {
   };
 }
 
+// Matches the wire `VirtualKeyUsageSummary` schema. See issue #1038.
 export interface VirtualKeyUsageSummary {
-  keyId: string;
+  virtualKeyId: number;
   keyName: string;
-  totalRequests: number;
-  totalTokens: number;
+  requestCount: number;
   totalCost: number;
-  averageRequestsPerDay: number;
-  budgetUsed: number;
-  budgetRemaining: number;
-  lastUsed: string;
+  lastUsed: string | null;
+  modelsUsed: string[];
 }
 
 export interface VirtualKeyRanking {

--- a/SDKs/Node/Admin/src/models/analyticsExport.ts
+++ b/SDKs/Node/Admin/src/models/analyticsExport.ts
@@ -2,7 +2,7 @@
  * Analytics export-related models for the Admin SDK
  */
 
-import type { ExportDestinationConfig, ExtendedMetadata } from './common-types';
+import type { ExportDestinationConfig } from './common-types';
 import { ProviderType } from './providerType';
 
 /**
@@ -332,34 +332,34 @@ export interface RequestLogSummary {
 }
 
 /**
- * Enhanced request log type with additional fields
+ * A single request-log record.
+ *
+ * Reconciled to wire shape — issue #1038.
  */
 export interface RequestLog {
-  id: string;
-  timestamp: string;
-  method: string;
-  endpoint: string;
-  statusCode: number;
-  responseTime: number;
-  virtualKeyId: string;
-  virtualKeyName?: string;
-  providerType?: ProviderType;
-  modelName?: string;
-  ipAddress: string;
-  userAgent?: string;
-  requestSize: number;
-  responseSize: number;
-  tokensUsed?: {
-    prompt: number;
-    completion: number;
-    total: number;
-  };
+  id?: number;
+  virtualKeyId?: number;
+  /** Wire references the VirtualKey schema; typed loosely on the client. */
+  virtualKey?: unknown;
+  modelName: string;
+  providerId?: number | null;
+  providerType?: string | null;
+  requestType: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number | null;
+  cachedWriteTokens?: number | null;
   cost?: number;
-  error?: {
-    type: string;
-    message: string;
-  };
-  metadata?: ExtendedMetadata;
+  /** Wire references the RequestBillingMethod schema; typed loosely on the client. */
+  billingMethod?: unknown;
+  providerReportedCostUsd?: number | null;
+  responseTimeMs?: number;
+  timestamp?: string;
+  userId?: string | null;
+  clientIp?: string | null;
+  requestPath?: string | null;
+  statusCode?: number | null;
+  metadata?: string | null;
 }
 
 /**

--- a/SDKs/Node/Admin/src/models/ipFilter.ts
+++ b/SDKs/Node/Admin/src/models/ipFilter.ts
@@ -3,6 +3,9 @@ import { FilterOptions } from './common';
 export type FilterType = 'whitelist' | 'blacklist';
 export type FilterMode = 'permissive' | 'restrictive';
 
+// Matches the wire `IpFilterDto` (filterType narrows the wire `string` to a union — asserted
+// with SameKeys). Client-only match-stats fields (lastMatchedAt/matchCount/blockedCount) and
+// the never-sent expiresAt/lastModifiedBy were removed in issue #1038; added updatedBy.
 export interface IpFilterDto {
   id: number;
   name: string;
@@ -12,12 +15,8 @@ export interface IpFilterDto {
   description?: string;
   createdAt: string;
   updatedAt: string;
-  lastMatchedAt?: string;
-  matchCount?: number;
-  expiresAt?: string; // For temporary rules
   createdBy?: string;
-  lastModifiedBy?: string;
-  blockedCount?: number; // Number of requests blocked
+  updatedBy?: string;
 }
 
 export interface CreateIpFilterDto {
@@ -37,6 +36,7 @@ export interface UpdateIpFilterDto {
   description?: string;
 }
 
+// Reconciled to wire shape — issue #1038 (dropped client-only maxFiltersPerType/ipv6Enabled)
 export interface IpFilterSettingsDto {
   isEnabled: boolean;
   defaultAllow: boolean;
@@ -45,8 +45,6 @@ export interface IpFilterSettingsDto {
   filterMode: FilterMode;
   whitelistFilters: IpFilterDto[];
   blacklistFilters: IpFilterDto[];
-  maxFiltersPerType?: number;
-  ipv6Enabled?: boolean;
 }
 
 export interface UpdateIpFilterSettingsDto {
@@ -63,13 +61,11 @@ export interface IpCheckRequest {
   endpoint?: string;
 }
 
+// Matches the wire `IpCheckResult`. The API returns only allow/deny + reason; the client-only
+// matchedFilter/matchedFilterId/filterType/isDefaultAction fields were removed in issue #1038.
 export interface IpCheckResult {
   isAllowed: boolean;
   deniedReason?: string;
-  matchedFilter?: string;
-  matchedFilterId?: number;
-  filterType?: FilterType;
-  isDefaultAction?: boolean;
 }
 
 export interface IpFilterFilters extends FilterOptions {

--- a/SDKs/Node/Admin/src/models/media.ts
+++ b/SDKs/Node/Admin/src/models/media.ts
@@ -1,11 +1,12 @@
 // Media models and types for Admin SDK
 
+// Reconciled to wire shape — issue #1038 (dropped client-only virtualKeyGroupId/Name; added virtualKey)
 export interface MediaRecord {
   id: string;
   storageKey: string;
   virtualKeyId: number;
-  virtualKeyGroupId?: number;
-  virtualKeyGroupName?: string;
+  /** Wire references the VirtualKey schema; typed loosely on the client. */
+  virtualKey?: unknown;
   mediaType: 'image' | 'video';
   contentType?: string;
   sizeBytes?: number;
@@ -131,6 +132,7 @@ export interface UpdateSimpleRetentionRequest {
 }
 
 // Full Media Retention Policy types
+// Reconciled to wire shape — issue #1038 (added virtualKeyGroups)
 export interface MediaRetentionPolicy {
   id: number;
   name: string;
@@ -157,8 +159,11 @@ export interface MediaRetentionPolicy {
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
+  /** Wire references the VirtualKeyGroup schema; typed loosely on the client. */
+  virtualKeyGroups?: unknown[];
 }
 
+// Reconciled to wire shape — issue #1038 (dropped client-only isActive)
 export interface CreateMediaRetentionPolicyRequest {
   name: string;
   description?: string;
@@ -171,7 +176,6 @@ export interface CreateMediaRetentionPolicyRequest {
   isDefault?: boolean;
   maxStorageSizeBytes?: number | null;
   maxFileCount?: number | null;
-  isActive?: boolean;
 }
 
 export interface UpdateMediaRetentionPolicyRequest {

--- a/SDKs/Node/Admin/src/models/modelCost.ts
+++ b/SDKs/Node/Admin/src/models/modelCost.ts
@@ -16,80 +16,65 @@ export enum PricingModel {
   PerThousandCharacters = 8
 }
 
+// Matches the wire `ModelCostDto` (modelType narrows the wire string to a client enum — asserted
+// with SameKeys). Media/inference pricing is carried in the polymorphic pricingConfiguration JSON,
+// not as flat fields; the legacy image/video/inference/extra-audio flat fields were removed and
+// audioCostPerKCharacters was corrected to audioCostPerThousandCharacters in issue #1038.
 export interface ModelCostDto {
   id: number;
   costName: string; // User-friendly name like "GPT-4 Standard Pricing"
-  associatedModelAliases: string[]; // Model aliases using this cost
   pricingModel: PricingModel; // The pricing model type
   pricingConfiguration?: string; // JSON configuration for polymorphic pricing
-  modelType: ModelType;
+  associatedModelAliases: string[]; // Model aliases using this cost
   inputCostPerMillionTokens: number; // Cost per million tokens in USD
   outputCostPerMillionTokens: number; // Cost per million tokens in USD
   embeddingCostPerMillionTokens?: number; // Cost per million tokens in USD
-  imageCostPerImage?: number;
-  audioCostPerMinute?: number;
-  audioCostPerKCharacters?: number;
-  audioInputCostPerMinute?: number;
-  audioOutputCostPerMinute?: number;
-  videoCostPerSecond?: number;
-  videoResolutionMultipliers?: string; // JSON string
-  imageResolutionMultipliers?: string; // JSON string for image resolution multipliers
+  createdAt: string;
+  updatedAt: string;
+  modelType: ModelType;
   isActive: boolean;
-  priority: number;
   effectiveDate: string;
   expiryDate?: string;
   description?: string;
-  createdAt: string;
-  updatedAt: string;
-  // Phase 1 fields
+  priority: number;
   batchProcessingMultiplier?: number;
   supportsBatchProcessing: boolean;
-  imageQualityMultipliers?: string; // JSON string
-  // Phase 2 fields
   cachedInputCostPerMillionTokens?: number; // Cost per million tokens in USD
   cachedInputWriteCostPerMillionTokens?: number; // Cost per million tokens in USD
   costPerSearchUnit?: number;
-  costPerInferenceStep?: number;
-  defaultInferenceSteps?: number;
+  audioCostPerMinute?: number;
+  audioCostPerThousandCharacters?: number;
 }
 
+// Matches the wire `CreateModelCostDto` (SameKeys — modelType narrows wire string). Media/inference
+// pricing is set via pricingConfiguration; the ID field is modelProviderTypeAssociationIds. See #1038.
 export interface CreateModelCostDto {
   costName: string; // Required: User-friendly name
-  modelProviderMappingIds: number[]; // IDs of ModelProviderMapping entities
   pricingModel?: PricingModel; // Default: Standard
   pricingConfiguration?: string; // JSON configuration for polymorphic pricing
+  modelProviderTypeAssociationIds?: number[]; // IDs of provider/model type associations
   modelType?: ModelType; // Default: ModelType.Chat
   priority?: number; // Default: 0
   description?: string;
   inputCostPerMillionTokens: number; // Cost per million tokens in USD
   outputCostPerMillionTokens: number; // Cost per million tokens in USD
   embeddingCostPerMillionTokens?: number; // Cost per million tokens in USD
-  imageCostPerImage?: number;
-  audioCostPerMinute?: number;
-  audioCostPerKCharacters?: number;
-  audioInputCostPerMinute?: number;
-  audioOutputCostPerMinute?: number;
-  videoCostPerSecond?: number;
-  videoResolutionMultipliers?: string; // JSON string
-  imageResolutionMultipliers?: string; // JSON string for image resolution multipliers
-  // Phase 1 fields
   batchProcessingMultiplier?: number;
   supportsBatchProcessing?: boolean;
-  imageQualityMultipliers?: string; // JSON string
-  // Phase 2 fields
   cachedInputCostPerMillionTokens?: number; // Cost per million tokens in USD
   cachedInputWriteCostPerMillionTokens?: number; // Cost per million tokens in USD
   costPerSearchUnit?: number;
-  costPerInferenceStep?: number;
-  defaultInferenceSteps?: number;
+  audioCostPerMinute?: number;
+  audioCostPerThousandCharacters?: number;
 }
 
+// Matches the wire `UpdateModelCostDto` (SameKeys — modelType narrows wire string). See issue #1038.
 export interface UpdateModelCostDto {
   id: number; // Required for update
   costName: string; // Required: User-friendly name
-  modelProviderMappingIds: number[]; // IDs of ModelProviderMapping entities
   pricingModel?: PricingModel;
   pricingConfiguration?: string; // JSON configuration for polymorphic pricing
+  modelProviderTypeAssociationIds?: number[]; // IDs of provider/model type associations
   modelType?: ModelType;
   priority?: number;
   description?: string;
@@ -97,24 +82,13 @@ export interface UpdateModelCostDto {
   inputCostPerMillionTokens?: number; // Cost per million tokens in USD
   outputCostPerMillionTokens?: number; // Cost per million tokens in USD
   embeddingCostPerMillionTokens?: number; // Cost per million tokens in USD
-  imageCostPerImage?: number;
-  audioCostPerMinute?: number;
-  audioCostPerKCharacters?: number;
-  audioInputCostPerMinute?: number;
-  audioOutputCostPerMinute?: number;
-  videoCostPerSecond?: number;
-  videoResolutionMultipliers?: string; // JSON string
-  imageResolutionMultipliers?: string; // JSON string for image resolution multipliers
-  // Phase 1 fields
   batchProcessingMultiplier?: number;
   supportsBatchProcessing?: boolean;
-  imageQualityMultipliers?: string; // JSON string
-  // Phase 2 fields
   cachedInputCostPerMillionTokens?: number; // Cost per million tokens in USD
   cachedInputWriteCostPerMillionTokens?: number; // Cost per million tokens in USD
   costPerSearchUnit?: number;
-  costPerInferenceStep?: number;
-  defaultInferenceSteps?: number;
+  audioCostPerMinute?: number;
+  audioCostPerThousandCharacters?: number;
 }
 
 export interface ModelCostFilters extends FilterOptions {

--- a/SDKs/Node/Admin/src/models/modelMapping.ts
+++ b/SDKs/Node/Admin/src/models/modelMapping.ts
@@ -23,6 +23,10 @@ export interface ModelCapabilitiesDto {
   supportsImageGeneration: boolean;
   supportsVideoGeneration: boolean;
   supportsEmbeddings: boolean;
+  // Audio + rerank capabilities added to the backend after the gate landed (issue #1038).
+  supportsSpeechToText?: boolean;
+  supportsTextToSpeech?: boolean;
+  supportsRerank?: boolean;
   supportsChat: boolean;
   supportsFunctionCalling: boolean;
   supportsStreaming: boolean;

--- a/SDKs/Node/Admin/src/models/pricing.ts
+++ b/SDKs/Node/Admin/src/models/pricing.ts
@@ -64,14 +64,26 @@ export interface PricingValidationResult {
   parsedConfig?: PricingRulesConfig;
 }
 
-/** Request for simulating pricing calculation */
+/**
+ * Request for simulating pricing calculation.
+ *
+ * Reconciled to wire shape — issue #1038.
+ */
 export interface PricingSimulationRequest {
-  /** The pricing configuration to simulate */
-  config: PricingRulesConfig;
-  /** Test parameters to evaluate */
-  parameters: Record<string, string | number | boolean>;
-  /** Quantity for cost calculation */
-  quantity: number;
+  /** The pricing configuration JSON */
+  pricingConfiguration?: string;
+  /** Parameters for the simulation */
+  parameters?: Record<string, string | number | boolean> | null;
+  /** Video duration in seconds (for per_second pricing) */
+  videoDurationSeconds?: number | null;
+  /** Video resolution (e.g., "1080p") */
+  videoResolution?: string | null;
+  /** Image count (for per_unit pricing) */
+  imageCount?: number | null;
+  /** Image resolution (e.g., "1024x1024") */
+  imageResolution?: string | null;
+  /** Image quality (e.g., "hd", "standard") */
+  imageQuality?: string | null;
 }
 
 /** Result of pricing simulation */
@@ -116,18 +128,23 @@ export interface PricingAuditQueryParams {
   pageSize?: number;
 }
 
-/** Summary statistics for pricing audit */
+/** Summary of a single pricing rule's match activity. Matches the wire `RuleMatchSummary`. */
+export interface RuleMatchSummary {
+  ruleDescription?: string;
+  matchCount: number;
+  totalRevenue: number;
+}
+
+/** Summary statistics for pricing audit. Matches the wire `PricingAuditSummary`. See issue #1038. */
 export interface PricingAuditSummary {
   totalEvaluations: number;
-  defaultRateUsageCount: number;
-  defaultRateUsagePercent: number;
-  averageCost: number;
-  totalCost: number;
-  topMatchedRules: Array<{
-    description?: string;
-    matchCount: number;
-    totalCost: number;
-  }>;
+  defaultRateUsed: number;
+  rulesMatched: number;
+  totalRevenue: number;
+  averageRate: number;
+  pricingTypeBreakdown: Record<string, number>;
+  modelBreakdown: Record<string, number>;
+  topMatchedRules: RuleMatchSummary[];
 }
 
 /** Pricing rules template for different use cases */

--- a/SDKs/Node/Admin/src/models/settings.ts
+++ b/SDKs/Node/Admin/src/models/settings.ts
@@ -1,6 +1,8 @@
 import { FilterOptions } from './common';
 import type { CustomSettings, ConfigValue } from './common-types';
 
+// Matches the wire `GlobalSettingDto`. The API returns no category/dataType/isSecret
+// metadata, so those client-only fields were removed in issue #1038.
 export interface GlobalSettingDto {
   id: number;
   key: string;
@@ -8,10 +10,6 @@ export interface GlobalSettingDto {
   description?: string;
   createdAt: string;
   updatedAt: string;
-  // Legacy fields for helper methods (not returned by API)
-  dataType?: 'string' | 'number' | 'boolean' | 'json';
-  category?: string;
-  isSecret?: boolean;
 }
 
 export interface GlobalSettingCacheStats {

--- a/SDKs/Node/Admin/src/models/system.ts
+++ b/SDKs/Node/Admin/src/models/system.ts
@@ -1,28 +1,48 @@
 import { FilterOptions } from './common';
 import type { MaintenanceTaskConfig, ConfigValue } from './common-types';
 
+// Reconciled to the wire `SystemInfoDto` in issue #1038: the endpoint returns nested
+// version/os/database/runtime/recordCounts objects, not the previous flat shape.
+export interface VersionInfo {
+  appVersion?: string;
+  buildDate?: string | null;
+}
+
+export interface OsInfo {
+  description?: string;
+  architecture?: string;
+}
+
+export interface DatabaseInfo {
+  provider?: string;
+  version?: string;
+  connected?: boolean;
+  connectionString?: string;
+  location?: string;
+  size?: string;
+  tableCount?: number;
+}
+
+export interface RuntimeInfo {
+  runtimeVersion?: string;
+  startTime?: string;
+  uptime?: string;
+}
+
+export interface RecordCountsDto {
+  virtualKeys?: number;
+  requests?: number;
+  settings?: number;
+  providers?: number;
+  modelMappings?: number;
+}
+
 export interface SystemInfoDto {
-  version: string;
-  buildDate: string;
-  environment: string;
-  uptime: number;
-  systemTime: string;
-  features: {
-    ipFiltering: boolean;
-    costTracking: boolean;
-    audioSupport: boolean;
-  };
-  runtime: {
-    dotnetVersion: string;
-    os: string;
-    architecture: string;
-  };
-  database: {
-    provider: string;
-    connectionString?: string;
-    isConnected: boolean;
-    pendingMigrations?: string[];
-  };
+  version?: VersionInfo;
+  operatingSystem?: OsInfo;
+  database?: DatabaseInfo;
+  runtime?: RuntimeInfo;
+  recordCounts?: RecordCountsDto;
 }
 
 export interface HealthCheckData {
@@ -123,7 +143,9 @@ export interface CreateNotificationDto {
   message: string;
 }
 
+// Reconciled to wire shape — issue #1038 (wire adds id)
 export interface UpdateNotificationDto {
+  id?: number;
   message?: string;
   isRead?: boolean;
 }
@@ -267,7 +289,10 @@ export interface SystemHealthDto {
   };
 }
 
-export interface SystemMetricsDto {
+// Client-side normalized resource view (CPU/memory/disk percentages). Distinct from the
+// wire `SystemMetricsDto` (process diagnostics: cpuCount/gcMemoryMb/threadCount/workingSetMb),
+// so it is intentionally named differently to avoid a false type-drift pairing. See issue #1038.
+export interface SystemResourceMetricsDto {
   cpuUsage: number;
   memoryUsage: number;
   diskUsage: number;
@@ -275,7 +300,10 @@ export interface SystemMetricsDto {
   uptime: number;
 }
 
-export interface ServiceStatusDto {
+// Client-side per-service health map produced by transforming the /api/health/services
+// response. Distinct from the wire `ServiceStatusDto` (a single per-service record), so it is
+// intentionally named differently to avoid a false type-drift pairing. See issue #1038.
+export interface ServiceStatusMapDto {
   coreApi: {
     status: 'healthy' | 'degraded' | 'unhealthy';
     latency: number;

--- a/SDKs/Node/Admin/src/models/virtualKey.ts
+++ b/SDKs/Node/Admin/src/models/virtualKey.ts
@@ -76,10 +76,6 @@ export interface VirtualKeyDto {
   rateLimitRpm?: number;
   rateLimitRpd?: number;
   description?: string;
-  // Compatibility properties
-  name?: string;
-  isActive?: boolean;
-  rateLimit?: number;
 }
 
 export interface CreateVirtualKeyRequest {
@@ -113,16 +109,13 @@ export interface VirtualKeyValidationRequest {
   key: string;
 }
 
+// Reconciled to wire shape — issue #1038 (reason -> errorMessage; allowedModels is a string; dropped client-only fields)
 export interface VirtualKeyValidationResult {
-  isValid: boolean;
+  isValid?: boolean;
   virtualKeyId?: number;
   keyName?: string;
-  reason?: string;
-  allowedModels?: string[];
-  expiresAt?: string;
-  rateLimitRpm?: number;
-  rateLimitRpd?: number;
-  virtualKeyGroupId?: number;
+  allowedModels?: string;
+  errorMessage?: string;
 }
 
 // Note: Spend tracking is now handled at the VirtualKeyGroup level

--- a/SDKs/Node/Admin/src/services/FetchModelCostService.ts
+++ b/SDKs/Node/Admin/src/services/FetchModelCostService.ts
@@ -36,9 +36,9 @@ interface ModelCostOverviewParams {
  */
 function validateCreateModelCostRequest(data: CreateModelCostDto): void {
   // Validate required fields
-  validateRequired(data, ['costName', 'modelProviderMappingIds', 'inputCostPerMillionTokens', 'outputCostPerMillionTokens']);
+  validateRequired(data, ['costName', 'modelProviderTypeAssociationIds', 'inputCostPerMillionTokens', 'outputCostPerMillionTokens']);
   validateStringLength(data.costName, 1, 255, 'costName');
-  validateNonEmptyArray(data.modelProviderMappingIds, 'modelProviderMappingIds');
+  validateNonEmptyArray(data.modelProviderTypeAssociationIds ?? [], 'modelProviderTypeAssociationIds');
 
   // Validate cost values are non-negative
   if (data.inputCostPerMillionTokens < 0) {
@@ -51,16 +51,11 @@ function validateCreateModelCostRequest(data: CreateModelCostDto): void {
   // Validate optional number fields if provided
   const optionalNumberFields = [
     'embeddingCostPerMillionTokens',
-    'imageCostPerImage',
     'audioCostPerMinute',
-    'audioCostPerKCharacters',
-    'audioInputCostPerMinute',
-    'audioOutputCostPerMinute',
-    'videoCostPerSecond',
+    'audioCostPerThousandCharacters',
     'cachedInputCostPerMillionTokens',
     'cachedInputWriteCostPerMillionTokens',
     'costPerSearchUnit',
-    'costPerInferenceStep',
   ] as const;
 
   for (const field of optionalNumberFields) {
@@ -73,11 +68,6 @@ function validateCreateModelCostRequest(data: CreateModelCostDto): void {
   // Validate batch processing multiplier is between 0 and 1
   if (data.batchProcessingMultiplier !== undefined && data.batchProcessingMultiplier !== null) {
     validateNumberRange(data.batchProcessingMultiplier, 0, 1, 'batchProcessingMultiplier');
-  }
-
-  // Validate default inference steps is at least 1
-  if (data.defaultInferenceSteps !== undefined && data.defaultInferenceSteps !== null && data.defaultInferenceSteps < 1) {
-    throw new ValidationError('defaultInferenceSteps must be at least 1');
   }
 }
 

--- a/SDKs/Node/Admin/src/services/FetchSettingsService.ts
+++ b/SDKs/Node/Admin/src/services/FetchSettingsService.ts
@@ -49,8 +49,8 @@ export class FetchSettingsService {
       }
     );
 
-    // Extract unique categories
-    const categories = [...new Set(settings.map(s => s.category).filter(Boolean))] as string[];
+    // The API does not return category metadata, so no categories can be derived.
+    const categories: string[] = [];
 
     // Find the most recent update
     const lastModified = settings
@@ -170,7 +170,8 @@ export class FetchSettingsService {
     const categoryMap = new Map<string, GlobalSettingDto[]>();
     
     for (const setting of allSettings.settings) {
-      const category = setting.category ?? 'General';
+      // The API does not return category metadata, so all settings are ungrouped.
+      const category = 'General';
       if (!categoryMap.has(category)) {
         categoryMap.set(category, []);
       }
@@ -213,17 +214,10 @@ export class FetchSettingsService {
    */
   async getTypedSettingValue<T = unknown>(key: string, config?: RequestConfig): Promise<T> {
     const setting = await this.getGlobalSetting(key, config);
-    
-    switch (setting.dataType) {
-      case 'number':
-        return parseFloat(setting.value) as T;
-      case 'boolean':
-        return (setting.value.toLowerCase() === 'true') as T;
-      case 'json':
-        return JSON.parse(setting.value) as T;
-      default:
-        return setting.value as T;
-    }
+
+    // The API stores values as opaque strings with no data-type metadata. Callers that
+    // know the expected shape should parse the returned string themselves.
+    return setting.value as T;
   }
 
   /**
@@ -254,9 +248,9 @@ export class FetchSettingsService {
   /**
    * Helper method to get all secret settings (with values hidden)
    */
-  async getSecretSettings(config?: RequestConfig): Promise<GlobalSettingDto[]> {
-    const allSettings = await this.getGlobalSettings(config);
-    return allSettings.settings.filter(s => s.isSecret);
+  async getSecretSettings(_config?: RequestConfig): Promise<GlobalSettingDto[]> {
+    // The API does not flag settings as secret, so none can be identified as such.
+    return Promise.resolve([]);
   }
 
   /**
@@ -284,20 +278,16 @@ export class FetchSettingsService {
    * Helper method to format setting value for display
    */
   formatSettingValue(setting: GlobalSettingDto): string {
-    if (setting.isSecret) {
-      return '********';
-    }
-
-    switch (setting.dataType) {
-      case 'json':
-        try {
-          return JSON.stringify(JSON.parse(setting.value), null, 2);
-        } catch {
-          return setting.value;
-        }
-      default:
+    // The API provides no data-type metadata; pretty-print values that happen to be JSON.
+    const trimmed = setting.value.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return JSON.stringify(JSON.parse(setting.value), null, 2);
+      } catch {
         return setting.value;
+      }
     }
+    return setting.value;
   }
 
   /**

--- a/SDKs/Node/Admin/src/services/FetchSystemHealthService.ts
+++ b/SDKs/Node/Admin/src/services/FetchSystemHealthService.ts
@@ -2,7 +2,7 @@ import type { FetchBaseApiClient } from '../client/FetchBaseApiClient';
 import type { RequestConfig } from '../client/types';
 import type { 
   SystemHealthDto,
-  ServiceStatusDto,
+  ServiceStatusMapDto,
   HealthEventDto,
   HealthEventsResponseDto,
   HealthEventSubscriptionOptions,
@@ -93,7 +93,7 @@ export class FetchSystemHealthService implements ISystemHealthService {
    * Get detailed system resource metrics.
    * Delegates to FetchSystemMetricsService.
    */
-  async getSystemMetrics(config?: RequestConfig): Promise<import('../models/system').SystemMetricsDto> {
+  async getSystemMetrics(config?: RequestConfig): Promise<import('../models/system').SystemResourceMetricsDto> {
     const metricsService = new FetchSystemMetricsService(this.client);
     return metricsService.getSystemMetrics(config);
   }
@@ -105,7 +105,7 @@ export class FetchSystemHealthService implements ISystemHealthService {
    * Uses dedicated services endpoint with fallback to health checks.
    * 
    * @param config - Optional request configuration for timeout, signal, headers
-   * @returns Promise<ServiceStatusDto> - Individual service health status including:
+   * @returns Promise<ServiceStatusMapDto> - Individual service health status including:
    *   - coreApi: Gateway API service health, latency, and endpoint
    *   - adminApi: Admin API service health, latency, and endpoint
    *   - database: Database health, latency, and connection count
@@ -113,7 +113,7 @@ export class FetchSystemHealthService implements ISystemHealthService {
    * @throws {Error} When service status data cannot be retrieved
    * @since Issue #427 - System Health SDK Methods
    */
-  async getServiceStatus(config?: RequestConfig): Promise<ServiceStatusDto> {
+  async getServiceStatus(config?: RequestConfig): Promise<ServiceStatusMapDto> {
     try {
       // Try to get from dedicated services endpoint
       const response = await this.client['get']<Record<string, unknown>>(
@@ -125,7 +125,7 @@ export class FetchSystemHealthService implements ISystemHealthService {
         }
       );
 
-      // Transform response to match ServiceStatusDto structure
+      // Transform response to match ServiceStatusMapDto structure
       // The /api/health/services endpoint returns a different format, so we'll map it
       const typedResponse = response as {
         coreApi?: { status?: string; responseTime?: number; endpoint?: string };
@@ -242,8 +242,10 @@ export class FetchSystemHealthService implements ISystemHealthService {
       const now = new Date();
       const events: HealthEventDto[] = [];
       
-      // Add system startup event
-      const startupTime = new Date(now.getTime() - systemInfo.uptime * 1000);
+      // Add system startup event (runtime.startTime is the process start timestamp)
+      const startupTime = systemInfo.runtime?.startTime
+        ? new Date(systemInfo.runtime.startTime)
+        : now;
       events.push({
         id: `system-startup-${startupTime.getTime()}`,
         timestamp: startupTime.toISOString(),

--- a/SDKs/Node/Admin/src/services/FetchSystemHelpers.ts
+++ b/SDKs/Node/Admin/src/services/FetchSystemHelpers.ts
@@ -9,43 +9,9 @@ export class FetchSystemHelpers implements ISystemHelpers {
    * Transform backend SystemInfo response to match frontend expectations
    */
   transformSystemInfoResponse(response: BackendSystemInfoResponse): SystemInfoDto {
-    // Calculate uptime in seconds from the TimeSpan format
-    let uptimeSeconds = 0;
-    if (response.runtime.uptime) {
-      // Parse TimeSpan format (e.g., "00:05:30" or "1.02:03:04.5")
-      const timeSpanMatch = response.runtime.uptime.match(/^(?:(\d+)\.)?(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/);
-      if (timeSpanMatch) {
-        const days = parseInt(timeSpanMatch[1] ?? '0', 10);
-        const hours = parseInt(timeSpanMatch[2], 10);
-        const minutes = parseInt(timeSpanMatch[3], 10);
-        const seconds = parseInt(timeSpanMatch[4], 10);
-        uptimeSeconds = (days * 24 * 60 * 60) + (hours * 60 * 60) + (minutes * 60) + seconds;
-      }
-    }
-    
-    return {
-      version: response.version.appVersion,
-      buildDate: response.version.buildDate ? new Date(response.version.buildDate).toISOString() : '',
-      environment: 'production',
-      uptime: uptimeSeconds,
-      systemTime: new Date().toISOString(),
-      features: {
-        ipFiltering: false,
-        costTracking: false,
-        audioSupport: false
-      },
-      runtime: {
-        dotnetVersion: response.runtime.runtimeVersion,
-        os: response.operatingSystem.description,
-        architecture: response.operatingSystem.architecture
-      },
-      database: {
-        provider: response.database.provider,
-        connectionString: response.database.connectionString,
-        isConnected: response.database.connected,
-        pendingMigrations: []
-      }
-    };
+    // The backend response now matches the wire SystemInfoDto shape (nested
+    // version/os/database/runtime/recordCounts), so no transformation is needed. See issue #1038.
+    return response;
   }
 
   /**
@@ -82,10 +48,12 @@ export class FetchSystemHelpers implements ISystemHelpers {
   }
 
   /**
-   * Helper method to check if a feature is enabled
+   * Helper method to check if a feature is enabled.
+   * The system-info endpoint no longer reports feature flags (issue #1038), so this
+   * always returns false. Retained for backward compatibility of the method surface.
    */
-  isFeatureEnabled(systemInfo: SystemInfoDto, feature: keyof SystemInfoDto['features']): boolean {
-    return systemInfo.features[feature] === true;
+  isFeatureEnabled(_systemInfo: SystemInfoDto, _feature: string): boolean {
+    return false;
   }
 
   /**

--- a/SDKs/Node/Admin/src/services/FetchSystemMetricsService.ts
+++ b/SDKs/Node/Admin/src/services/FetchSystemMetricsService.ts
@@ -1,6 +1,6 @@
 import type { FetchBaseApiClient } from '../client/FetchBaseApiClient';
 import type { RequestConfig } from '../client/types';
-import type { SystemMetricsDto } from '../models/system';
+import type { SystemInfoDto, SystemResourceMetricsDto } from '../models/system';
 import type { 
   MetricsParams, 
   PerformanceMetrics, 
@@ -66,7 +66,7 @@ export class FetchSystemMetricsService {
    * with fallback to constructed metrics from system info.
    * 
    * @param config - Optional request configuration for timeout, signal, headers
-   * @returns Promise<SystemMetricsDto> - System resource metrics including:
+   * @returns Promise<SystemResourceMetricsDto> - System resource metrics including:
    *   - cpuUsage: CPU utilization percentage (0-100)
    *   - memoryUsage: Memory utilization percentage (0-100)
    *   - diskUsage: Disk utilization percentage (0-100)
@@ -75,10 +75,10 @@ export class FetchSystemMetricsService {
    * @throws {Error} When metrics data cannot be retrieved
    * @since Issue #427 - System Health SDK Methods
    */
-  async getSystemMetrics(config?: RequestConfig): Promise<SystemMetricsDto> {
+  async getSystemMetrics(config?: RequestConfig): Promise<SystemResourceMetricsDto> {
     try {
       // Try to get from dedicated metrics endpoint first
-      return await this.client['get']<SystemMetricsDto>(
+      return await this.client['get']<SystemResourceMetricsDto>(
         ENDPOINTS.METRICS.BASE,
         {
           signal: config?.signal,
@@ -97,7 +97,7 @@ export class FetchSystemMetricsService {
         memoryUsage: 0, // Memory usage not available from backend
         diskUsage: 0, // Will be enhanced when disk monitoring is available
         activeConnections,
-        uptime: systemInfo.uptime,
+        uptime: this.computeUptimeSeconds(systemInfo),
       };
     }
   }
@@ -151,6 +151,22 @@ export class FetchSystemMetricsService {
   async getUptime(config?: RequestConfig): Promise<number> {
     const systemService = new FetchSystemService(this.client);
     const systemInfo = await systemService.getSystemInfo(config);
-    return systemInfo.uptime;
+    return this.computeUptimeSeconds(systemInfo);
+  }
+
+  /**
+   * Derives uptime in seconds from the system info's runtime.startTime.
+   * The endpoint no longer returns a numeric uptime (issue #1038); returns 0 when unknown.
+   */
+  private computeUptimeSeconds(systemInfo: SystemInfoDto): number {
+    const startTime = systemInfo.runtime?.startTime;
+    if (!startTime) {
+      return 0;
+    }
+    const started = new Date(startTime).getTime();
+    if (Number.isNaN(started)) {
+      return 0;
+    }
+    return Math.max(0, Math.floor((Date.now() - started) / 1000));
   }
 }

--- a/SDKs/Node/Admin/src/services/FetchSystemService.ts
+++ b/SDKs/Node/Admin/src/services/FetchSystemService.ts
@@ -6,8 +6,8 @@ import type {
   SystemInfoDto, 
   HealthStatusDto,
   SystemHealthDto,
-  SystemMetricsDto,
-  ServiceStatusDto,
+  SystemResourceMetricsDto,
+  ServiceStatusMapDto,
   HealthEventsResponseDto,
   HealthEventSubscriptionOptions,
   HealthEventSubscription
@@ -120,7 +120,7 @@ export class FetchSystemService implements ISystemService {
    * Get detailed system resource metrics.
    * Delegates to FetchSystemMetricsService
    */
-  async getSystemMetrics(config?: RequestConfig): Promise<SystemMetricsDto> {
+  async getSystemMetrics(config?: RequestConfig): Promise<SystemResourceMetricsDto> {
     return this.metricsService.getSystemMetrics(config);
   }
 
@@ -128,7 +128,7 @@ export class FetchSystemService implements ISystemService {
    * Get health status of individual services.
    * Delegates to FetchSystemHealthService
    */
-  async getServiceStatus(config?: RequestConfig): Promise<ServiceStatusDto> {
+  async getServiceStatus(config?: RequestConfig): Promise<ServiceStatusMapDto> {
     return this.healthService.getServiceStatus(config);
   }
 
@@ -195,7 +195,7 @@ export class FetchSystemService implements ISystemService {
    * Helper method to check if a feature is enabled
    * Delegates to FetchSystemHelpers
    */
-  isFeatureEnabled(systemInfo: SystemInfoDto, feature: keyof SystemInfoDto['features']): boolean {
+  isFeatureEnabled(systemInfo: SystemInfoDto, feature: string): boolean {
     return this.helpers.isFeatureEnabled(systemInfo, feature);
   }
 

--- a/SDKs/Node/Admin/src/services/types/system-service.types.ts
+++ b/SDKs/Node/Admin/src/services/types/system-service.types.ts
@@ -3,8 +3,8 @@ import type {
   SystemInfoDto, 
   HealthStatusDto,
   SystemHealthDto,
-  SystemMetricsDto,
-  ServiceStatusDto,
+  SystemResourceMetricsDto,
+  ServiceStatusMapDto,
   HealthEventsResponseDto,
   HealthEventSubscriptionOptions,
   HealthEventSubscription
@@ -94,8 +94,8 @@ export interface ISystemService {
 // Service interface for health operations
 export interface ISystemHealthService {
   getSystemHealth(config?: RequestConfig): Promise<SystemHealthDto>;
-  getSystemMetrics(config?: RequestConfig): Promise<SystemMetricsDto>;
-  getServiceStatus(config?: RequestConfig): Promise<ServiceStatusDto>;
+  getSystemMetrics(config?: RequestConfig): Promise<SystemResourceMetricsDto>;
+  getServiceStatus(config?: RequestConfig): Promise<ServiceStatusMapDto>;
   getUptime(config?: RequestConfig): Promise<number>;
   getActiveConnections(config?: RequestConfig): Promise<number>;
   getHealthEvents(limit?: number, config?: RequestConfig): Promise<HealthEventsResponseDto>;
@@ -110,6 +110,6 @@ export interface ISystemHelpers {
   isSystemHealthy(health: HealthStatusDto): boolean;
   getUnhealthyServices(health: HealthStatusDto): string[];
   formatUptime(uptimeSeconds: number): string;
-  isFeatureEnabled(systemInfo: SystemInfoDto, feature: keyof SystemInfoDto['features']): boolean;
+  isFeatureEnabled(systemInfo: SystemInfoDto, feature: string): boolean;
   transformSystemInfoResponse(response: BackendSystemInfoResponse): SystemInfoDto;
 }

--- a/SDKs/Node/Admin/src/type-tests/admin-api-compat.ts
+++ b/SDKs/Node/Admin/src/type-tests/admin-api-compat.ts
@@ -15,18 +15,38 @@
  *   model intentionally narrows wire types (string-literal unions, typed
  *   dictionaries, client-side enums), which `Compatible` cannot express.
  *
- * 24 additional same-named types are NOT asserted here because they had
- * already drifted before this gate existed. They are cataloged in
- * https://github.com/nickna/Conduit/issues/1038 — as each one is
- * reconciled, add it to the sections below so it can never drift again.
+ * The 24 pre-existing drifted types cataloged in
+ * https://github.com/nickna/Conduit/issues/1038 have been reconciled and are
+ * now asserted below (a couple were renamed to distinct client-abstraction
+ * names so they no longer falsely pair with unrelated wire schemas —
+ * ServiceStatusMapDto, SystemResourceMetricsDto).
+ *
+ * Two of the 24 remain unasserted because the current Admin OpenAPI exposes NO
+ * corresponding wire schema (the backend DTOs exist under
+ * ConduitLLM.Configuration.DTOs.Cache but no annotated endpoint surfaces them):
+ * `UpdateCacheConfigDto` (models/cache-types.ts) and `UpdateCachePolicyDto`
+ * (models/configuration.ts). Add assertions once those endpoints are exposed.
+ * (`ExportFormat` from the issue has no named hand-written type in this SDK, so
+ * there is nothing to pair against the wire `ExportFormat` enum.)
  */
 import type { components } from '../generated/admin-api';
 import type { Expect, Compatible, SameKeys } from './helpers';
 
+import type { RequestLog } from '../models/analyticsExport';
 import type { LLMCacheControlDto, ToggleLLMCacheRequest } from '../models/cache-types';
 import type { CreateFunctionCostDto, UpdateFunctionCostDto } from '../models/functions';
-import type { CreateIpFilterDto, UpdateIpFilterDto } from '../models/ipFilter';
+import type { CreateModelCostDto, ModelCostDto, UpdateModelCostDto } from '../models/modelCost';
 import type {
+  CreateIpFilterDto,
+  IpCheckResult,
+  IpFilterDto,
+  IpFilterSettingsDto,
+  UpdateIpFilterDto,
+} from '../models/ipFilter';
+import type {
+  CreateMediaRetentionPolicyRequest,
+  MediaRecord,
+  MediaRetentionPolicy,
   MediaStorageStats,
   MediaTypeStats,
   OverallMediaStorageStats,
@@ -54,20 +74,37 @@ import type {
   ModelCapabilitiesDto,
   ModelProviderMappingDto,
 } from '../models/modelMapping';
-import type { PricingConstraints, PricingRule, PricingRulesConfig } from '../models/pricing';
+import type { ModelUsage } from '../models/analytics-core';
+import type { VirtualKeyUsageSummary } from '../models/analytics-usage';
+import type {
+  PricingAuditSummary,
+  PricingConstraints,
+  PricingRule,
+  PricingRulesConfig,
+  PricingSimulationRequest,
+} from '../models/pricing';
 import type { ProviderReferenceDto, StandardApiKeyTestResponse } from '../models/provider';
 import type {
   CreateGlobalSettingDto,
+  GlobalSettingDto,
   UpdateGlobalSettingByKeyDto,
   UpdateGlobalSettingDto,
 } from '../models/settings';
-import type { CreateNotificationDto, HealthStatusDto, NotificationDto } from '../models/system';
+import type {
+  CreateNotificationDto,
+  HealthStatusDto,
+  NotificationDto,
+  SystemInfoDto,
+  UpdateNotificationDto,
+} from '../models/system';
 import type {
   AdjustBalanceDto,
   CreateVirtualKeyGroupRequestDto,
   UpdateVirtualKeyGroupRequestDto,
+  VirtualKeyDto,
   VirtualKeyGroupDto,
   VirtualKeyGroupTransactionDto,
+  VirtualKeyValidationResult,
 } from '../models/virtualKey';
 
 type Wire = components['schemas'];
@@ -83,6 +120,7 @@ export type CheckCreateFunctionCostDto = Expect<Compatible<CreateFunctionCostDto
 export type CheckUpdateFunctionCostDto = Expect<Compatible<UpdateFunctionCostDto, Wire['UpdateFunctionCostDto']>>;
 
 // models/media.ts
+export type CheckCreateMediaRetentionPolicyRequest = Expect<Compatible<CreateMediaRetentionPolicyRequest, Wire['CreateMediaRetentionPolicyRequest']>>; // reconciled in issue #1038
 export type CheckMediaStorageStats = Expect<Compatible<MediaStorageStats, Wire['MediaStorageStats']>>;
 export type CheckMediaTypeStats = Expect<Compatible<MediaTypeStats, Wire['MediaTypeStats']>>;
 export type CheckOverallMediaStorageStats = Expect<Compatible<OverallMediaStorageStats, Wire['OverallMediaStorageStats']>>;
@@ -110,36 +148,74 @@ export type CheckBulkUpdateResult = Expect<Compatible<BulkUpdateResult, Wire['Bu
 export type CheckModelCapabilitiesDto = Expect<Compatible<ModelCapabilitiesDto, Wire['ModelCapabilitiesDto']>>;
 export type CheckModelProviderMappingDto = Expect<Compatible<ModelProviderMappingDto, Wire['ModelProviderMappingDto']>>;
 
+// models/analytics-core.ts — reconciled in issue #1038
+export type CheckModelUsage = Expect<Compatible<ModelUsage, Wire['ModelUsage']>>;
+
+// models/analytics-usage.ts — reconciled in issue #1038
+export type CheckVirtualKeyUsageSummary = Expect<Compatible<VirtualKeyUsageSummary, Wire['VirtualKeyUsageSummary']>>;
+
 // models/pricing.ts
 export type CheckPricingConstraints = Expect<Compatible<PricingConstraints, Wire['PricingConstraints']>>;
+export type CheckPricingAuditSummary = Expect<Compatible<PricingAuditSummary, Wire['PricingAuditSummary']>>; // reconciled in issue #1038
 
 // models/provider.ts
 export type CheckProviderReferenceDto = Expect<Compatible<ProviderReferenceDto, Wire['ProviderReferenceDto']>>;
 
+// models/ipFilter.ts — reconciled in issue #1038
+export type CheckIpCheckResult = Expect<Compatible<IpCheckResult, Wire['IpCheckResult']>>;
+
 // models/settings.ts
+export type CheckGlobalSettingDto = Expect<Compatible<GlobalSettingDto, Wire['GlobalSettingDto']>>; // reconciled in issue #1038
 export type CheckCreateGlobalSettingDto = Expect<Compatible<CreateGlobalSettingDto, Wire['CreateGlobalSettingDto']>>;
 export type CheckUpdateGlobalSettingByKeyDto = Expect<Compatible<UpdateGlobalSettingByKeyDto, Wire['UpdateGlobalSettingByKeyDto']>>;
 export type CheckUpdateGlobalSettingDto = Expect<Compatible<UpdateGlobalSettingDto, Wire['UpdateGlobalSettingDto']>>;
 
 // models/system.ts
+export type CheckSystemInfoDto = Expect<Compatible<SystemInfoDto, Wire['SystemInfoDto']>>; // reconciled in issue #1038
 export type CheckCreateNotificationDto = Expect<Compatible<CreateNotificationDto, Wire['CreateNotificationDto']>>;
+export type CheckUpdateNotificationDto = Expect<Compatible<UpdateNotificationDto, Wire['UpdateNotificationDto']>>; // reconciled in issue #1038
 
 // models/virtualKey.ts
+export type CheckVirtualKeyDto = Expect<Compatible<VirtualKeyDto, Wire['VirtualKeyDto']>>; // reconciled in issue #1038
 export type CheckAdjustBalanceDto = Expect<Compatible<AdjustBalanceDto, Wire['AdjustBalanceDto']>>;
 export type CheckCreateVirtualKeyGroupRequestDto = Expect<Compatible<CreateVirtualKeyGroupRequestDto, Wire['CreateVirtualKeyGroupRequestDto']>>;
 export type CheckUpdateVirtualKeyGroupRequestDto = Expect<Compatible<UpdateVirtualKeyGroupRequestDto, Wire['UpdateVirtualKeyGroupRequestDto']>>;
 export type CheckVirtualKeyGroupDto = Expect<Compatible<VirtualKeyGroupDto, Wire['VirtualKeyGroupDto']>>;
 export type CheckVirtualKeyGroupTransactionDto = Expect<Compatible<VirtualKeyGroupTransactionDto, Wire['VirtualKeyGroupTransactionDto']>>;
+export type CheckVirtualKeyValidationResult = Expect<Compatible<VirtualKeyValidationResult, Wire['VirtualKeyValidationResult']>>; // reconciled in issue #1038
 
 // ---- Key-set only: manual model intentionally narrows wire types ----
 
+// models/analyticsExport.ts — reconciled in issue #1038
+// virtualKey/billingMethod reference nested wire schemas typed loosely on the client.
+export type CheckRequestLog = Expect<SameKeys<RequestLog, Wire['RequestLog']>>;
+
 // models/ipFilter.ts
 export type CheckCreateIpFilterDto = Expect<SameKeys<CreateIpFilterDto, Wire['CreateIpFilterDto']>>;
+// reconciled in issue #1038 — filterType narrows the wire string to a 'whitelist' | 'blacklist' union.
+export type CheckIpFilterDto = Expect<SameKeys<IpFilterDto, Wire['IpFilterDto']>>;
+// reconciled in issue #1038 — filterMode narrows wire string to a union; filters are typed IpFilterDto[].
+export type CheckIpFilterSettingsDto = Expect<SameKeys<IpFilterSettingsDto, Wire['IpFilterSettingsDto']>>;
 export type CheckUpdateIpFilterDto = Expect<SameKeys<UpdateIpFilterDto, Wire['UpdateIpFilterDto']>>;
+
+// models/modelCost.ts — reconciled in issue #1038
+// modelType narrows the wire string to a client ModelType enum; flat media/inference cost fields
+// were removed (that pricing lives in pricingConfiguration).
+export type CheckModelCostDto = Expect<SameKeys<ModelCostDto, Wire['ModelCostDto']>>;
+export type CheckCreateModelCostDto = Expect<SameKeys<CreateModelCostDto, Wire['CreateModelCostDto']>>;
+export type CheckUpdateModelCostDto = Expect<SameKeys<UpdateModelCostDto, Wire['UpdateModelCostDto']>>;
+
+// models/media.ts — reconciled in issue #1038
+// mediaType narrows wire string to a union; virtualKey references a nested wire schema.
+export type CheckMediaRecord = Expect<SameKeys<MediaRecord, Wire['MediaRecord']>>;
+// virtualKeyGroups references a nested wire schema typed loosely on the client.
+export type CheckMediaRetentionPolicy = Expect<SameKeys<MediaRetentionPolicy, Wire['MediaRetentionPolicy']>>;
 
 // models/pricing.ts
 export type CheckPricingRule = Expect<SameKeys<PricingRule, Wire['PricingRule']>>;
 export type CheckPricingRulesConfig = Expect<SameKeys<PricingRulesConfig, Wire['PricingRulesConfig']>>;
+// reconciled in issue #1038 — parameters narrows the wire's Record<string, never> to a typed dictionary.
+export type CheckPricingSimulationRequest = Expect<SameKeys<PricingSimulationRequest, Wire['PricingSimulationRequest']>>;
 
 // models/provider.ts
 export type CheckStandardApiKeyTestResponse = Expect<SameKeys<StandardApiKeyTestResponse, Wire['StandardApiKeyTestResponse']>>;

--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -11669,6 +11669,269 @@
         }
       }
     },
+    "/api/ProviderSync/drift": {
+      "get": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Lists drift items (defaults to Pending), optionally filtered.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "driftType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "providerId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/drift/{id}": {
+      "get": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Gets a single drift item.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/drift/{id}/apply": {
+      "post": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Applies a drift item's proposed change.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/drift/{id}/dismiss": {
+      "post": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Dismisses a drift item.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/drift/bulk/apply": {
+      "post": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Applies multiple drift items.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/drift/bulk/dismiss": {
+      "post": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Dismisses multiple drift items.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkDriftActionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/run": {
+      "post": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Triggers a sync now. Returns 409 if a sync is already in progress.",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
+    "/api/ProviderSync/runs": {
+      "get": {
+        "tags": [
+          "ProviderSync"
+        ],
+        "summary": "Lists recent sync runs.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal server error. Returns a standardized ErrorResponseDto."
+          }
+        }
+      }
+    },
     "/api/admin/provider-tools": {
       "get": {
         "tags": [
@@ -14625,6 +14888,19 @@
         },
         "description": "Result of a bulk delete operation"
       },
+      "BulkDriftActionRequest": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        "description": "Request body for bulk apply/dismiss."
+      },
       "BulkMappingResult": {
         "type": "object",
         "properties": {
@@ -15289,6 +15565,20 @@
               "number"
             ],
             "format": "double"
+          },
+          "audioCostPerMinute": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
+          },
+          "audioCostPerThousandCharacters": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
           }
         }
       },
@@ -15328,6 +15618,18 @@
           "supportsVideoGeneration": {
             "type": "boolean",
             "description": "Gets or sets whether the model supports video generation."
+          },
+          "supportsSpeechToText": {
+            "type": "boolean",
+            "description": "Whether the model supports speech-to-text transcription."
+          },
+          "supportsTextToSpeech": {
+            "type": "boolean",
+            "description": "Whether the model supports text-to-speech synthesis."
+          },
+          "supportsRerank": {
+            "type": "boolean",
+            "description": "Whether the model supports document reranking."
           },
           "supportsEmbeddings": {
             "type": "boolean",
@@ -15516,6 +15818,15 @@
           "isEnabled": {
             "type": "boolean",
             "description": "Whether the provider is enabled"
+          },
+          "trustProviderReportedCosts": {
+            "type": "boolean",
+            "description": "When true, the cost the provider reports per request is authoritative for billing\r\n(falls back to ModelCost when no cost is reported). Defaults to false."
+          },
+          "providerCostMarkupMultiplier": {
+            "type": "number",
+            "description": "Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).\r\nOnly consulted when bool CreateProviderRequest.TrustProviderReportedCosts is true.",
+            "format": "double"
           }
         },
         "description": "Request model for creating a provider"
@@ -16915,6 +17226,23 @@
             "type": "number",
             "format": "double"
           },
+          "billingMethod": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RequestBillingMethod"
+              }
+            ]
+          },
+          "providerReportedCostUsd": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
+          },
           "responseTimeMs": {
             "type": "number",
             "format": "double"
@@ -17589,6 +17917,15 @@
           "supportsEmbeddings": {
             "type": "boolean"
           },
+          "supportsSpeechToText": {
+            "type": "boolean"
+          },
+          "supportsTextToSpeech": {
+            "type": "boolean"
+          },
+          "supportsRerank": {
+            "type": "boolean"
+          },
           "supportsChat": {
             "type": "boolean"
           },
@@ -17788,6 +18125,20 @@
               "number"
             ],
             "format": "double"
+          },
+          "audioCostPerMinute": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
+          },
+          "audioCostPerThousandCharacters": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
           }
         }
       },
@@ -17855,6 +18206,18 @@
           "supportsVideoGeneration": {
             "type": "boolean",
             "description": "Gets or sets whether the model supports video generation."
+          },
+          "supportsSpeechToText": {
+            "type": "boolean",
+            "description": "Whether the model supports speech-to-text transcription."
+          },
+          "supportsTextToSpeech": {
+            "type": "boolean",
+            "description": "Whether the model supports text-to-speech synthesis."
+          },
+          "supportsRerank": {
+            "type": "boolean",
+            "description": "Whether the model supports document reranking."
           },
           "supportsEmbeddings": {
             "type": "boolean",
@@ -18057,6 +18420,12 @@
               "string"
             ]
           },
+          "providerOptions": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "capabilities": {
             "oneOf": [
               {
@@ -18217,6 +18586,18 @@
           "supportsVideoGeneration": {
             "type": "boolean",
             "description": "Gets or sets whether the model supports video generation."
+          },
+          "supportsSpeechToText": {
+            "type": "boolean",
+            "description": "Whether the model supports speech-to-text transcription."
+          },
+          "supportsTextToSpeech": {
+            "type": "boolean",
+            "description": "Whether the model supports text-to-speech synthesis."
+          },
+          "supportsRerank": {
+            "type": "boolean",
+            "description": "Whether the model supports document reranking."
           },
           "supportsEmbeddings": {
             "type": "boolean",
@@ -19141,6 +19522,13 @@
               "null",
               "string"
             ]
+          },
+          "requestLogId": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
           }
         }
       },
@@ -19184,6 +19572,13 @@
           },
           "isEnabled": {
             "type": "boolean"
+          },
+          "trustProviderReportedCosts": {
+            "type": "boolean"
+          },
+          "providerCostMarkupMultiplier": {
+            "type": "number",
+            "format": "double"
           },
           "createdAt": {
             "type": "string",
@@ -19649,6 +20044,9 @@
           }
         }
       },
+      "RequestBillingMethod": {
+        "type": "integer"
+      },
       "RequestLog": {
         "required": [
           "modelName",
@@ -19720,6 +20118,23 @@
           },
           "cost": {
             "type": "number",
+            "format": "double"
+          },
+          "billingMethod": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RequestBillingMethod"
+              }
+            ]
+          },
+          "providerReportedCostUsd": {
+            "type": [
+              "null",
+              "number"
+            ],
             "format": "double"
           },
           "responseTimeMs": {
@@ -21017,6 +21432,20 @@
               "number"
             ],
             "format": "double"
+          },
+          "audioCostPerMinute": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
+          },
+          "audioCostPerThousandCharacters": {
+            "type": [
+              "null",
+              "number"
+            ],
+            "format": "double"
           }
         }
       },
@@ -21084,6 +21513,27 @@
               "boolean"
             ],
             "description": "Gets or sets whether the model supports video generation.\nTrue to enable video generation, false to disable, or null to keep existing."
+          },
+          "supportsSpeechToText": {
+            "type": [
+              "null",
+              "boolean"
+            ],
+            "description": "Whether the model supports speech-to-text transcription."
+          },
+          "supportsTextToSpeech": {
+            "type": [
+              "null",
+              "boolean"
+            ],
+            "description": "Whether the model supports text-to-speech synthesis."
+          },
+          "supportsRerank": {
+            "type": [
+              "null",
+              "boolean"
+            ],
+            "description": "Whether the model supports document reranking."
           },
           "supportsEmbeddings": {
             "type": [
@@ -21296,6 +21746,15 @@
           "isEnabled": {
             "type": "boolean",
             "description": "Whether the provider is enabled"
+          },
+          "trustProviderReportedCosts": {
+            "type": "boolean",
+            "description": "When true, the cost the provider reports per request is authoritative for billing\r\n(falls back to ModelCost when no cost is reported). Defaults to false when omitted."
+          },
+          "providerCostMarkupMultiplier": {
+            "type": "number",
+            "description": "Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).\r\nDefaults to 1.0 when omitted, so a partial update never silently zeroes the markup.",
+            "format": "double"
           }
         },
         "description": "Request model for updating a provider"
@@ -22460,6 +22919,9 @@
     },
     {
       "name": "ProviderErrors"
+    },
+    {
+      "name": "ProviderSync"
     },
     {
       "name": "ProviderTools"

--- a/WebAdmin/src/app/media-assets/retention-policies/RetentionPoliciesContent.tsx
+++ b/WebAdmin/src/app/media-assets/retention-policies/RetentionPoliciesContent.tsx
@@ -143,7 +143,7 @@ export default function RetentionPoliciesContent() {
           respectRecentAccess: formData.respectRecentAccess,
           recentAccessWindowDays: formData.recentAccessWindowDays,
           isDefault: formData.isDefault,
-          isActive: formData.isActive,
+          // isActive removed from CreateMediaRetentionPolicyRequest in #1038 (create defaults active)
         };
         await withAdminClient(client =>
           client.media.createRetentionPolicy(createData)

--- a/WebAdmin/src/app/model-costs/add-v2/page.tsx
+++ b/WebAdmin/src/app/model-costs/add-v2/page.tsx
@@ -134,9 +134,13 @@ export default function AddModelCostV2Page() {
   });
 
   const handleSubmit = (values: FormValues) => {
+    // Media/inference pricing (image/video/inference-step/resolution & quality multipliers plus the
+    // per-input/output audio splits) is carried in pricingConfiguration (serialized by the pricing
+    // selector), not as flat fields — those were removed from CreateModelCostDto in #1038. Only the
+    // token/search/batch and top-level audio (per-minute, per-1K-chars) fields remain flat.
     const data: CreateModelCostDto = {
       costName: values.costName,
-      modelProviderMappingIds: values.modelProviderMappingIds,
+      modelProviderTypeAssociationIds: values.modelProviderMappingIds,
       pricingModel: values.pricingModel,
       pricingConfiguration: values.pricingConfiguration || undefined,
       modelType: values.modelType,
@@ -148,19 +152,10 @@ export default function AddModelCostV2Page() {
       cachedInputWriteCostPerMillionTokens: values.cachedInputWriteCostPerMillion || undefined,
       embeddingCostPerMillionTokens: values.embeddingCostPerMillion || undefined,
       costPerSearchUnit: values.searchUnitCostPer1K || undefined,
-      costPerInferenceStep: values.inferenceStepCost || undefined,
-      defaultInferenceSteps: values.defaultInferenceSteps || undefined,
-      imageCostPerImage: values.imageCostPerImage || undefined,
       audioCostPerMinute: values.audioCostPerMinute || undefined,
-      audioCostPerKCharacters: values.audioCostPerKCharacters || undefined,
-      audioInputCostPerMinute: values.audioInputCostPerMinute || undefined,
-      audioOutputCostPerMinute: values.audioOutputCostPerMinute || undefined,
-      videoCostPerSecond: values.videoCostPerSecond || undefined,
-      videoResolutionMultipliers: values.videoResolutionMultipliers || undefined,
-      imageResolutionMultipliers: values.imageResolutionMultipliers || undefined,
+      audioCostPerThousandCharacters: values.audioCostPerKCharacters || undefined,
       supportsBatchProcessing: values.supportsBatchProcessing,
       batchProcessingMultiplier: values.supportsBatchProcessing ? values.batchProcessingMultiplier : undefined,
-      imageQualityMultipliers: values.imageQualityMultipliers || undefined,
     };
 
     createMutation.mutate(data);

--- a/WebAdmin/src/app/model-costs/add/page.tsx
+++ b/WebAdmin/src/app/model-costs/add/page.tsx
@@ -55,9 +55,12 @@ export default function AddModelCostPage() {
   });
 
   const handleSubmit = (values: FormValues) => {
+    // Media/inference pricing (image/video/inference-step/quality multipliers) is no longer sent as
+    // flat fields — those were removed from CreateModelCostDto in #1038 (backend carries them in
+    // pricingConfiguration). This legacy v1 form only submits token/search/batch pricing.
     const data: CreateModelCostDto = {
       costName: values.costName,
-      modelProviderMappingIds: values.modelProviderMappingIds,
+      modelProviderTypeAssociationIds: values.modelProviderMappingIds,
       modelType: values.modelType,
       // Values are already per million tokens
       inputCostPerMillionTokens: values.inputCostPerMillion,
@@ -66,14 +69,8 @@ export default function AddModelCostPage() {
       cachedInputWriteCostPerMillionTokens: values.cachedInputWriteCostPerMillion > 0 ? values.cachedInputWriteCostPerMillion : undefined,
       embeddingCostPerMillionTokens: values.embeddingCostPerMillion > 0 ? values.embeddingCostPerMillion : undefined,
       costPerSearchUnit: values.searchUnitCostPer1K > 0 ? values.searchUnitCostPer1K : undefined,
-      costPerInferenceStep: values.inferenceStepCost > 0 ? values.inferenceStepCost : undefined,
-      defaultInferenceSteps: values.defaultInferenceSteps > 0 ? values.defaultInferenceSteps : undefined,
-      imageCostPerImage: values.imageCostPerImage > 0 ? values.imageCostPerImage : undefined,
-      videoCostPerSecond: values.videoCostPerSecond > 0 ? values.videoCostPerSecond : undefined,
-      videoResolutionMultipliers: values.videoResolutionMultipliers || undefined,
       supportsBatchProcessing: values.supportsBatchProcessing,
       batchProcessingMultiplier: values.supportsBatchProcessing && values.batchProcessingMultiplier > 0 ? values.batchProcessingMultiplier : undefined,
-      imageQualityMultipliers: values.imageQualityMultipliers || undefined,
       priority: values.priority,
       description: values.description || undefined
     };

--- a/WebAdmin/src/app/model-costs/components/CostPreview.tsx
+++ b/WebAdmin/src/app/model-costs/components/CostPreview.tsx
@@ -69,50 +69,9 @@ export const CostPreview: React.FC<CostPreviewProps> = ({ modelCost }) => {
       });
     }
 
-    // Inference steps example
-    if (modelCost.costPerInferenceStep && modelCost.defaultInferenceSteps) {
-      const stepCost = modelCost.costPerInferenceStep * modelCost.defaultInferenceSteps;
-      examples.push({
-        label: `1 image (${modelCost.defaultInferenceSteps} steps)`,
-        cost: stepCost,
-        breakdown: `${modelCost.defaultInferenceSteps} × ${formatCost(modelCost.costPerInferenceStep, 6)}`
-      });
-
-      // Custom step count
-      const customSteps = 50;
-      const customStepCost = modelCost.costPerInferenceStep * customSteps;
-      examples.push({
-        label: `1 image (${customSteps} steps)`,
-        description: 'High quality generation',
-        cost: customStepCost,
-        breakdown: `${customSteps} × ${formatCost(modelCost.costPerInferenceStep, 6)}`
-      });
-    }
-
-    // Image generation example
-    if (modelCost.imageCostPerImage) {
-      examples.push({
-        label: '1 standard image',
-        cost: modelCost.imageCostPerImage
-      });
-
-      // With quality multiplier
-      if (modelCost.imageQualityMultipliers) {
-        try {
-          const multipliers = JSON.parse(modelCost.imageQualityMultipliers) as Record<string, number>;
-          if (multipliers.hd) {
-            examples.push({
-              label: '1 HD image',
-              cost: modelCost.imageCostPerImage * multipliers.hd,
-              breakdown: `${formatCost(modelCost.imageCostPerImage)} × ${multipliers.hd}x`
-            });
-          }
-        } catch (error) {
-          // Skip the multiplier rows; surface that the stored JSON is corrupt
-          console.warn('Failed to parse image quality multipliers for cost preview:', error);
-        }
-      }
-    }
+    // Inference-step, image, and video cost previews were dropped: those flat fields were removed
+    // from ModelCostDto in #1038 and now live only in pricingConfiguration, which this preview does
+    // not parse. Token/search/audio/batch estimates below remain accurate.
 
     // Audio examples
     if (modelCost.audioCostPerMinute) {
@@ -123,20 +82,11 @@ export const CostPreview: React.FC<CostPreviewProps> = ({ modelCost }) => {
       });
     }
 
-    if (modelCost.audioCostPerKCharacters) {
+    if (modelCost.audioCostPerThousandCharacters) {
       examples.push({
         label: '10K characters TTS',
-        cost: modelCost.audioCostPerKCharacters * 10,
-        breakdown: `10 × ${formatCost(modelCost.audioCostPerKCharacters, 2)}/1K chars`
-      });
-    }
-
-    // Video example
-    if (modelCost.videoCostPerSecond) {
-      examples.push({
-        label: '10 second video',
-        cost: modelCost.videoCostPerSecond * 10,
-        breakdown: `10 × ${formatCost(modelCost.videoCostPerSecond, 2)}/sec`
+        cost: modelCost.audioCostPerThousandCharacters * 10,
+        breakdown: `10 × ${formatCost(modelCost.audioCostPerThousandCharacters, 2)}/1K chars`
       });
     }
 

--- a/WebAdmin/src/app/model-costs/components/EditModelCostModal.tsx
+++ b/WebAdmin/src/app/model-costs/components/EditModelCostModal.tsx
@@ -67,14 +67,16 @@ export function EditModelCostModal({ isOpen, modelCost, onClose, onSuccess }: Ed
     cachedInputWriteCostPerMillion: (modelCost.cachedInputWriteCostPerMillionTokens as number) ?? 0,
     embeddingCostPerMillion: (modelCost.embeddingCostPerMillionTokens as number) ?? 0,
     searchUnitCostPer1K: (modelCost.costPerSearchUnit as number) ?? 0,
-    inferenceStepCost: (modelCost.costPerInferenceStep as number) ?? 0,
-    defaultInferenceSteps: (modelCost.defaultInferenceSteps as number) ?? 0,
-    imageCostPerImage: (modelCost.imageCostPerImage as number) ?? 0,
-    videoCostPerSecond: (modelCost.videoCostPerSecond as number) ?? 0,
-    videoResolutionMultipliers: (modelCost.videoResolutionMultipliers as string) ?? '',
+    // Media/inference pricing lives in pricingConfiguration (not parsed by this legacy v1 modal) —
+    // the flat fields were removed from ModelCostDto in #1038, so these form inputs start empty.
+    inferenceStepCost: 0,
+    defaultInferenceSteps: 0,
+    imageCostPerImage: 0,
+    videoCostPerSecond: 0,
+    videoResolutionMultipliers: '',
     supportsBatchProcessing: (modelCost.supportsBatchProcessing) ?? false,
     batchProcessingMultiplier: (modelCost.batchProcessingMultiplier as number) ?? 0.5,
-    imageQualityMultipliers: (modelCost.imageQualityMultipliers as string) ?? '',
+    imageQualityMultipliers: '',
     priority: modelCost.priority,
     description: (modelCost.description as string) ?? '',
     isActive: modelCost.isActive,
@@ -99,7 +101,7 @@ export function EditModelCostModal({ isOpen, modelCost, onClose, onSuccess }: Ed
     const updates: UpdateModelCostDto = {
       id: modelCost.id,
       costName: values.costName,
-      modelProviderMappingIds: values.modelProviderMappingIds
+      modelProviderTypeAssociationIds: values.modelProviderMappingIds
     };
     
     // Values are already per million tokens
@@ -123,42 +125,20 @@ export function EditModelCostModal({ isOpen, modelCost, onClose, onSuccess }: Ed
     if (values.searchUnitCostPer1K !== modelCost.costPerSearchUnit) {
       updates.costPerSearchUnit = values.searchUnitCostPer1K || undefined;
     }
-    
-    if (values.inferenceStepCost !== modelCost.costPerInferenceStep) {
-      updates.costPerInferenceStep = values.inferenceStepCost || undefined;
-    }
-    
-    if (values.defaultInferenceSteps !== modelCost.defaultInferenceSteps) {
-      updates.defaultInferenceSteps = values.defaultInferenceSteps || undefined;
-    }
-    
-    if (values.imageCostPerImage !== modelCost.imageCostPerImage) {
-      updates.imageCostPerImage = values.imageCostPerImage || undefined;
-    }
-    
-    
-    if (values.videoCostPerSecond !== modelCost.videoCostPerSecond) {
-      updates.videoCostPerSecond = values.videoCostPerSecond || undefined;
-    }
-    
-    if (values.videoResolutionMultipliers) {
-      updates.videoResolutionMultipliers = values.videoResolutionMultipliers;
-    }
-    
+
+    // Media/inference pricing (inference-step, image/video, resolution & quality multipliers) is no
+    // longer sent as flat fields — removed from UpdateModelCostDto in #1038 (carried in
+    // pricingConfiguration). This legacy v1 modal only updates token/search/batch pricing.
+
     // Batch processing fields
     if (values.supportsBatchProcessing !== modelCost.supportsBatchProcessing) {
       updates.supportsBatchProcessing = values.supportsBatchProcessing;
     }
-    
+
     if (values.supportsBatchProcessing && values.batchProcessingMultiplier !== modelCost.batchProcessingMultiplier) {
       updates.batchProcessingMultiplier = values.batchProcessingMultiplier || undefined;
     }
-    
-    // Image quality multipliers
-    if (values.imageQualityMultipliers !== modelCost.imageQualityMultipliers) {
-      updates.imageQualityMultipliers = values.imageQualityMultipliers || undefined;
-    }
-    
+
     if (values.priority !== modelCost.priority) {
       updates.priority = values.priority;
     }

--- a/WebAdmin/src/app/model-costs/components/EditModelCostModalV2.tsx
+++ b/WebAdmin/src/app/model-costs/components/EditModelCostModalV2.tsx
@@ -102,19 +102,23 @@ export function EditModelCostModalV2({ isOpen, modelCost, onClose, onSuccess }: 
     cachedInputWriteCostPerMillion: modelCost.cachedInputWriteCostPerMillionTokens ?? 0,
     embeddingCostPerMillion: modelCost.embeddingCostPerMillionTokens ?? 0,
     searchUnitCostPer1K: modelCost.costPerSearchUnit ?? 0,
-    inferenceStepCost: modelCost.costPerInferenceStep ?? 0,
-    defaultInferenceSteps: modelCost.defaultInferenceSteps ?? 0,
-    imageCostPerImage: modelCost.imageCostPerImage ?? 0,
+    // Media/inference pricing (inference-step, image/video, resolution & quality multipliers, and the
+    // per-input/output audio splits) now lives only in pricingConfiguration — the flat fields were
+    // removed from ModelCostDto in #1038. The raw JSON is loaded above into pricingConfiguration; the
+    // individual flat inputs below are not derived from it, so they start empty.
+    inferenceStepCost: 0,
+    defaultInferenceSteps: 0,
+    imageCostPerImage: 0,
     audioCostPerMinute: modelCost.audioCostPerMinute ?? 0,
-    audioCostPerKCharacters: modelCost.audioCostPerKCharacters ?? 0,
-    audioInputCostPerMinute: modelCost.audioInputCostPerMinute ?? 0,
-    audioOutputCostPerMinute: modelCost.audioOutputCostPerMinute ?? 0,
-    videoCostPerSecond: modelCost.videoCostPerSecond ?? 0,
-    videoResolutionMultipliers: modelCost.videoResolutionMultipliers ?? '',
-    imageResolutionMultipliers: modelCost.imageResolutionMultipliers ?? '',
+    audioCostPerKCharacters: modelCost.audioCostPerThousandCharacters ?? 0,
+    audioInputCostPerMinute: 0,
+    audioOutputCostPerMinute: 0,
+    videoCostPerSecond: 0,
+    videoResolutionMultipliers: '',
+    imageResolutionMultipliers: '',
     supportsBatchProcessing: modelCost.supportsBatchProcessing ?? false,
     batchProcessingMultiplier: modelCost.batchProcessingMultiplier ?? 0.5,
-    imageQualityMultipliers: modelCost.imageQualityMultipliers ?? '',
+    imageQualityMultipliers: '',
     priority: modelCost.priority,
     description: modelCost.description ?? '',
     isActive: modelCost.isActive,
@@ -152,10 +156,13 @@ export function EditModelCostModalV2({ isOpen, modelCost, onClose, onSuccess }: 
   });
 
   const handleSubmit = (values: FormValues) => {
+    // Media/inference pricing is serialized into pricingConfiguration (below), not sent as flat
+    // fields — those were removed from UpdateModelCostDto in #1038. Only token/search/batch and the
+    // top-level audio (per-minute, per-1K-chars) fields remain flat.
     const updates: UpdateModelCostDto = {
       id: modelCost.id,
       costName: values.costName,
-      modelProviderMappingIds: values.modelProviderMappingIds,
+      modelProviderTypeAssociationIds: values.modelProviderMappingIds,
       pricingModel: values.pricingModel,
       pricingConfiguration: values.pricingConfiguration || undefined,
       modelType: values.modelType,
@@ -168,19 +175,10 @@ export function EditModelCostModalV2({ isOpen, modelCost, onClose, onSuccess }: 
       cachedInputWriteCostPerMillionTokens: values.cachedInputWriteCostPerMillion || undefined,
       embeddingCostPerMillionTokens: values.embeddingCostPerMillion || undefined,
       costPerSearchUnit: values.searchUnitCostPer1K || undefined,
-      costPerInferenceStep: values.inferenceStepCost || undefined,
-      defaultInferenceSteps: values.defaultInferenceSteps || undefined,
-      imageCostPerImage: values.imageCostPerImage || undefined,
       audioCostPerMinute: values.audioCostPerMinute || undefined,
-      audioCostPerKCharacters: values.audioCostPerKCharacters || undefined,
-      audioInputCostPerMinute: values.audioInputCostPerMinute || undefined,
-      audioOutputCostPerMinute: values.audioOutputCostPerMinute || undefined,
-      videoCostPerSecond: values.videoCostPerSecond || undefined,
-      videoResolutionMultipliers: values.videoResolutionMultipliers || undefined,
-      imageResolutionMultipliers: values.imageResolutionMultipliers || undefined,
+      audioCostPerThousandCharacters: values.audioCostPerKCharacters || undefined,
       supportsBatchProcessing: values.supportsBatchProcessing,
       batchProcessingMultiplier: values.supportsBatchProcessing ? values.batchProcessingMultiplier : undefined,
-      imageQualityMultipliers: values.imageQualityMultipliers || undefined,
     };
 
     updateMutation.mutate(updates);

--- a/WebAdmin/src/app/model-costs/components/ModelCostDisplay.tsx
+++ b/WebAdmin/src/app/model-costs/components/ModelCostDisplay.tsx
@@ -79,39 +79,12 @@ export const ModelCostDisplay: React.FC<ModelCostDisplayProps> = ({
         </Group>
       )}
 
-      {/* Inference steps */}
-      {modelCost.costPerInferenceStep && (
-        <Group gap="xs">
-          <Text size={compact ? 'xs' : 'sm'} c="dimmed">Per Step:</Text>
-          <Text size={compact ? 'xs' : 'sm'} fw={500}>
-            {formatCost(modelCost.costPerInferenceStep, 6)}
-          </Text>
-          {modelCost.defaultInferenceSteps && (
-            <Text size="xs" c="dimmed">
-              (Default: {modelCost.defaultInferenceSteps} steps = {formatCost(
-                modelCost.costPerInferenceStep * modelCost.defaultInferenceSteps
-              )})
-            </Text>
-          )}
-        </Group>
-      )}
-
-      {/* Image cost */}
-      {modelCost.imageCostPerImage && (
-        <Group gap="xs">
-          <Text size={compact ? 'xs' : 'sm'} c="dimmed">Per Image:</Text>
-          <Text size={compact ? 'xs' : 'sm'} fw={500}>
-            {formatCost(modelCost.imageCostPerImage, 2)}
-          </Text>
-          {modelCost.imageQualityMultipliers && modelCost.imageQualityMultipliers !== '{}' && (
-            <Badge size="xs" variant="light" color="orange">Quality tiers</Badge>
-          )}
-        </Group>
-      )}
+      {/* Inference-step, image, and video pricing (plus the per-input/output audio splits) were
+          removed from ModelCostDto in #1038; they now live in pricingConfiguration, which this
+          summary does not parse, so those rows are omitted here. */}
 
       {/* Audio costs */}
-      {(modelCost.audioCostPerMinute ?? modelCost.audioCostPerKCharacters ?? 
-        modelCost.audioInputCostPerMinute ?? modelCost.audioOutputCostPerMinute) && (
+      {(modelCost.audioCostPerMinute ?? modelCost.audioCostPerThousandCharacters) && (
         <>
           {modelCost.audioCostPerMinute && (
             <Group gap="xs">
@@ -121,44 +94,15 @@ export const ModelCostDisplay: React.FC<ModelCostDisplayProps> = ({
               </Text>
             </Group>
           )}
-          {modelCost.audioCostPerKCharacters && (
+          {modelCost.audioCostPerThousandCharacters && (
             <Group gap="xs">
               <Text size={compact ? 'xs' : 'sm'} c="dimmed">Audio (TTS):</Text>
               <Text size={compact ? 'xs' : 'sm'} fw={500}>
-                {formatCost(modelCost.audioCostPerKCharacters, 2)}/1K chars
-              </Text>
-            </Group>
-          )}
-          {modelCost.audioInputCostPerMinute && (
-            <Group gap="xs">
-              <Text size={compact ? 'xs' : 'sm'} c="dimmed">Transcription:</Text>
-              <Text size={compact ? 'xs' : 'sm'} fw={500}>
-                {formatCost(modelCost.audioInputCostPerMinute, 2)}/minute
-              </Text>
-            </Group>
-          )}
-          {modelCost.audioOutputCostPerMinute && (
-            <Group gap="xs">
-              <Text size={compact ? 'xs' : 'sm'} c="dimmed">Speech:</Text>
-              <Text size={compact ? 'xs' : 'sm'} fw={500}>
-                {formatCost(modelCost.audioOutputCostPerMinute, 2)}/minute
+                {formatCost(modelCost.audioCostPerThousandCharacters, 2)}/1K chars
               </Text>
             </Group>
           )}
         </>
-      )}
-
-      {/* Video cost */}
-      {modelCost.videoCostPerSecond && (
-        <Group gap="xs">
-          <Text size={compact ? 'xs' : 'sm'} c="dimmed">Video:</Text>
-          <Text size={compact ? 'xs' : 'sm'} fw={500}>
-            {formatCost(modelCost.videoCostPerSecond, 2)}/second
-          </Text>
-          {modelCost.videoResolutionMultipliers && modelCost.videoResolutionMultipliers !== '{}' && (
-            <Badge size="xs" variant="light" color="pink">Resolution tiers</Badge>
-          )}
-        </Group>
       )}
 
       {/* Batch processing */}

--- a/WebAdmin/src/app/model-costs/components/ModelCostsTable.tsx
+++ b/WebAdmin/src/app/model-costs/components/ModelCostsTable.tsx
@@ -173,27 +173,9 @@ export function ModelCostsTable({ onRefresh, hasProviders, hasModelMappings }: M
         </Stack>
       );
     }
-    if (cost.imageCostPerImage !== undefined) {
-      const hasMultipliers = cost.imageQualityMultipliers && 
-        cost.imageQualityMultipliers !== '{}';
-      
-      return (
-        <Group gap="xs">
-          <Text size="xs">{formatters.currency(cost.imageCostPerImage, { currency: 'USD' })}/image</Text>
-          {hasMultipliers && (
-            <Tooltip label="Has quality multipliers">
-              <IconAdjustments size={14} />
-            </Tooltip>
-          )}
-        </Group>
-      );
-    }
-    if (cost.imageCostPerImage !== undefined) {
-      return <Text size="xs">{formatters.currency(cost.imageCostPerImage, { currency: 'USD' })}/image</Text>;
-    }
-    if (cost.videoCostPerSecond !== undefined) {
-      return <Text size="xs">{formatters.currency(cost.videoCostPerSecond, { currency: 'USD' })}/second</Text>;
-    }
+    // Image, video, and inference-step pricing were removed from ModelCostDto as flat fields in
+    // #1038 (now carried in pricingConfiguration, which this table does not parse). Those summary
+    // branches are dropped; the pricingConfiguration fallback below flags such rows as configured.
     if (cost.costPerSearchUnit !== undefined) {
       return (
         <Stack gap={2}>
@@ -204,17 +186,8 @@ export function ModelCostsTable({ onRefresh, hasProviders, hasModelMappings }: M
         </Stack>
       );
     }
-    if (cost.costPerInferenceStep !== undefined) {
-      return (
-        <Stack gap={2}>
-          <Text size="xs">
-            Steps: {formatters.currency(cost.costPerInferenceStep, { currency: 'USD', precision: 4 })}/step
-          </Text>
-          {cost.defaultInferenceSteps && (
-            <Badge size="xs" variant="light" color="teal">Default: {cost.defaultInferenceSteps} steps</Badge>
-          )}
-        </Stack>
-      );
+    if (cost.pricingConfiguration && cost.pricingConfiguration !== '{}') {
+      return <Badge size="xs" variant="light" color="teal">Configured</Badge>;
     }
     return <Text size="xs" c="dimmed">No pricing set</Text>;
   };
@@ -369,11 +342,8 @@ export function ModelCostsTable({ onRefresh, hasProviders, hasModelMappings }: M
                               <IconSearch size={14} style={{ opacity: 0.7 }} />
                             </Tooltip>
                           )}
-                          {cost.costPerInferenceStep && (
-                            <Tooltip label="Step-based pricing">
-                              <IconStairs size={14} style={{ opacity: 0.7 }} />
-                            </Tooltip>
-                          )}
+                          {/* Step-based pricing indicator removed: costPerInferenceStep is no longer
+                              a flat field on ModelCostDto (#1038); it lives in pricingConfiguration. */}
                         </Group>
                       </Table.Td>
                       <Table.Td>

--- a/WebAdmin/src/app/model-costs/components/ViewModelCostModal.tsx
+++ b/WebAdmin/src/app/model-costs/components/ViewModelCostModal.tsx
@@ -20,8 +20,6 @@ import {
   IconVectorBezier,
   IconCurrencyDollar,
   IconDatabase,
-  IconStairs,
-  IconAdjustments,
 } from '@tabler/icons-react';
 import { ModelCost } from '../types/modelCost';
 import { ModelType } from '@knn_labs/conduit-admin-client';
@@ -162,121 +160,29 @@ function EmbeddingPricingSection({ modelCost }: { modelCost: ModelCost }) {
 }
 
 function ImagePricingSection({ modelCost }: { modelCost: ModelCost }) {
-  const hasPerImageCost = modelCost.imageCostPerImage !== undefined;
-  const hasStepCost = modelCost.costPerInferenceStep !== undefined;
-  const hasMultipliers = modelCost.imageQualityMultipliers ?? modelCost.imageResolutionMultipliers;
-
-  if (!hasPerImageCost && !hasStepCost) {
-    return (
-      <Text size="sm" c="dimmed" ta="center" py="md">
-        No pricing configured
-      </Text>
-    );
-  }
-
-  // Parse multipliers if they exist
-  let qualityMultipliers: Record<string, number> | null = null;
-  let resolutionMultipliers: Record<string, number> | null = null;
-
-  try {
-    if (modelCost.imageQualityMultipliers && modelCost.imageQualityMultipliers !== '{}') {
-      qualityMultipliers = JSON.parse(modelCost.imageQualityMultipliers) as Record<string, number>;
-    }
-    if (modelCost.imageResolutionMultipliers && modelCost.imageResolutionMultipliers !== '{}') {
-      resolutionMultipliers = JSON.parse(modelCost.imageResolutionMultipliers) as Record<string, number>;
-    }
-  } catch (error) {
-    // Multipliers stay null; surface that the stored JSON is corrupt
-    console.warn('Failed to parse image multipliers for model cost:', error);
-  }
+  // Flat image pricing fields (imageCostPerImage, costPerInferenceStep, defaultInferenceSteps,
+  // image quality/resolution multipliers) were removed from ModelCostDto in #1038 — image pricing
+  // now lives in pricingConfiguration, which this read-only view does not decode.
+  const hasConfig = modelCost.pricingConfiguration !== undefined &&
+    modelCost.pricingConfiguration !== '' && modelCost.pricingConfiguration !== '{}';
 
   return (
-    <Stack gap="md">
-      {hasPerImageCost && (
-        <Card withBorder>
-          <Group gap="xs" mb="sm">
-            <IconCurrencyDollar size={16} />
-            <Text size="sm" fw={600}>Per Image Pricing</Text>
-          </Group>
-          <PricingRow label="Base Cost" value={modelCost.imageCostPerImage} unit="per image" />
-        </Card>
-      )}
-
-      {hasStepCost && (
-        <Card withBorder>
-          <Group gap="xs" mb="sm">
-            <IconStairs size={16} />
-            <Text size="sm" fw={600}>Step-Based Pricing</Text>
-          </Group>
-          <Stack gap="xs">
-            <PricingRow label="Per Step" value={modelCost.costPerInferenceStep} unit="per step" />
-            {modelCost.defaultInferenceSteps && (
-              <Group justify="space-between">
-                <Text size="sm">Default Steps</Text>
-                <Text fw={500}>{modelCost.defaultInferenceSteps}</Text>
-              </Group>
-            )}
-            {modelCost.defaultInferenceSteps && modelCost.costPerInferenceStep && (
-              <Group justify="space-between">
-                <Text size="sm">Typical Image Cost</Text>
-                <Text fw={500}>
-                  {formatters.currency(
-                    modelCost.defaultInferenceSteps * modelCost.costPerInferenceStep,
-                    { currency: 'USD', precision: 4 }
-                  )}
-                </Text>
-              </Group>
-            )}
-          </Stack>
-          <Text size="xs" c="dimmed" mt="xs">
-            For diffusion models with configurable inference steps
-          </Text>
-        </Card>
-      )}
-
-      {hasMultipliers && (
-        <Card withBorder>
-          <Group gap="xs" mb="sm">
-            <IconAdjustments size={16} />
-            <Text size="sm" fw={600}>Pricing Multipliers</Text>
-          </Group>
-          <SimpleGrid cols={2} spacing="md">
-            {qualityMultipliers && Object.keys(qualityMultipliers).length > 0 && (
-              <Stack gap="xs">
-                <Text size="xs" c="dimmed">Quality</Text>
-                {Object.entries(qualityMultipliers).map(([quality, multiplier]) => (
-                  <Group key={quality} justify="space-between">
-                    <Text size="sm" tt="capitalize">{quality}</Text>
-                    <Badge size="sm" variant="light">{multiplier}x</Badge>
-                  </Group>
-                ))}
-              </Stack>
-            )}
-            {resolutionMultipliers && Object.keys(resolutionMultipliers).length > 0 && (
-              <Stack gap="xs">
-                <Text size="xs" c="dimmed">Resolution</Text>
-                {Object.entries(resolutionMultipliers).map(([resolution, multiplier]) => (
-                  <Group key={resolution} justify="space-between">
-                    <Text size="sm">{resolution}</Text>
-                    <Badge size="sm" variant="light">{multiplier}x</Badge>
-                  </Group>
-                ))}
-              </Stack>
-            )}
-          </SimpleGrid>
-        </Card>
-      )}
-    </Stack>
+    <Text size="sm" c="dimmed" ta="center" py="md">
+      {hasConfig
+        ? 'Image pricing is defined in the pricing configuration.'
+        : 'No pricing configured'}
+    </Text>
   );
 }
 
 function AudioPricingSection({ modelCost }: { modelCost: ModelCost }) {
   const hasMinuteCost = modelCost.audioCostPerMinute !== undefined;
-  const hasCharacterCost = modelCost.audioCostPerKCharacters !== undefined;
-  const hasInputOutputCosts = modelCost.audioInputCostPerMinute !== undefined ||
-                              modelCost.audioOutputCostPerMinute !== undefined;
+  const hasCharacterCost = modelCost.audioCostPerThousandCharacters !== undefined;
+  // The per-input/output audio splits (audioInputCostPerMinute/audioOutputCostPerMinute) were
+  // removed from ModelCostDto in #1038; only the top-level per-minute and per-1K-character rates
+  // remain flat (any split pricing lives in pricingConfiguration).
 
-  if (!hasMinuteCost && !hasCharacterCost && !hasInputOutputCosts) {
+  if (!hasMinuteCost && !hasCharacterCost) {
     return (
       <Text size="sm" c="dimmed" ta="center" py="md">
         No pricing configured
@@ -296,19 +202,6 @@ function AudioPricingSection({ modelCost }: { modelCost: ModelCost }) {
         </Card>
       )}
 
-      {hasInputOutputCosts && (
-        <Card withBorder>
-          <Group gap="xs" mb="sm">
-            <IconCurrencyDollar size={16} />
-            <Text size="sm" fw={600}>Input/Output Pricing</Text>
-          </Group>
-          <Stack gap="xs">
-            <PricingRow label="Input (STT)" value={modelCost.audioInputCostPerMinute} unit="per minute" />
-            <PricingRow label="Output (TTS)" value={modelCost.audioOutputCostPerMinute} unit="per minute" />
-          </Stack>
-        </Card>
-      )}
-
       {hasCharacterCost && (
         <Card withBorder>
           <Group gap="xs" mb="sm">
@@ -316,7 +209,7 @@ function AudioPricingSection({ modelCost }: { modelCost: ModelCost }) {
             <Text size="sm" fw={600}>Character-Based Pricing</Text>
             <Badge size="xs" variant="light">TTS</Badge>
           </Group>
-          <PricingRow label="Characters" value={modelCost.audioCostPerKCharacters} unit="per 1K chars" />
+          <PricingRow label="Characters" value={modelCost.audioCostPerThousandCharacters} unit="per 1K chars" />
         </Card>
       )}
     </Stack>
@@ -324,54 +217,18 @@ function AudioPricingSection({ modelCost }: { modelCost: ModelCost }) {
 }
 
 function VideoPricingSection({ modelCost }: { modelCost: ModelCost }) {
-  const hasVideoCost = modelCost.videoCostPerSecond !== undefined;
-
-  // Parse resolution multipliers if they exist
-  let resolutionMultipliers: Record<string, number> | null = null;
-  try {
-    if (modelCost.videoResolutionMultipliers && modelCost.videoResolutionMultipliers !== '{}') {
-      resolutionMultipliers = JSON.parse(modelCost.videoResolutionMultipliers) as Record<string, number>;
-    }
-  } catch (error) {
-    // Multipliers stay null; surface that the stored JSON is corrupt
-    console.warn('Failed to parse video resolution multipliers for model cost:', error);
-  }
-
-  if (!hasVideoCost) {
-    return (
-      <Text size="sm" c="dimmed" ta="center" py="md">
-        No pricing configured
-      </Text>
-    );
-  }
+  // Flat video pricing fields (videoCostPerSecond, videoResolutionMultipliers) were removed from
+  // ModelCostDto in #1038 — video pricing now lives in pricingConfiguration, which this read-only
+  // view does not decode.
+  const hasConfig = modelCost.pricingConfiguration !== undefined &&
+    modelCost.pricingConfiguration !== '' && modelCost.pricingConfiguration !== '{}';
 
   return (
-    <Stack gap="md">
-      <Card withBorder>
-        <Group gap="xs" mb="sm">
-          <IconCurrencyDollar size={16} />
-          <Text size="sm" fw={600}>Per Second Pricing</Text>
-        </Group>
-        <PricingRow label="Video" value={modelCost.videoCostPerSecond} unit="per second" />
-      </Card>
-
-      {resolutionMultipliers && Object.keys(resolutionMultipliers).length > 0 && (
-        <Card withBorder>
-          <Group gap="xs" mb="sm">
-            <IconAdjustments size={16} />
-            <Text size="sm" fw={600}>Resolution Multipliers</Text>
-          </Group>
-          <Stack gap="xs">
-            {Object.entries(resolutionMultipliers).map(([resolution, multiplier]) => (
-              <Group key={resolution} justify="space-between">
-                <Text size="sm">{resolution}</Text>
-                <Badge size="sm" variant="light">{multiplier}x</Badge>
-              </Group>
-            ))}
-          </Stack>
-        </Card>
-      )}
-    </Stack>
+    <Text size="sm" c="dimmed" ta="center" py="md">
+      {hasConfig
+        ? 'Video pricing is defined in the pricing configuration.'
+        : 'No pricing configured'}
+    </Text>
   );
 }
 

--- a/WebAdmin/src/app/system-info/SystemDependenciesTab.tsx
+++ b/WebAdmin/src/app/system-info/SystemDependenciesTab.tsx
@@ -42,7 +42,7 @@ export function SystemDependenciesTab({ systemInfo }: SystemDependenciesTabProps
               <Table.Td>
                 <Code>Conduit Core</Code>
               </Table.Td>
-              <Table.Td>{systemInfo?.version ?? 'Unknown'}</Table.Td>
+              <Table.Td>{systemInfo?.version?.appVersion ?? 'Unknown'}</Table.Td>
               <Table.Td>
                 <Badge variant="light" color="green">
                   Current
@@ -53,7 +53,7 @@ export function SystemDependenciesTab({ systemInfo }: SystemDependenciesTabProps
               <Table.Td>
                 <Code>.NET Runtime</Code>
               </Table.Td>
-              <Table.Td>{systemInfo?.runtime?.dotnetVersion ?? 'Unknown'}</Table.Td>
+              <Table.Td>{systemInfo?.runtime?.runtimeVersion ?? 'Unknown'}</Table.Td>
               <Table.Td>
                 <Badge variant="light" color="green">
                   Runtime
@@ -68,9 +68,9 @@ export function SystemDependenciesTab({ systemInfo }: SystemDependenciesTabProps
               <Table.Td>
                 <Badge 
                   variant="light" 
-                  color={systemInfo?.database?.isConnected ? 'green' : 'red'}
+                  color={systemInfo?.database?.connected ? 'green' : 'red'}
                 >
-                  {systemInfo?.database?.isConnected ? 'Connected' : 'Disconnected'}
+                  {systemInfo?.database?.connected ? 'Connected' : 'Disconnected'}
                 </Badge>
               </Table.Td>
             </Table.Tr>

--- a/WebAdmin/src/app/system-info/SystemEnvironmentTab.tsx
+++ b/WebAdmin/src/app/system-info/SystemEnvironmentTab.tsx
@@ -8,7 +8,6 @@ import {
   Code,
   Alert,
   ScrollArea,
-  Stack,
 } from '@mantine/core';
 import { IconLock } from '@tabler/icons-react';
 import { SystemInfoDto } from '@knn_labs/conduit-admin-client';
@@ -41,10 +40,23 @@ export function SystemEnvironmentTab({ systemInfo }: SystemEnvironmentTabProps) 
           <Table.Tbody>
             <Table.Tr>
               <Table.Td>
-                <Code>Environment</Code>
+                <Code>Operating System</Code>
               </Table.Td>
               <Table.Td>
-                <Code>{systemInfo?.environment ?? 'Unknown'}</Code>
+                <Code>{systemInfo?.operatingSystem?.description ?? 'Unknown'}</Code>
+              </Table.Td>
+              <Table.Td>
+                <Badge variant="light" size="sm" color="blue">
+                  System
+                </Badge>
+              </Table.Td>
+            </Table.Tr>
+            <Table.Tr>
+              <Table.Td>
+                <Code>Architecture</Code>
+              </Table.Td>
+              <Table.Td>
+                <Code>{systemInfo?.operatingSystem?.architecture ?? 'Unknown'}</Code>
               </Table.Td>
               <Table.Td>
                 <Badge variant="light" size="sm" color="blue">
@@ -57,7 +69,7 @@ export function SystemEnvironmentTab({ systemInfo }: SystemEnvironmentTabProps) 
                 <Code>Build Date</Code>
               </Table.Td>
               <Table.Td>
-                <Code>{systemInfo?.buildDate ? new Date(systemInfo.buildDate).toLocaleDateString() : 'Unknown'}</Code>
+                <Code>{systemInfo?.version?.buildDate ? new Date(systemInfo.version.buildDate).toLocaleDateString() : 'Unknown'}</Code>
               </Table.Td>
               <Table.Td>
                 <Badge variant="light" size="sm" color="blue">
@@ -67,74 +79,30 @@ export function SystemEnvironmentTab({ systemInfo }: SystemEnvironmentTabProps) 
             </Table.Tr>
             <Table.Tr>
               <Table.Td>
-                <Code>IP Filtering</Code>
+                <Code>Database Version</Code>
               </Table.Td>
               <Table.Td>
-                <Code>{systemInfo?.features?.ipFiltering ? 'Enabled' : 'Disabled'}</Code>
+                <Code>{systemInfo?.database?.version ?? 'Unknown'}</Code>
               </Table.Td>
               <Table.Td>
-                <Badge 
-                  variant="light" 
-                  size="sm" 
-                  color={systemInfo?.features?.ipFiltering ? 'green' : 'gray'}
-                >
-                  Feature
+                <Badge variant="light" size="sm" color="blue">
+                  Database
                 </Badge>
               </Table.Td>
             </Table.Tr>
             <Table.Tr>
               <Table.Td>
-                <Code>Cost Tracking</Code>
+                <Code>Database Tables</Code>
               </Table.Td>
               <Table.Td>
-                <Code>{systemInfo?.features?.costTracking ? 'Enabled' : 'Disabled'}</Code>
+                <Code>{systemInfo?.database?.tableCount ?? 'Unknown'}</Code>
               </Table.Td>
               <Table.Td>
-                <Badge 
-                  variant="light" 
-                  size="sm" 
-                  color={systemInfo?.features?.costTracking ? 'green' : 'gray'}
-                >
-                  Feature
+                <Badge variant="light" size="sm" color="blue">
+                  Database
                 </Badge>
               </Table.Td>
             </Table.Tr>
-            <Table.Tr>
-              <Table.Td>
-                <Code>Audio Support</Code>
-              </Table.Td>
-              <Table.Td>
-                <Code>{systemInfo?.features?.audioSupport ? 'Enabled' : 'Disabled'}</Code>
-              </Table.Td>
-              <Table.Td>
-                <Badge 
-                  variant="light" 
-                  size="sm" 
-                  color={systemInfo?.features?.audioSupport ? 'green' : 'gray'}
-                >
-                  Feature
-                </Badge>
-              </Table.Td>
-            </Table.Tr>
-            {systemInfo?.database?.pendingMigrations && Array.isArray(systemInfo.database.pendingMigrations) && systemInfo.database.pendingMigrations.length > 0 && (
-              <Table.Tr>
-                <Table.Td>
-                  <Code>Pending Migrations</Code>
-                </Table.Td>
-                <Table.Td>
-                  <Stack gap="xs">
-                    {systemInfo.database.pendingMigrations.map((migration) => (
-                      <Code key={migration}>{String(migration)}</Code>
-                    ))}
-                  </Stack>
-                </Table.Td>
-                <Table.Td>
-                  <Badge variant="light" size="sm" color="orange">
-                    Database
-                  </Badge>
-                </Table.Td>
-              </Table.Tr>
-            )}
           </Table.Tbody>
         </Table>
       </ScrollArea>

--- a/WebAdmin/src/app/system-info/helpers.ts
+++ b/WebAdmin/src/app/system-info/helpers.ts
@@ -20,23 +20,6 @@ export interface ServiceInfo {
   cpu?: string;
 }
 
-// Helper function to format uptime from seconds
-export const formatUptime = (uptimeSeconds: number): string => {
-  if (!uptimeSeconds) return 'Unknown';
-  
-  const days = Math.floor(uptimeSeconds / 86400);
-  const hours = Math.floor((uptimeSeconds % 86400) / 3600);
-  const minutes = Math.floor((uptimeSeconds % 3600) / 60);
-  
-  if (days > 0) {
-    return `${days}d ${hours}h ${minutes}m`;
-  } else if (hours > 0) {
-    return `${hours}h ${minutes}m`;
-  } else {
-    return `${minutes}m`;
-  }
-};
-
 // Generate system metrics from real data
 export const generateSystemMetrics = (
   systemInfo: SystemInfoDto | null,
@@ -44,11 +27,11 @@ export const generateSystemMetrics = (
 ): SystemMetric[] => {
   const systemMetrics: SystemMetric[] = [];
 
-  if (systemInfo?.database?.isConnected !== undefined) {
+  if (systemInfo?.database?.connected !== undefined) {
     systemMetrics.push({
       name: 'Database Status',
-      value: systemInfo.database.isConnected ? 'Connected' : 'Disconnected',
-      status: systemInfo.database.isConnected ? 'healthy' : 'critical',
+      value: systemInfo.database.connected ? 'Connected' : 'Disconnected',
+      status: systemInfo.database.connected ? 'healthy' : 'critical',
       description: `Provider: ${systemInfo.database.provider ?? 'Unknown'}`
     });
   }
@@ -75,16 +58,17 @@ export const generateServiceInfo = (systemInfo: SystemInfoDto | null): ServiceIn
   if (systemInfo) {
     services.push({
       name: 'Conduit Gateway API',
-      version: systemInfo.version ?? 'Unknown',
+      version: systemInfo.version?.appVersion ?? 'Unknown',
       status: 'running',
-      uptime: formatUptime(systemInfo.uptime ?? 0)
+      // runtime.uptime is now a preformatted string (.NET TimeSpan) — display as-is
+      uptime: systemInfo.runtime?.uptime ?? 'Unknown'
     });
-    
-    if (systemInfo.database?.isConnected) {
+
+    if (systemInfo.database?.connected) {
       services.push({
         name: systemInfo.database.provider ?? 'Database',
         version: 'Unknown',
-        status: systemInfo.database.isConnected ? 'running' : 'stopped'
+        status: systemInfo.database.connected ? 'running' : 'stopped'
       });
     }
   }

--- a/WebAdmin/src/app/system-info/page.tsx
+++ b/WebAdmin/src/app/system-info/page.tsx
@@ -30,7 +30,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { notify } from '@/lib/notifications';
 import { SystemInfoDto, LLMCacheControlDto, GlobalSettingDto, GlobalSettingCacheStats } from '@knn_labs/conduit-admin-client';
 import { withAdminClient } from '@/lib/client/adminClient';
-import { formatUptime } from './helpers';
 import { SystemOverviewTab } from './SystemOverviewTab';
 import { SystemServicesTab } from './SystemServicesTab';
 import { SystemEnvironmentTab } from './SystemEnvironmentTab';
@@ -347,10 +346,10 @@ export default function SystemInfoPage() {
                 Platform
               </Text>
               <Text size="xl" fw={700} mt={4}>
-                {systemInfo?.runtime?.os ?? 'Unknown'}
+                {systemInfo?.operatingSystem?.description ?? 'Unknown'}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
-                {systemInfo?.runtime?.architecture ?? 'Unknown Architecture'}
+                {systemInfo?.operatingSystem?.architecture ?? 'Unknown Architecture'}
               </Text>
             </div>
             <ThemeIcon color="blue" variant="light" size={48} radius="md">
@@ -366,10 +365,10 @@ export default function SystemInfoPage() {
                 .NET Runtime
               </Text>
               <Text size="xl" fw={700} mt={4}>
-                {systemInfo?.runtime?.dotnetVersion ?? 'Unknown'}
+                {systemInfo?.runtime?.runtimeVersion ?? 'Unknown'}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
-                Environment: {systemInfo?.environment ?? 'Unknown'}
+                OS: {systemInfo?.operatingSystem?.description ?? 'Unknown'}
               </Text>
             </div>
             <ThemeIcon color="green" variant="light" size={48} radius="md">
@@ -385,10 +384,10 @@ export default function SystemInfoPage() {
                 System Uptime
               </Text>
               <Text size="xl" fw={700} mt={4}>
-                {systemInfo?.uptime ? formatUptime(systemInfo.uptime) : 'Unknown'}
+                {systemInfo?.runtime?.uptime ?? 'Unknown'}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
-                Version: {systemInfo?.version ?? 'Unknown'}
+                Version: {systemInfo?.version?.appVersion ?? 'Unknown'}
               </Text>
             </div>
             <ThemeIcon color="teal" variant="light" size={48} radius="md">
@@ -404,14 +403,14 @@ export default function SystemInfoPage() {
                 Database
               </Text>
               <Text size="xl" fw={700} mt={4}>
-                {systemInfo?.database?.isConnected ? 'Connected' : 'Disconnected'}
+                {systemInfo?.database?.connected ? 'Connected' : 'Disconnected'}
               </Text>
               <Text size="xs" c="dimmed" mt={4}>
                 {systemInfo?.database?.provider ?? 'Unknown Provider'}
               </Text>
             </div>
             <ThemeIcon 
-              color={systemInfo?.database?.isConnected ? 'green' : 'red'} 
+              color={systemInfo?.database?.connected ? 'green' : 'red'} 
               variant="light" 
               size={48} 
               radius="md"

--- a/WebAdmin/src/components/ip-filtering/IpTestModal.tsx
+++ b/WebAdmin/src/components/ip-filtering/IpTestModal.tsx
@@ -73,34 +73,12 @@ export function IpTestModal({ opened, onClose }: IpTestModalProps) {
         client.ipFilters.checkIp(values.ipAddress)
       );
 
-      // Convert IpCheckResult to TestResult format
+      // Convert IpCheckResult to TestResult format. The API now returns only allow/deny + reason;
+      // matched-filter enrichment was removed from IpCheckResult in #1038.
       const testResult: TestResult = {
         allowed: result.isAllowed,
         reason: result.deniedReason ?? (result.isAllowed ? 'IP address is allowed' : 'IP address is blocked'),
       };
-
-      // If there's a matched filter, add rule details
-      if (result.matchedFilter && result.matchedFilterId) {
-        try {
-          const filter = await withAdminClient(client =>
-            client.ipFilters.getById(result.matchedFilterId as number)
-          );
-          
-          testResult.matchedRule = {
-            id: filter.id.toString(),
-            ipAddress: filter.ipAddressOrCidr,
-            action: filter.filterType === 'whitelist' ? 'allow' : 'block',
-            description: filter.description,
-          };
-        } catch {
-          // If we can't get the filter details, just use the basic info
-          testResult.matchedRule = {
-            id: result.matchedFilterId.toString(),
-            ipAddress: result.matchedFilter,
-            action: result.filterType === 'whitelist' ? 'allow' : 'block',
-          };
-        }
-      }
 
       setTestResult(testResult);
     } catch (error) {

--- a/WebAdmin/src/components/models/ModelCostEditorModal.tsx
+++ b/WebAdmin/src/components/models/ModelCostEditorModal.tsx
@@ -205,7 +205,7 @@ export function ModelCostEditorModal({
             pricingConfiguration: values.pricingModel !== PricingModel.Standard ? values.pricingConfiguration : undefined,
             supportsBatchProcessing: values.supportsBatchProcessing,
             batchProcessingMultiplier: values.supportsBatchProcessing && values.batchProcessingMultiplier > 0 ? values.batchProcessingMultiplier : undefined,
-            modelProviderMappingIds: values.modelProviderMappingIds,
+            modelProviderTypeAssociationIds: values.modelProviderMappingIds,
           };
 
           await executeWithAdmin(client =>
@@ -228,7 +228,7 @@ export function ModelCostEditorModal({
             pricingConfiguration: values.pricingModel !== PricingModel.Standard ? values.pricingConfiguration : undefined,
             supportsBatchProcessing: values.supportsBatchProcessing,
             batchProcessingMultiplier: values.supportsBatchProcessing && values.batchProcessingMultiplier > 0 ? values.batchProcessingMultiplier : undefined,
-            modelProviderMappingIds: values.modelProviderMappingIds,
+            modelProviderTypeAssociationIds: values.modelProviderMappingIds,
           };
 
           await executeWithAdmin(client =>

--- a/WebAdmin/src/hooks/useSecurityApi.ts
+++ b/WebAdmin/src/hooks/useSecurityApi.ts
@@ -40,8 +40,9 @@ function ipFilterToLegacyRule(filter: IpFilterDto): IpRule {
     description: filter.description,
     createdAt: filter.createdAt,
     isEnabled: filter.isEnabled,
-    lastMatchedAt: filter.lastMatchedAt,
-    matchCount: filter.matchCount,
+    // lastMatchedAt/matchCount are no longer tracked server-side (removed from IpFilterDto in #1038)
+    lastMatchedAt: undefined,
+    matchCount: undefined,
   };
 }
 
@@ -186,7 +187,8 @@ export function useSecurityApi() {
         allowRules: filters.filter(f => f.filterType === 'whitelist').length,
         blockRules: filters.filter(f => f.filterType === 'blacklist').length,
         activeRules: filters.filter(f => f.isEnabled).length,
-        blockedRequests24h: filters.reduce((sum, f) => sum + (f.matchCount ?? 0), 0),
+        // Per-filter match counts are no longer tracked server-side (removed in #1038)
+        blockedRequests24h: 0,
         lastRuleUpdate: filters.length > 0 ?
           Math.max(...filters.map(f => new Date(f.updatedAt).getTime())).toString() :
           null,


### PR DESCRIPTION
Closes #1038.

Resolves all 24 pre-existing drifted Admin SDK model types cataloged in #1038 and adds them to the compile-time drift gate (`SDKs/Node/Admin/src/type-tests/admin-api-compat.ts`: **44 → 63 assertions**), so they can never silently drift again.

## How the 24 were resolved

**19 aligned to the wire shape + asserted**, including the **ModelCostDto family** — dropped ~10 flat image/video/inference cost fields the backend never served (that pricing lives in the polymorphic `pricingConfiguration` JSON), renamed `modelProviderMappingIds` → `modelProviderTypeAssociationIds` and `audioCostPerKCharacters` → `audioCostPerThousandCharacters`.

**2 false pairings renamed** to client-abstraction names (they transform the wire response, so no wire pairing):
- `ServiceStatusDto` → `ServiceStatusMapDto`
- `SystemMetricsDto` → `SystemResourceMetricsDto`

**3 documented in the gate header as unassertable:**
- `UpdateCacheConfigDto` / `UpdateCachePolicyDto` — backend DTOs exist under `ConduitLLM.Configuration.DTOs.Cache` but no annotated endpoint surfaces them, so there is no wire schema to compare against.
- `ExportFormat` — no named hand-written type exists in the SDK to pair with the wire enum.

## Spec regeneration (Step 0)

Regenerated `openapi-admin.json` + `admin-api.ts` from the current backend via `npm run generate:admin:offline`. This surfaced that **dev's committed spec was stale** — the backend had grown a `/api/ProviderSync/drift` controller and `ModelCapabilitiesDto` had gained `supportsSpeechToText`/`supportsTextToSpeech`/`supportsRerank`. Both are reconciled here. The regeneration is deterministic (re-run produces byte-identical files → the CI drift gate passes).

## WebAdmin fallout (16 files)

Fixed all compile fallout: the model-cost editor, system-info tabs (now read the nested `version`/`operatingSystem`/`database`/`runtime`/`recordCounts` shape), IP filter/test modals, and media retention. The v2 model-cost UI already serializes to `pricingConfiguration`; read-only views now show config-aware messaging instead of the removed flat fields (no fabricated values).

## Verification

- SDK `type-check` ✅ and `lint` ✅
- `generate:admin:offline` deterministic ✅ (CI drift gate will pass)
- WebAdmin `type-check` ✅ and `lint` ✅ (verified against the rebuilt worktree SDK)
- ⚠️ Live smoke test (System Info tabs, Model Costs editor) not yet run — needs the Docker dev env (`./scripts/dev/start-dev.ps1`). Recommend running before merge.

## Follow-up

#1049 — the orphaned legacy v1 model-cost form still renders dead media/inference inputs (already no-ops; route is unreachable). Out of scope here.