### PR TITLE
refactor(webadmin): consolidate modals (useFormModal / JsonEditorField / EntityFormModal) + drop unused deps

### DIFF
--- a/WebAdmin/package-lock.json
+++ b/WebAdmin/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@clerk/nextjs": "^6.37.1",
-        "@hello-pangea/dnd": "^18.0.1",
         "@mantine/carousel": "^8.3.14",
         "@mantine/charts": "^8.3.14",
         "@mantine/code-highlight": "^8.3.14",
@@ -36,7 +35,6 @@
         "remark-gfm": "^4.0.1",
         "typescript": "^5.9.3",
         "uuid": "^13.0.0",
-        "video.js": "^8.23.4",
         "zod": "^4.3.6",
         "zustand": "^5.0.11"
       },
@@ -52,7 +50,6 @@
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@types/video.js": "^7.3.58",
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.1.6",
         "eslint-plugin-eslint-comments": "^3.2.0",
@@ -1025,21 +1022,6 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
       "license": "MIT"
-    },
-    "node_modules/@hello-pangea/dnd": {
-      "version": "18.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.26.7",
-        "css-box-model": "^1.2.1",
-        "raf-schd": "^4.0.3",
-        "react-redux": "^9.2.0",
-        "redux": "^5.0.1"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2452,11 +2434,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/video.js": {
-      "version": "7.3.58",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "dev": true,
@@ -2749,55 +2726,6 @@
         "win32"
       ]
     },
-    "node_modules/@videojs/http-streaming": {
-      "version": "3.17.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.1.1",
-        "aes-decrypter": "^4.0.2",
-        "global": "^4.4.0",
-        "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.3.1",
-        "mux.js": "7.1.0",
-        "video.js": "^7 || ^8"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "video.js": "^8.19.0"
-      }
-    },
-    "node_modules/@videojs/vhs-utils": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
-    },
-    "node_modules/@videojs/xhr": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "global": "~4.4.0",
-        "is-function": "^1.0.1"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "license": "MIT",
@@ -2836,16 +2764,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/aes-decrypter": {
-      "version": "4.0.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.1.1",
-        "global": "^4.4.0",
-        "pkcs7": "^1.0.4"
       }
     },
     "node_modules/agent-base": {
@@ -4058,13 +3976,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-box-model": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
     "node_modules/css-functions-list": {
       "version": "3.3.3",
       "dev": true,
@@ -4570,9 +4481,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/dom-walk": {
-      "version": "0.1.2"
     },
     "node_modules/domelementtype": {
       "version": "1.3.1",
@@ -6012,14 +5920,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "node_modules/global-modules": {
       "version": "2.0.0",
       "dev": true,
@@ -6992,10 +6892,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-function": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -8864,15 +8760,6 @@
         "lz-string": "bin/bin.js"
       }
     },
-    "node_modules/m3u8-parser": {
-      "version": "7.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.1.1",
-        "global": "^4.4.0"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "dev": true,
@@ -9822,13 +9709,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/min-document": {
-      "version": "2.19.2",
-      "license": "MIT",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "dev": true,
@@ -9907,37 +9787,9 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mpd-parser": {
-      "version": "1.3.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.0.0",
-        "@xmldom/xmldom": "^0.8.3",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "mpd-to-m3u8-json": "bin/parse.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
-    },
-    "node_modules/mux.js": {
-      "version": "7.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "global": "^4.4.0"
-      },
-      "bin": {
-        "muxjs-transmux": "bin/transmux.js"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      }
     },
     "node_modules/nano-spawn": {
       "version": "2.0.0",
@@ -10657,16 +10509,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pkcs7": {
-      "version": "1.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5"
-      },
-      "bin": {
-        "pkcs7": "bin/cli.js"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -11141,13 +10983,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
@@ -11242,10 +11077,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/raf-schd": {
-      "version": "4.0.3",
-      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -15515,49 +15346,6 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/video.js": {
-      "version": "8.23.7",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@videojs/http-streaming": "^3.17.3",
-        "@videojs/vhs-utils": "^4.1.1",
-        "@videojs/xhr": "2.7.0",
-        "aes-decrypter": "^4.0.2",
-        "global": "4.4.0",
-        "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.3.1",
-        "mux.js": "^7.0.1",
-        "videojs-contrib-quality-levels": "4.1.0",
-        "videojs-font": "4.2.0",
-        "videojs-vtt.js": "0.15.5"
-      }
-    },
-    "node_modules/videojs-contrib-quality-levels": {
-      "version": "4.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "global": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=16",
-        "npm": ">=8"
-      },
-      "peerDependencies": {
-        "video.js": "^8"
-      }
-    },
-    "node_modules/videojs-font": {
-      "version": "4.2.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/videojs-vtt.js": {
-      "version": "0.15.5",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "global": "^4.3.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/WebAdmin/package.json
+++ b/WebAdmin/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.1",
-    "@hello-pangea/dnd": "^18.0.1",
     "@mantine/carousel": "^8.3.14",
     "@mantine/charts": "^8.3.14",
     "@mantine/code-highlight": "^8.3.14",
@@ -48,7 +47,6 @@
     "remark-gfm": "^4.0.1",
     "typescript": "^5.9.3",
     "uuid": "^13.0.0",
-    "video.js": "^8.23.4",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
@@ -74,7 +72,6 @@
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/video.js": "^7.3.58",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/WebAdmin/src/components/common/EntityFormModal.tsx
+++ b/WebAdmin/src/components/common/EntityFormModal.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { type ReactNode, type FormEvent } from 'react';
+import { Modal, Stack, Group, Button, type ModalProps } from '@mantine/core';
+
+interface EntityFormModalProps {
+  /** Whether the modal is open. */
+  opened: boolean;
+  /** Close handler (also used by the Cancel button). */
+  onClose: () => void;
+  /** Modal title. */
+  title: ReactNode;
+  /** Mantine modal size. Default: 'lg'. */
+  size?: ModalProps['size'];
+  /** Submit handler for the form, e.g. `form.onSubmit(handleSubmit)`. */
+  onSubmit: (event?: FormEvent<HTMLFormElement>) => void;
+  /** Whether the submit button shows a loading state. */
+  loading?: boolean;
+  /** Submit button label. */
+  submitLabel: ReactNode;
+  /** Whether the submit button is disabled. */
+  submitDisabled?: boolean;
+  /** Cancel button label. Default: 'Cancel'. */
+  cancelLabel?: ReactNode;
+  /** Form fields. */
+  children: ReactNode;
+}
+
+/**
+ * Standard entity create/edit modal shell: a Mantine Modal wrapping a form with
+ * a Stack of fields and a right-aligned Cancel/Submit footer. Removes the
+ * repeated Modal + form + Group footer boilerplate from entity modals; pair with
+ * useFormModal for the submit lifecycle.
+ */
+export function EntityFormModal({
+  opened,
+  onClose,
+  title,
+  size = 'lg',
+  onSubmit,
+  loading,
+  submitLabel,
+  submitDisabled,
+  cancelLabel = 'Cancel',
+  children,
+}: EntityFormModalProps) {
+  return (
+    <Modal opened={opened} onClose={onClose} title={title} size={size}>
+      <form onSubmit={onSubmit}>
+        <Stack>
+          {children}
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={onClose}>
+              {cancelLabel}
+            </Button>
+            <Button type="submit" loading={loading} disabled={submitDisabled}>
+              {submitLabel}
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/WebAdmin/src/components/common/EntityFormModal.tsx
+++ b/WebAdmin/src/components/common/EntityFormModal.tsx
@@ -20,6 +20,8 @@ interface EntityFormModalProps {
   submitLabel: ReactNode;
   /** Whether the submit button is disabled. */
   submitDisabled?: boolean;
+  /** Optional icon/element rendered in the submit button's left section. */
+  submitLeftSection?: ReactNode;
   /** Cancel button label. Default: 'Cancel'. */
   cancelLabel?: ReactNode;
   /** Form fields. */
@@ -41,6 +43,7 @@ export function EntityFormModal({
   loading,
   submitLabel,
   submitDisabled,
+  submitLeftSection,
   cancelLabel = 'Cancel',
   children,
 }: EntityFormModalProps) {
@@ -50,10 +53,10 @@ export function EntityFormModal({
         <Stack>
           {children}
           <Group justify="flex-end">
-            <Button variant="subtle" onClick={onClose}>
+            <Button variant="subtle" onClick={onClose} disabled={loading}>
               {cancelLabel}
             </Button>
-            <Button type="submit" loading={loading} disabled={submitDisabled}>
+            <Button type="submit" loading={loading} disabled={submitDisabled} leftSection={submitLeftSection}>
               {submitLabel}
             </Button>
           </Group>

--- a/WebAdmin/src/components/common/JsonEditorField.tsx
+++ b/WebAdmin/src/components/common/JsonEditorField.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useCallback, type ReactNode } from 'react';
+import { Textarea, Alert, Text, Group, Button, Stack } from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+
+interface JsonEditorFieldProps {
+  /** Label shown above the editor. */
+  label?: string;
+  /** Current JSON string value. */
+  value: string;
+  /** Called with the new value on every change. */
+  onChange: (value: string) => void;
+  /**
+   * Called whenever validity changes, so the parent can gate submission
+   * (e.g. `disabled={!jsonValid}`). Fires on every edit.
+   */
+  onValidityChange?: (isValid: boolean) => void;
+  rows?: number;
+  placeholder?: string;
+  /** Optional preview, rendered only when the JSON is valid and non-empty. */
+  renderPreview?: (value: string) => ReactNode;
+  /** Where to render the preview relative to the textarea. Default: 'below'. */
+  previewPosition?: 'above' | 'below';
+  /** When true, the preview is hidden behind a Show/Hide toggle button. */
+  collapsiblePreview?: boolean;
+}
+
+/**
+ * Shared JSON editor: a monospace Textarea with live JSON validation, an inline
+ * error, and an optional preview. Replaces the copy-pasted "Parameters (JSON)"
+ * block (validate + textarea + error Alert) duplicated across entity modals.
+ */
+export function JsonEditorField({
+  label,
+  value,
+  onChange,
+  onValidityChange,
+  rows = 8,
+  placeholder = 'JSON parameters...',
+  renderPreview,
+  previewPosition = 'below',
+  collapsiblePreview = false,
+}: JsonEditorFieldProps) {
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [showPreview, setShowPreview] = useState(!collapsiblePreview);
+
+  const handleChange = useCallback(
+    (next: string) => {
+      onChange(next);
+      let error: string | null = null;
+      if (next) {
+        try {
+          JSON.parse(next);
+        } catch {
+          error = 'Invalid JSON format';
+        }
+      }
+      setJsonError(error);
+      onValidityChange?.(error === null);
+    },
+    [onChange, onValidityChange]
+  );
+
+  const previewVisible =
+    Boolean(renderPreview) && !jsonError && Boolean(value) && (collapsiblePreview ? showPreview : true);
+  const preview = previewVisible && renderPreview ? renderPreview(value) : null;
+
+  return (
+    <Stack gap="xs">
+      {(label ?? (collapsiblePreview && renderPreview)) && (
+        <Group justify="space-between">
+          {label && (
+            <Text size="sm" fw={500}>
+              {label}
+            </Text>
+          )}
+          {collapsiblePreview && renderPreview && (
+            <Button size="xs" variant="subtle" onClick={() => setShowPreview((s) => !s)}>
+              {showPreview ? 'Hide' : 'Show'} Preview
+            </Button>
+          )}
+        </Group>
+      )}
+
+      {previewPosition === 'above' && preview}
+
+      <Textarea
+        placeholder={placeholder}
+        rows={rows}
+        style={{ fontFamily: 'monospace' }}
+        value={value}
+        onChange={(e) => handleChange(e.currentTarget.value)}
+        error={jsonError}
+      />
+
+      {previewPosition === 'below' && preview}
+
+      {jsonError && (
+        <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
+          {jsonError}
+        </Alert>
+      )}
+    </Stack>
+  );
+}

--- a/WebAdmin/src/components/models/CreateModelAuthorModal.tsx
+++ b/WebAdmin/src/components/models/CreateModelAuthorModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useCallback } from 'react';
-import { Modal, TextInput, Switch, Button, Stack, Group } from '@mantine/core';
+import { TextInput, Switch } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import type { CreateModelAuthorDto } from '@/lib/admin-api';
 
 
@@ -45,42 +46,32 @@ export function CreateModelAuthorModal({ isOpen, onClose, onSuccess }: CreateMod
   });
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Create New Author"
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Create Author"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Author Name"
-            placeholder="e.g., OpenAI"
-            required
-            {...form.getInputProps('name')}
-          />
+      <TextInput
+        label="Author Name"
+        placeholder="e.g., OpenAI"
+        required
+        {...form.getInputProps('name')}
+      />
 
-          <TextInput
-            label="Website URL"
-            placeholder="https://..."
-            {...form.getInputProps('websiteUrl')}
-          />
+      <TextInput
+        label="Website URL"
+        placeholder="https://..."
+        {...form.getInputProps('websiteUrl')}
+      />
 
-          <Switch
-            label="Active"
-            {...form.getInputProps('isActive', { type: 'checkbox' })}
-          />
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Create Author
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Switch
+        label="Active"
+        {...form.getInputProps('isActive', { type: 'checkbox' })}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/models/CreateModelModal.tsx
+++ b/WebAdmin/src/components/models/CreateModelModal.tsx
@@ -5,6 +5,7 @@ import { Modal, TextInput, Select, Switch, Button, Stack, Group, NumberInput, Di
 import { useForm } from '@mantine/form';
 import { notify } from '@/lib/notifications';
 import { withAdminClient } from '@/lib/client/adminClient';
+import { useFormModal } from '@/hooks/useFormModal';
 import { TOKENIZER_SELECT_OPTIONS, TokenizerType } from '@/lib/utils/tokenizerTypes';
 import type { CreateModelDto, ModelSeriesDto } from '@/lib/admin-api';
 
@@ -16,7 +17,6 @@ interface CreateModelModalProps {
 
 
 export function CreateModelModal({ isOpen, onClose, onSuccess }: CreateModelModalProps) {
-  const [loading, setLoading] = useState(false);
   const [series, setSeries] = useState<ModelSeriesDto[]>([]);
   // Capabilities are now embedded in the Model, no need for separate capabilities
 
@@ -67,14 +67,11 @@ export function CreateModelModal({ isOpen, onClose, onSuccess }: CreateModelModa
     }
   };
 
-  const handleClose = () => {
-    form.reset();
-    onClose();
-  };
-
-  const handleSubmit = async (values: typeof form.values) => {
-    try {
-      setLoading(true);
+  const { loading, handleSubmit, handleClose } = useFormModal({
+    form,
+    onClose,
+    onSuccess,
+    submitAction: async (values) => {
       const dto: CreateModelDto = {
         name: values.name,
         modelSeriesId: values.modelSeriesId ? parseInt(values.modelSeriesId) : undefined,
@@ -91,16 +88,9 @@ export function CreateModelModal({ isOpen, onClose, onSuccess }: CreateModelModa
         maxOutputTokens: values.maxOutputTokens ?? undefined
       } as CreateModelDto;
       await withAdminClient(client => client.models.create(dto));
-      notify.success('Model created successfully');
-      form.reset();
-      onSuccess();
-    } catch (error) {
-      console.error('Failed to create model:', error);
-      notify.error(error, 'Failed to create model');
-    } finally {
-      setLoading(false);
-    }
-  };
+    },
+    successMessage: 'Model created successfully',
+  });
 
   const seriesOptions = series.map(s => ({
     value: s.id?.toString() ?? '',

--- a/WebAdmin/src/components/models/CreateModelModal.tsx
+++ b/WebAdmin/src/components/models/CreateModelModal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Modal, TextInput, Select, Switch, Button, Stack, Group, NumberInput, Divider } from '@mantine/core';
+import { TextInput, Select, Switch, Group, NumberInput, Divider } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notify } from '@/lib/notifications';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import { TOKENIZER_SELECT_OPTIONS, TokenizerType } from '@/lib/utils/tokenizerTypes';
 import type { CreateModelDto, ModelSeriesDto } from '@/lib/admin-api';
 
@@ -100,113 +101,102 @@ export function CreateModelModal({ isOpen, onClose, onSuccess }: CreateModelModa
   // Capabilities are now embedded in the Model, no separate selection needed
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Create New Model"
-      size="lg"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Create Model"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Model Name"
-            placeholder="e.g., gpt-4-turbo"
-            required
-            {...form.getInputProps('name')}
-          />
+      <TextInput
+        label="Model Name"
+        placeholder="e.g., gpt-4-turbo"
+        required
+        {...form.getInputProps('name')}
+      />
 
-          <Select
-            label="Model Series"
-            data={seriesOptions}
-            placeholder="Select a series (optional)"
-            {...form.getInputProps('modelSeriesId')}
-          />
+      <Select
+        label="Model Series"
+        data={seriesOptions}
+        placeholder="Select a series (optional)"
+        {...form.getInputProps('modelSeriesId')}
+      />
 
-          <Select
-            label="Tokenizer Type"
-            data={TOKENIZER_SELECT_OPTIONS}
-            placeholder="Select tokenizer type"
-            value={form.values.tokenizerType.toString()}
-            onChange={(value) => form.setFieldValue('tokenizerType', value ? parseInt(value) : TokenizerType.Cl100KBase)}
-            required
-            searchable
-            error={form.errors.tokenizerType}
-          />
+      <Select
+        label="Tokenizer Type"
+        data={TOKENIZER_SELECT_OPTIONS}
+        placeholder="Select tokenizer type"
+        value={form.values.tokenizerType.toString()}
+        onChange={(value) => form.setFieldValue('tokenizerType', value ? parseInt(value) : TokenizerType.Cl100KBase)}
+        required
+        searchable
+        error={form.errors.tokenizerType}
+      />
 
-          <Divider label="Model Capabilities" labelPosition="center" my="md" />
-          
-          <Group grow>
-            <Switch
-              label="Supports Chat"
-              {...form.getInputProps('supportsChat', { type: 'checkbox' })}
-            />
-            <Switch
-              label="Supports Vision"
-              {...form.getInputProps('supportsVision', { type: 'checkbox' })}
-            />
-          </Group>
+      <Divider label="Model Capabilities" labelPosition="center" my="md" />
 
-          <Group grow>
-            <Switch
-              label="Supports Function Calling"
-              {...form.getInputProps('supportsFunctionCalling', { type: 'checkbox' })}
-            />
-            <Switch
-              label="Supports Streaming"
-              {...form.getInputProps('supportsStreaming', { type: 'checkbox' })}
-            />
-          </Group>
+      <Group grow>
+        <Switch
+          label="Supports Chat"
+          {...form.getInputProps('supportsChat', { type: 'checkbox' })}
+        />
+        <Switch
+          label="Supports Vision"
+          {...form.getInputProps('supportsVision', { type: 'checkbox' })}
+        />
+      </Group>
 
-          <Group grow>
-            <Switch
-              label="Supports Image Generation"
-              {...form.getInputProps('supportsImageGeneration', { type: 'checkbox' })}
-            />
-            <Switch
-              label="Supports Video Generation"
-              {...form.getInputProps('supportsVideoGeneration', { type: 'checkbox' })}
-            />
-          </Group>
+      <Group grow>
+        <Switch
+          label="Supports Function Calling"
+          {...form.getInputProps('supportsFunctionCalling', { type: 'checkbox' })}
+        />
+        <Switch
+          label="Supports Streaming"
+          {...form.getInputProps('supportsStreaming', { type: 'checkbox' })}
+        />
+      </Group>
 
-          <Switch
-            label="Supports Embeddings"
-            {...form.getInputProps('supportsEmbeddings', { type: 'checkbox' })}
-          />
+      <Group grow>
+        <Switch
+          label="Supports Image Generation"
+          {...form.getInputProps('supportsImageGeneration', { type: 'checkbox' })}
+        />
+        <Switch
+          label="Supports Video Generation"
+          {...form.getInputProps('supportsVideoGeneration', { type: 'checkbox' })}
+        />
+      </Group>
 
-          <Divider label="Token Limits" labelPosition="center" my="md" />
+      <Switch
+        label="Supports Embeddings"
+        {...form.getInputProps('supportsEmbeddings', { type: 'checkbox' })}
+      />
 
-          <Group grow>
-            <NumberInput
-              label="Max Input Tokens"
-              placeholder="e.g., 128000"
-              min={0}
-              {...form.getInputProps('maxInputTokens')}
-            />
-            <NumberInput
-              label="Max Output Tokens"
-              placeholder="e.g., 4096"
-              min={0}
-              {...form.getInputProps('maxOutputTokens')}
-            />
-          </Group>
+      <Divider label="Token Limits" labelPosition="center" my="md" />
 
-          <Divider my="md" />
+      <Group grow>
+        <NumberInput
+          label="Max Input Tokens"
+          placeholder="e.g., 128000"
+          min={0}
+          {...form.getInputProps('maxInputTokens')}
+        />
+        <NumberInput
+          label="Max Output Tokens"
+          placeholder="e.g., 4096"
+          min={0}
+          {...form.getInputProps('maxOutputTokens')}
+        />
+      </Group>
 
-          <Switch
-            label="Active"
-            {...form.getInputProps('isActive', { type: 'checkbox' })}
-          />
+      <Divider my="md" />
 
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Create Model
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Switch
+        label="Active"
+        {...form.getInputProps('isActive', { type: 'checkbox' })}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/models/CreateModelSeriesModal.tsx
+++ b/WebAdmin/src/components/models/CreateModelSeriesModal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Modal, TextInput, Select, Switch, Button, Stack, Group, Textarea } from '@mantine/core';
+import { TextInput, Select, Switch, Textarea } from '@mantine/core';
 import { CodeHighlight } from '@mantine/code-highlight';
 import { useForm } from '@mantine/form';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import { JsonEditorField } from '@/components/common/JsonEditorField';
 import { notify } from '@/lib/notifications';
 import type { CreateModelSeriesDto, ModelAuthorDto } from '@/lib/admin-api';
@@ -110,70 +111,60 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
     }));
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Create New Model Series"
-      size="lg"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Create Series"
+      submitDisabled={!jsonValid}
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Series Name"
-            placeholder="e.g., GPT-4"
-            required
-            {...form.getInputProps('name')}
-          />
+      <TextInput
+        label="Series Name"
+        placeholder="e.g., GPT-4"
+        required
+        {...form.getInputProps('name')}
+      />
 
-          <TextInput
-            label="Display Name"
-            placeholder="e.g., GPT-4 Series"
-            {...form.getInputProps('displayName')}
-          />
+      <TextInput
+        label="Display Name"
+        placeholder="e.g., GPT-4 Series"
+        {...form.getInputProps('displayName')}
+      />
 
-          <Select
-            label="Author"
-            required
-            data={authorOptions}
-            placeholder="Select an author"
-            value={form.values.authorId?.toString()}
-            onChange={(value) => form.setFieldValue('authorId', value ? parseInt(value) : 0)}
-          />
+      <Select
+        label="Author"
+        required
+        data={authorOptions}
+        placeholder="Select an author"
+        value={form.values.authorId?.toString()}
+        onChange={(value) => form.setFieldValue('authorId', value ? parseInt(value) : 0)}
+      />
 
-          <Textarea
-            label="Description"
-            placeholder="Description of the model series..."
-            rows={3}
-            {...form.getInputProps('description')}
-          />
+      <Textarea
+        label="Description"
+        placeholder="Description of the model series..."
+        rows={3}
+        {...form.getInputProps('description')}
+      />
 
-          <JsonEditorField
-            label="Parameters (JSON)"
-            value={form.values.parameters ?? ''}
-            onChange={(v) => form.setFieldValue('parameters', v)}
-            onValidityChange={setJsonValid}
-            placeholder="JSON parameters for UI generation..."
-            collapsiblePreview
-            renderPreview={(v) => (
-              <CodeHighlight code={v} language="json" withCopyButton={false} />
-            )}
-          />
+      <JsonEditorField
+        label="Parameters (JSON)"
+        value={form.values.parameters ?? ''}
+        onChange={(v) => form.setFieldValue('parameters', v)}
+        onValidityChange={setJsonValid}
+        placeholder="JSON parameters for UI generation..."
+        collapsiblePreview
+        renderPreview={(v) => (
+          <CodeHighlight code={v} language="json" withCopyButton={false} />
+        )}
+      />
 
-          <Switch
-            label="Active"
-            {...form.getInputProps('isActive', { type: 'checkbox' })}
-          />
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading} disabled={!jsonValid}>
-              Create Series
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Switch
+        label="Active"
+        {...form.getInputProps('isActive', { type: 'checkbox' })}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/models/CreateModelSeriesModal.tsx
+++ b/WebAdmin/src/components/models/CreateModelSeriesModal.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Modal, TextInput, Select, Switch, Button, Stack, Group, Textarea, Alert, Text } from '@mantine/core';
+import { Modal, TextInput, Select, Switch, Button, Stack, Group, Textarea } from '@mantine/core';
 import { CodeHighlight } from '@mantine/code-highlight';
 import { useForm } from '@mantine/form';
-import { IconAlertCircle } from '@tabler/icons-react';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { JsonEditorField } from '@/components/common/JsonEditorField';
 import { notify } from '@/lib/notifications';
 import type { CreateModelSeriesDto, ModelAuthorDto } from '@/lib/admin-api';
 
@@ -33,8 +33,7 @@ const DEFAULT_PARAMETERS = JSON.stringify({
 
 export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateModelSeriesModalProps) {
   const [authors, setAuthors] = useState<ModelAuthorDto[]>([]);
-  const [jsonError, setJsonError] = useState<string | null>(null);
-  const [showJsonPreview, setShowJsonPreview] = useState(false);
+  const [jsonValid, setJsonValid] = useState(true);
 
   const form = useForm<CreateModelSeriesDto & { parameters?: string }>({
     initialValues: {
@@ -52,12 +51,9 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
         if (value) {
           try {
             JSON.parse(value);
-            setJsonError(null);
             return null;
           } catch {
-            const error = 'Invalid JSON format';
-            setJsonError(error);
-            return error;
+            return 'Invalid JSON format';
           }
         }
         return null;
@@ -87,7 +83,7 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
   });
 
   const handleClose = useCallback(() => {
-    setJsonError(null);
+    setJsonValid(true);
     baseHandleClose();
   }, [baseHandleClose]);
 
@@ -112,17 +108,6 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
       value: String(a.id),
       label: a.name ?? 'Unknown Author'
     }));
-
-  const validateJson = (value: string) => {
-    try {
-      if (value) {
-        JSON.parse(value);
-        setJsonError(null);
-      }
-    } catch {
-      setJsonError('Invalid JSON format');
-    }
-  };
 
   return (
     <Modal
@@ -162,46 +147,17 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
             {...form.getInputProps('description')}
           />
 
-          <Stack gap="xs">
-            <Group justify="space-between">
-              <Text size="sm" fw={500}>
-                Parameters (JSON)
-              </Text>
-              <Button
-                size="xs"
-                variant="subtle"
-                onClick={() => setShowJsonPreview(!showJsonPreview)}
-              >
-                {showJsonPreview ? 'Hide' : 'Show'} Preview
-              </Button>
-            </Group>
-
-            <Textarea
-              placeholder="JSON parameters for UI generation..."
-              rows={8}
-              style={{ fontFamily: 'monospace' }}
-              {...form.getInputProps('parameters')}
-              onChange={(e) => {
-                form.setFieldValue('parameters', e.currentTarget.value);
-                validateJson(e.currentTarget.value);
-              }}
-              error={jsonError}
-            />
-
-            {showJsonPreview && form.values.parameters && !jsonError && (
-              <CodeHighlight
-                code={form.values.parameters}
-                language="json"
-                withCopyButton={false}
-              />
+          <JsonEditorField
+            label="Parameters (JSON)"
+            value={form.values.parameters ?? ''}
+            onChange={(v) => form.setFieldValue('parameters', v)}
+            onValidityChange={setJsonValid}
+            placeholder="JSON parameters for UI generation..."
+            collapsiblePreview
+            renderPreview={(v) => (
+              <CodeHighlight code={v} language="json" withCopyButton={false} />
             )}
-
-            {jsonError && (
-              <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
-                {jsonError}
-              </Alert>
-            )}
-          </Stack>
+          />
 
           <Switch
             label="Active"
@@ -212,7 +168,7 @@ export function CreateModelSeriesModal({ isOpen, onClose, onSuccess }: CreateMod
             <Button variant="subtle" onClick={handleClose}>
               Cancel
             </Button>
-            <Button type="submit" loading={loading} disabled={!!jsonError}>
+            <Button type="submit" loading={loading} disabled={!jsonValid}>
               Create Series
             </Button>
           </Group>

--- a/WebAdmin/src/components/models/EditModelAuthorModal.tsx
+++ b/WebAdmin/src/components/models/EditModelAuthorModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
-import { Modal, TextInput, Button, Stack, Group } from '@mantine/core';
+import { TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import type { ModelAuthorDto, UpdateModelAuthorDto } from '@/lib/admin-api';
 
 
@@ -61,39 +62,29 @@ export function EditModelAuthorModal({ isOpen, author, onClose, onSuccess }: Edi
   });
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Edit Author"
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Update Author"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Author Name"
-            placeholder="e.g., OpenAI"
-            required
-            {...form.getInputProps('name')}
-          />
+      <TextInput
+        label="Author Name"
+        placeholder="e.g., OpenAI"
+        required
+        {...form.getInputProps('name')}
+      />
 
-          <TextInput
-            label="Website URL"
-            placeholder="https://..."
-            {...form.getInputProps('websiteUrl')}
-          />
+      <TextInput
+        label="Website URL"
+        placeholder="https://..."
+        {...form.getInputProps('websiteUrl')}
+      />
 
-          {/* isActive field doesn't exist in ModelAuthorDto */}
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Update Author
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      {/* isActive field doesn't exist in ModelAuthorDto */}
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/models/EditModelSeriesModal.tsx
+++ b/WebAdmin/src/components/models/EditModelSeriesModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Modal, TextInput, Button, Stack, Group, Textarea, Alert, Text } from '@mantine/core';
+import { Modal, TextInput, Button, Stack, Group, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconAlertCircle } from '@tabler/icons-react';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { JsonEditorField } from '@/components/common/JsonEditorField';
 import { ParameterPreview } from '@/components/parameters/ParameterPreview';
 import type { ModelSeriesDto, UpdateModelSeriesDto } from '@/lib/admin-api';
 
@@ -18,7 +18,7 @@ interface EditModelSeriesModalProps {
 }
 
 export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: EditModelSeriesModalProps) {
-  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [jsonValid, setJsonValid] = useState(true);
 
   const form = useForm<UpdateModelSeriesDto & { parameters?: string }>({
     initialValues: {
@@ -33,12 +33,9 @@ export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: Edi
         if (value) {
           try {
             JSON.parse(value);
-            setJsonError(null);
             return null;
           } catch {
-            const error = 'Invalid JSON format';
-            setJsonError(error);
-            return error;
+            return 'Invalid JSON format';
           }
         }
         return null;
@@ -80,22 +77,9 @@ export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: Edi
   });
 
   const handleClose = useCallback(() => {
-    setJsonError(null);
+    setJsonValid(true);
     baseHandleClose();
   }, [baseHandleClose]);
-
-  // Removed authorOptions as it's no longer used
-
-  const validateJson = (value: string) => {
-    try {
-      if (value) {
-        JSON.parse(value);
-        setJsonError(null);
-      }
-    } catch {
-      setJsonError('Invalid JSON format');
-    }
-  };
 
   return (
     <Modal
@@ -121,43 +105,29 @@ export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: Edi
             {...form.getInputProps('description')}
           />
 
-          <Stack gap="xs">
-            <Text size="sm" fw={500}>
-              Parameters (JSON)
-            </Text>
-            
-            <ParameterPreview 
-              parametersJson={form.values.parameters ?? ''}
-              context="chat"
-              label="Preview UI Components"
-              maxHeight={300}
-            />
-            
-            <Textarea
-              placeholder="JSON parameters for UI generation..."
-              rows={8}
-              style={{ fontFamily: 'monospace' }}
-              {...form.getInputProps('parameters')}
-              onChange={(e) => {
-                form.setFieldValue('parameters', e.currentTarget.value);
-                validateJson(e.currentTarget.value);
-              }}
-              error={jsonError}
-            />
-
-            {jsonError && (
-              <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
-                {jsonError}
-              </Alert>
+          <JsonEditorField
+            label="Parameters (JSON)"
+            value={form.values.parameters ?? ''}
+            onChange={(v) => form.setFieldValue('parameters', v)}
+            onValidityChange={setJsonValid}
+            placeholder="JSON parameters for UI generation..."
+            previewPosition="above"
+            renderPreview={(v) => (
+              <ParameterPreview
+                parametersJson={v}
+                context="chat"
+                label="Preview UI Components"
+                maxHeight={300}
+              />
             )}
-          </Stack>
+          />
 
 
           <Group justify="flex-end">
             <Button variant="subtle" onClick={handleClose}>
               Cancel
             </Button>
-            <Button type="submit" loading={loading} disabled={!!jsonError}>
+            <Button type="submit" loading={loading} disabled={!jsonValid}>
               Update Series
             </Button>
           </Group>

--- a/WebAdmin/src/components/models/EditModelSeriesModal.tsx
+++ b/WebAdmin/src/components/models/EditModelSeriesModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Modal, TextInput, Button, Stack, Group, Textarea, Alert, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { notify } from '@/lib/notifications';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { withAdminClient } from '@/lib/client/adminClient';
+import { useFormModal } from '@/hooks/useFormModal';
 import { ParameterPreview } from '@/components/parameters/ParameterPreview';
 import type { ModelSeriesDto, UpdateModelSeriesDto } from '@/lib/admin-api';
 
@@ -18,7 +18,6 @@ interface EditModelSeriesModalProps {
 }
 
 export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: EditModelSeriesModalProps) {
-  const [loading, setLoading] = useState(false);
   const [jsonError, setJsonError] = useState<string | null>(null);
 
   const form = useForm<UpdateModelSeriesDto & { parameters?: string }>({
@@ -59,33 +58,31 @@ export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: Edi
   }, [series]);
 
 
-  const handleClose = () => {
-    form.reset();
-    setJsonError(null);
-    onClose();
-  };
-
-  const handleSubmit = async (values: typeof form.values) => {
-    try {
-      setLoading(true);
+  const submitAction = useCallback(
+    async (values: UpdateModelSeriesDto & { parameters?: string }) => {
+      if (!series.id) throw new Error('Series ID is required');
       const dto: UpdateModelSeriesDto = {
         name: values.name,
         description: values.description,
         parameters: values.parameters ?? null
       };
-      
-      if (!series.id) throw new Error('Series ID is required');
       await withAdminClient(client => client.modelSeries.update(series.id as number, dto));
-      notify.success('Model series updated successfully');
-      handleClose();
-      onSuccess();
-    } catch (error) {
-      console.error('Failed to update model series:', error);
-      notify.error(error, 'Failed to update model series');
-    } finally {
-      setLoading(false);
-    }
-  };
+    },
+    [series.id]
+  );
+
+  const { loading, handleSubmit, handleClose: baseHandleClose } = useFormModal({
+    form,
+    onClose,
+    onSuccess,
+    submitAction,
+    successMessage: 'Model series updated successfully',
+  });
+
+  const handleClose = useCallback(() => {
+    setJsonError(null);
+    baseHandleClose();
+  }, [baseHandleClose]);
 
   // Removed authorOptions as it's no longer used
 

--- a/WebAdmin/src/components/models/EditModelSeriesModal.tsx
+++ b/WebAdmin/src/components/models/EditModelSeriesModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Modal, TextInput, Button, Stack, Group, Textarea } from '@mantine/core';
+import { TextInput, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import { JsonEditorField } from '@/components/common/JsonEditorField';
 import { ParameterPreview } from '@/components/parameters/ParameterPreview';
 import type { ModelSeriesDto, UpdateModelSeriesDto } from '@/lib/admin-api';
@@ -82,57 +83,45 @@ export function EditModelSeriesModal({ isOpen, series, onClose, onSuccess }: Edi
   }, [baseHandleClose]);
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Edit Model Series"
-      size="lg"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Update Series"
+      submitDisabled={!jsonValid}
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Series Name"
-            placeholder="e.g., GPT-4"
-            required
-            {...form.getInputProps('name')}
+      <TextInput
+        label="Series Name"
+        placeholder="e.g., GPT-4"
+        required
+        {...form.getInputProps('name')}
+      />
+
+      <Textarea
+        label="Description"
+        placeholder="Description of the model series..."
+        rows={3}
+        {...form.getInputProps('description')}
+      />
+
+      <JsonEditorField
+        label="Parameters (JSON)"
+        value={form.values.parameters ?? ''}
+        onChange={(v) => form.setFieldValue('parameters', v)}
+        onValidityChange={setJsonValid}
+        placeholder="JSON parameters for UI generation..."
+        previewPosition="above"
+        renderPreview={(v) => (
+          <ParameterPreview
+            parametersJson={v}
+            context="chat"
+            label="Preview UI Components"
+            maxHeight={300}
           />
-
-
-          <Textarea
-            label="Description"
-            placeholder="Description of the model series..."
-            rows={3}
-            {...form.getInputProps('description')}
-          />
-
-          <JsonEditorField
-            label="Parameters (JSON)"
-            value={form.values.parameters ?? ''}
-            onChange={(v) => form.setFieldValue('parameters', v)}
-            onValidityChange={setJsonValid}
-            placeholder="JSON parameters for UI generation..."
-            previewPosition="above"
-            renderPreview={(v) => (
-              <ParameterPreview
-                parametersJson={v}
-                context="chat"
-                label="Preview UI Components"
-                maxHeight={300}
-              />
-            )}
-          />
-
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading} disabled={!jsonValid}>
-              Update Series
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+        )}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/provider-tools/CreateProviderToolModal.tsx
+++ b/WebAdmin/src/components/provider-tools/CreateProviderToolModal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Modal, TextInput, NumberInput, Select, Switch, Button, Stack, Group, Textarea } from '@mantine/core';
+import { TextInput, NumberInput, Select, Switch, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notify } from '@/lib/notifications';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import type { CreateProviderTool, ToolProviderOption } from '@/lib/admin-api';
 
 interface CreateProviderToolModalProps {
@@ -71,79 +72,69 @@ export function CreateProviderToolModal({ isOpen, onClose, onSuccess }: CreatePr
   }, [isOpen]);
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title="Add Provider Tool"
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Create Tool"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <Select
-            label="Provider"
-            placeholder="Select a provider"
-            data={providers.map(p => ({
-              value: p.value.toString(),
-              label: p.name,
-            }))}
-            {...form.getInputProps('provider')}
-            onChange={(value) => form.setFieldValue('provider', value ? parseInt(value) : 0)}
-            value={form.values.provider.toString()}
-            required
-          />
+      <Select
+        label="Provider"
+        placeholder="Select a provider"
+        data={providers.map(p => ({
+          value: p.value.toString(),
+          label: p.name,
+        }))}
+        {...form.getInputProps('provider')}
+        onChange={(value) => form.setFieldValue('provider', value ? parseInt(value) : 0)}
+        value={form.values.provider.toString()}
+        required
+      />
 
-          <TextInput
-            label="Tool Name"
-            placeholder="e.g., code_execution, web_search"
-            {...form.getInputProps('toolName')}
-            required
-          />
+      <TextInput
+        label="Tool Name"
+        placeholder="e.g., code_execution, web_search"
+        {...form.getInputProps('toolName')}
+        required
+      />
 
-          <Textarea
-            label="Tool Parameters"
-            placeholder="Optional JSON parameters"
-            minRows={2}
-            {...form.getInputProps('toolParameters')}
-          />
+      <Textarea
+        label="Tool Parameters"
+        placeholder="Optional JSON parameters"
+        minRows={2}
+        {...form.getInputProps('toolParameters')}
+      />
 
-          <NumberInput
-            label="Cost Per Unit"
-            placeholder="0.0001"
-            min={0}
-            decimalScale={8}
-            step={0.0001}
-            {...form.getInputProps('costPerUnit')}
-          />
+      <NumberInput
+        label="Cost Per Unit"
+        placeholder="0.0001"
+        min={0}
+        decimalScale={8}
+        step={0.0001}
+        {...form.getInputProps('costPerUnit')}
+      />
 
-          <Select
-            label="Billing Unit"
-            placeholder="Select a billing unit"
-            data={billingUnits}
-            searchable
-            {...form.getInputProps('billingUnit')}
-          />
+      <Select
+        label="Billing Unit"
+        placeholder="Select a billing unit"
+        data={billingUnits}
+        searchable
+        {...form.getInputProps('billingUnit')}
+      />
 
-          <Textarea
-            label="Cost Description"
-            placeholder="Describe how the cost is calculated"
-            {...form.getInputProps('costDescription')}
-          />
+      <Textarea
+        label="Cost Description"
+        placeholder="Describe how the cost is calculated"
+        {...form.getInputProps('costDescription')}
+      />
 
-          <Switch
-            label="Active"
-            {...form.getInputProps('isActive', { type: 'checkbox' })}
-          />
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Create Tool
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Switch
+        label="Active"
+        {...form.getInputProps('isActive', { type: 'checkbox' })}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/provider-tools/EditProviderToolModal.tsx
+++ b/WebAdmin/src/components/provider-tools/EditProviderToolModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Modal, TextInput, NumberInput, Select, Switch, Button, Stack, Group, Textarea } from '@mantine/core';
+import { TextInput, NumberInput, Select, Switch, Textarea } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 import type { ProviderTool, UpdateProviderTool } from '@/lib/admin-api';
 
 interface EditProviderToolModalProps {
@@ -71,71 +72,61 @@ export function EditProviderToolModal({ isOpen, tool, onClose, onSuccess }: Edit
   }, [isOpen, tool, form]);
 
   return (
-    <Modal
+    <EntityFormModal
       opened={isOpen}
       onClose={handleClose}
       title={`Edit ${tool.toolName}`}
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Update Tool"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack>
-          <TextInput
-            label="Provider"
-            value={tool.providerName ?? 'Unknown'}
-            disabled
-          />
+      <TextInput
+        label="Provider"
+        value={tool.providerName ?? 'Unknown'}
+        disabled
+      />
 
-          <TextInput
-            label="Tool Name"
-            value={tool.toolName}
-            disabled
-          />
+      <TextInput
+        label="Tool Name"
+        value={tool.toolName}
+        disabled
+      />
 
-          <Textarea
-            label="Tool Parameters"
-            placeholder="Optional JSON parameters"
-            minRows={2}
-            {...form.getInputProps('toolParameters')}
-          />
+      <Textarea
+        label="Tool Parameters"
+        placeholder="Optional JSON parameters"
+        minRows={2}
+        {...form.getInputProps('toolParameters')}
+      />
 
-          <NumberInput
-            label="Cost Per Unit"
-            placeholder="0.0001"
-            min={0}
-            decimalScale={8}
-            step={0.0001}
-            {...form.getInputProps('costPerUnit')}
-          />
+      <NumberInput
+        label="Cost Per Unit"
+        placeholder="0.0001"
+        min={0}
+        decimalScale={8}
+        step={0.0001}
+        {...form.getInputProps('costPerUnit')}
+      />
 
-          <Select
-            label="Billing Unit"
-            placeholder="Select a billing unit"
-            data={billingUnits}
-            searchable
-            {...form.getInputProps('billingUnit')}
-          />
+      <Select
+        label="Billing Unit"
+        placeholder="Select a billing unit"
+        data={billingUnits}
+        searchable
+        {...form.getInputProps('billingUnit')}
+      />
 
-          <Textarea
-            label="Cost Description"
-            placeholder="Describe how the cost is calculated"
-            {...form.getInputProps('costDescription')}
-          />
+      <Textarea
+        label="Cost Description"
+        placeholder="Describe how the cost is calculated"
+        {...form.getInputProps('costDescription')}
+      />
 
-          <Switch
-            label="Active"
-            {...form.getInputProps('isActive', { type: 'checkbox' })}
-          />
-
-          <Group justify="flex-end">
-            <Button variant="subtle" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Update Tool
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Switch
+        label="Active"
+        {...form.getInputProps('isActive', { type: 'checkbox' })}
+      />
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/virtualkeys/AddCreditsModal.tsx
+++ b/WebAdmin/src/components/virtualkeys/AddCreditsModal.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import {
-  Modal,
   Stack,
   NumberInput,
   TextInput,
-  Button,
   Group,
   Text,
   Alert,
@@ -18,6 +16,7 @@ import { formatters } from '@/lib/utils/formatters';
 import type { VirtualKeyGroupDto, AdjustBalanceDto } from '@/lib/admin-api';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 
 interface AddCreditsModalProps {
   opened: boolean;
@@ -64,7 +63,7 @@ export function AddCreditsModal({ opened, onClose, group, onSuccess }: AddCredit
   };
 
   return (
-    <Modal
+    <EntityFormModal
       opened={opened}
       onClose={handleClose}
       title={
@@ -74,73 +73,60 @@ export function AddCreditsModal({ opened, onClose, group, onSuccess }: AddCredit
         </Group>
       }
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Add Credits"
+      submitLeftSection={<IconCash size={16} />}
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack gap="md">
-          <Card withBorder>
-            <Stack gap="sm">
-              <Group justify="space-between">
-                <Text size="sm" c="dimmed">Group</Text>
-                <Text fw={500}>{group.groupName}</Text>
-              </Group>
+      <Card withBorder>
+        <Stack gap="sm">
+          <Group justify="space-between">
+            <Text size="sm" c="dimmed">Group</Text>
+            <Text fw={500}>{group.groupName}</Text>
+          </Group>
 
-              <Group justify="space-between">
-                <Text size="sm" c="dimmed">Current Balance</Text>
-                <Badge
-                  color={getBalanceColor(group.balance)}
-                  variant={group.balance <= 0 ? 'filled' : 'light'}
-                >
-                  {formatters.currency(group.balance)}
-                </Badge>
-              </Group>
-            </Stack>
-          </Card>
-
-          <NumberInput
-            label="Amount to Add"
-            placeholder="0.00"
-            prefix="$"
-            min={0.01}
-            max={1000000}
-            decimalScale={2}
-            fixedDecimalScale
-            thousandSeparator=","
-            required
-            autoFocus
-            {...form.getInputProps('amount')}
-          />
-
-          <TextInput
-            label="Description"
-            placeholder="Reason for adding credits (optional)"
-            {...form.getInputProps('description')}
-          />
-
-          {form.values.amount > 0 && (
-            <Alert icon={<IconAlertCircle size={16} />} color="blue">
-              <Stack gap={4}>
-                <Text size="sm">New balance after adding credits:</Text>
-                <Text size="lg" fw={700} c={getBalanceColor(newBalance)}>
-                  {formatters.currency(newBalance)}
-                </Text>
-              </Stack>
-            </Alert>
-          )}
-
-          <Group justify="flex-end" mt="md">
-            <Button variant="subtle" onClick={handleClose} disabled={loading}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              loading={loading}
-              leftSection={<IconCash size={16} />}
+          <Group justify="space-between">
+            <Text size="sm" c="dimmed">Current Balance</Text>
+            <Badge
+              color={getBalanceColor(group.balance)}
+              variant={group.balance <= 0 ? 'filled' : 'light'}
             >
-              Add Credits
-            </Button>
+              {formatters.currency(group.balance)}
+            </Badge>
           </Group>
         </Stack>
-      </form>
-    </Modal>
+      </Card>
+
+      <NumberInput
+        label="Amount to Add"
+        placeholder="0.00"
+        prefix="$"
+        min={0.01}
+        max={1000000}
+        decimalScale={2}
+        fixedDecimalScale
+        thousandSeparator=","
+        required
+        autoFocus
+        {...form.getInputProps('amount')}
+      />
+
+      <TextInput
+        label="Description"
+        placeholder="Reason for adding credits (optional)"
+        {...form.getInputProps('description')}
+      />
+
+      {form.values.amount > 0 && (
+        <Alert icon={<IconAlertCircle size={16} />} color="blue">
+          <Stack gap={4}>
+            <Text size="sm">New balance after adding credits:</Text>
+            <Text size="lg" fw={700} c={getBalanceColor(newBalance)}>
+              {formatters.currency(newBalance)}
+            </Text>
+          </Stack>
+        </Alert>
+      )}
+    </EntityFormModal>
   );
 }

--- a/WebAdmin/src/components/virtualkeys/CreateVirtualKeyGroupModal.tsx
+++ b/WebAdmin/src/components/virtualkeys/CreateVirtualKeyGroupModal.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import {
-  Modal,
-  Stack,
   TextInput,
   NumberInput,
-  Button,
   Group,
   Text,
   Alert,
@@ -15,6 +12,7 @@ import { IconAlertCircle, IconLayersLinked } from '@tabler/icons-react';
 import type { CreateVirtualKeyGroupRequestDto } from '@/lib/admin-api';
 import { withAdminClient } from '@/lib/client/adminClient';
 import { useFormModal } from '@/hooks/useFormModal';
+import { EntityFormModal } from '@/components/common/EntityFormModal';
 
 interface CreateVirtualKeyGroupModalProps {
   opened: boolean;
@@ -54,7 +52,7 @@ export function CreateVirtualKeyGroupModal({ opened, onClose, onSuccess }: Creat
   });
 
   return (
-    <Modal
+    <EntityFormModal
       opened={opened}
       onClose={handleClose}
       title={
@@ -64,50 +62,40 @@ export function CreateVirtualKeyGroupModal({ opened, onClose, onSuccess }: Creat
         </Group>
       }
       size="md"
+      onSubmit={form.onSubmit(handleSubmit)}
+      loading={loading}
+      submitLabel="Create Group"
     >
-      <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack gap="md">
-          <TextInput
-            label="Group Name"
-            placeholder="Enter a name for this group"
-            required
-            {...form.getInputProps('groupName')}
-          />
+      <TextInput
+        label="Group Name"
+        placeholder="Enter a name for this group"
+        required
+        {...form.getInputProps('groupName')}
+      />
 
-          <TextInput
-            label="External Group ID"
-            placeholder="Optional external identifier"
-            {...form.getInputProps('externalGroupId')}
-          />
+      <TextInput
+        label="External Group ID"
+        placeholder="Optional external identifier"
+        {...form.getInputProps('externalGroupId')}
+      />
 
-          <NumberInput
-            label="Initial Balance"
-            placeholder="0.00"
-            prefix="$"
-            min={0}
-            decimalScale={2}
-            fixedDecimalScale
-            thousandSeparator=","
-            {...form.getInputProps('initialBalance')}
-          />
+      <NumberInput
+        label="Initial Balance"
+        placeholder="0.00"
+        prefix="$"
+        min={0}
+        decimalScale={2}
+        fixedDecimalScale
+        thousandSeparator=","
+        {...form.getInputProps('initialBalance')}
+      />
 
-          <Alert icon={<IconAlertCircle size={16} />} color="blue">
-            <Text size="sm">
-              Virtual keys in this group will share the group&apos;s balance.
-              You can add more credits later.
-            </Text>
-          </Alert>
-
-          <Group justify="flex-end" mt="md">
-            <Button variant="subtle" onClick={handleClose} disabled={loading}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={loading}>
-              Create Group
-            </Button>
-          </Group>
-        </Stack>
-      </form>
-    </Modal>
+      <Alert icon={<IconAlertCircle size={16} />} color="blue">
+        <Text size="sm">
+          Virtual keys in this group will share the group&apos;s balance.
+          You can add more credits later.
+        </Text>
+      </Alert>
+    </EntityFormModal>
   );
 }


### PR DESCRIPTION
## Phase 2 — consolidation (stacked on #1057)

Builds on the dead-code sweep; finishes in-flight consolidations and removes duplicated modal boilerplate.

**Shared abstractions:**
- Adopt the existing `useFormModal` in simple create/update modals. *Selective by design* — modals with custom error handling (e.g. `EditProviderTypeModal` maps `ModelValidationError` onto fields) or multi-op submits (`EditModelModal`) keep their bespoke handlers.
- New **`<JsonEditorField>`** — encapsulates the copy-pasted "Parameters (JSON)" editor (live validation + monospace textarea + inline error + optional preview slot). Adopted in the ModelSeries modals.
- New **`<EntityFormModal>`** — the Modal + form + Cancel/Submit footer shell. Adopted in **9 modals** (ModelSeries ×2, author ×2, provider-tool ×2, CreateModel, VirtualKeyGroup, AddCredits).

**Also:** removes 3 unused deps (`@hello-pangea/dnd`, `video.js`, `@types/video.js`) — pruned from `package.json` and the exclusive lockfile subtree (22 entries) via a reachability walk over the committed lockfile, avoiding a whole-tree `npm install` regen (no npm-version/platform drift).

### Verification
Every commit passes `type-check`, `lint`, `check:api-boundary`, and `test` (30 suites / 336 tests).

### Remaining (future PRs)
- Roll `EntityFormModal`/`JsonEditorField` to the remaining modal shells.
- Generic `<DataTable>` to collapse the ~13–15 near-identical table components.

> Base is \`chore/webadmin-deadcode-sweep\` so the diff shows only Phase 2; it will auto-retarget to \`dev\` when #1057 merges.