### PR TITLE
fix(admin): report real Gateway/Admin health via heartbeat events (#1067)

### DIFF
--- a/Services/ConduitLLM.Admin/DTOs/HealthMonitoringDtos.cs
+++ b/Services/ConduitLLM.Admin/DTOs/HealthMonitoringDtos.cs
@@ -66,6 +66,11 @@ namespace ConduitLLM.Admin.DTOs
         public int Unhealthy { get; set; }
 
         /// <summary>
+        /// Number of services whose status could not be determined.
+        /// </summary>
+        public int Unknown { get; set; }
+
+        /// <summary>
         /// Total number of monitored services.
         /// </summary>
         public int Total { get; set; }
@@ -92,9 +97,10 @@ namespace ConduitLLM.Admin.DTOs
         public string Status { get; set; } = string.Empty;
 
         /// <summary>
-        /// How long the service has been running.
+        /// How long the service has been running, or <c>null</c> when it is not known
+        /// (e.g. a service reporting via heartbeat that has not been seen yet).
         /// </summary>
-        public TimeSpan Uptime { get; set; }
+        public TimeSpan? Uptime { get; set; }
 
         /// <summary>
         /// Timestamp of the last health check (UTC).
@@ -102,9 +108,10 @@ namespace ConduitLLM.Admin.DTOs
         public DateTime LastCheck { get; set; }
 
         /// <summary>
-        /// Health check response time in milliseconds.
+        /// Health check response time in milliseconds, or <c>null</c> when a response time is
+        /// not applicable (e.g. liveness derived from a heartbeat rather than a probe).
         /// </summary>
-        public int ResponseTime { get; set; }
+        public int? ResponseTime { get; set; }
 
         /// <summary>
         /// Service-specific detail values (shape varies per service).
@@ -297,11 +304,6 @@ namespace ConduitLLM.Admin.DTOs
         /// System health percentage (100 minus error rate).
         /// </summary>
         public double SystemHealth { get; set; }
-
-        /// <summary>
-        /// Provider health percentage.
-        /// </summary>
-        public int ProviderHealth { get; set; }
 
         /// <summary>
         /// Average response time in milliseconds for the interval.

--- a/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
@@ -2,11 +2,13 @@ using System.Diagnostics;
 
 using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration;
+using ConduitLLM.Core.Constants;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ConduitLLM.Admin.Endpoints
 {
@@ -35,84 +37,73 @@ namespace ConduitLLM.Admin.Endpoints
         /// <summary>
         /// Gets current service health status.
         /// </summary>
+        /// <param name="dbContextFactory">Factory for the configuration database context.</param>
+        /// <param name="systemInfoService">System information service (database size).</param>
+        /// <param name="healthCheckService">The Admin's registered ASP.NET health checks.</param>
+        /// <param name="heartbeatStore">Store of cross-service liveness heartbeats.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Service health information.</returns>
         private static async Task<IResult> GetServiceHealth(
             [FromServices] IDbContextFactory<ConduitDbContext> dbContextFactory,
             [FromServices] IAdminSystemInfoService systemInfoService,
+            [FromServices] HealthCheckService healthCheckService,
+            [FromServices] IServiceHeartbeatStore heartbeatStore,
             CancellationToken cancellationToken)
         {
             using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
             var services = new List<ServiceStatusDto>();
 
-            // Gateway API Service
-            services.Add(new ServiceStatusDto
-            {
-                Id = "core-api",
-                Name = "Gateway API",
-                Status = "healthy",
-                Uptime = GetProcessUptime(),
-                LastCheck = DateTime.UtcNow,
-                ResponseTime = 15,
-                Details = new
-                {
-                    Version = typeof(HealthMonitoringEndpoints).Assembly.GetName().Version?.ToString() ?? "unknown",
-                    Environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production",
-                    RequestsHandled = await dbContext.RequestLogs
-                        .CountAsync(r => r.Timestamp >= DateTime.UtcNow.AddHours(-1), cancellationToken)
-                }
-            });
+            // Gateway API — real liveness from the Gateway's heartbeat (#1067). The Admin never
+            // probes the Gateway over HTTP; the Gateway publishes a heartbeat event that the
+            // GatewayHeartbeatHandler records, and we derive status from how stale it is.
+            var gatewayHeartbeat = await heartbeatStore.GetAsync(
+                RedisKeys.ServiceHeartbeat.GatewayServiceId, cancellationToken);
+            services.Add(BuildGatewayStatus(gatewayHeartbeat));
 
-            // Admin API Service
-            services.Add(new ServiceStatusDto
-            {
-                Id = "admin-api",
-                Name = "Admin API",
-                Status = "healthy",
-                Uptime = GetProcessUptime(),
-                LastCheck = DateTime.UtcNow,
-                ResponseTime = 10,
-                Details = new
-                {
-                    ActiveSessions = 1, // Current session
-                    ConfiguredKeys = await dbContext.VirtualKeys.CountAsync(cancellationToken)
-                }
-            });
+            // Admin API — real readiness from this process's registered health checks (mirrors
+            // /health/ready), replacing the previous hardcoded "healthy".
+            var configuredKeys = await dbContext.VirtualKeys.CountAsync(cancellationToken);
+            services.Add(await BuildAdminStatusAsync(healthCheckService, configuredKeys, cancellationToken));
 
-            // Database Service
+            // Database — genuinely probed (SELECT 1) with a real response time and best-effort
+            // server uptime (replacing the previous 30-day placeholder).
             var dbHealthCheck = await CheckDatabaseHealth(dbContext, cancellationToken);
+            var dbUptime = await GetDatabaseUptimeAsync(dbContext, cancellationToken);
             services.Add(new ServiceStatusDto
             {
                 Id = "database",
                 Name = "PostgreSQL Database",
                 Status = dbHealthCheck.IsHealthy ? "healthy" : "unhealthy",
-                Uptime = TimeSpan.FromDays(30), // Would need actual DB uptime
+                Uptime = dbUptime,
                 LastCheck = DateTime.UtcNow,
                 ResponseTime = dbHealthCheck.ResponseTime,
                 Details = new
                 {
                     ConnectionPooling = true,
-                    ActiveConnections = 5, // Would need actual connection count
                     DatabaseSize = await GetDatabaseSize(systemInfoService)
                 }
             });
 
-
-            // Calculate overall health
+            // Calculate overall health. "unknown" services (e.g. a Gateway not seen yet) are
+            // not counted as healthy — they pull the rollup down to at least "degraded".
             var healthyCount = services.Count(s => s.Status == "healthy");
             var degradedCount = services.Count(s => s.Status == "degraded");
             var unhealthyCount = services.Count(s => s.Status == "unhealthy");
+            var unknownCount = services.Count(s => s.Status == "unknown");
 
             return Results.Ok(new ServiceHealthResponse
             {
                 Timestamp = DateTime.UtcNow,
-                OverallStatus = unhealthyCount > 0 ? "unhealthy" : (degradedCount > 0 ? "degraded" : "healthy"),
+                OverallStatus = unhealthyCount > 0
+                    ? "unhealthy"
+                    : (degradedCount > 0 || unknownCount > 0) ? "degraded" : "healthy",
                 Summary = new ServiceHealthSummary
                 {
                     Healthy = healthyCount,
                     Degraded = degradedCount,
                     Unhealthy = unhealthyCount,
+                    Unknown = unknownCount,
                     Total = services.Count
                 },
                 Services = services
@@ -122,6 +113,7 @@ namespace ConduitLLM.Admin.Endpoints
         /// <summary>
         /// Gets incident history.
         /// </summary>
+        /// <param name="dbContextFactory">Factory for the configuration database context.</param>
         /// <param name="days">Number of days to look back (default: 7).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Incident history data.</returns>
@@ -174,8 +166,6 @@ namespace ConduitLLM.Admin.Endpoints
                 }
             }).ToList();
 
-            // Health failures removed - no longer tracking provider health
-
             var allIncidents = incidents
                 .OrderByDescending(i => i.StartTime)
                 .ToList();
@@ -203,6 +193,7 @@ namespace ConduitLLM.Admin.Endpoints
         /// <summary>
         /// Gets health history data.
         /// </summary>
+        /// <param name="dbContextFactory">Factory for the configuration database context.</param>
         /// <param name="hours">Number of hours to look back (default: 24).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Health history time series.</returns>
@@ -223,8 +214,6 @@ namespace ConduitLLM.Admin.Endpoints
             {
                 var intervalEnd = currentTime.AddMinutes(intervalMinutes);
 
-                // Provider health tracking has been removed
-
                 // Get error rates for this interval
                 var errorStats = await dbContext.RequestLogs
                     .Where(r => r.Timestamp >= currentTime && r.Timestamp < intervalEnd)
@@ -243,7 +232,6 @@ namespace ConduitLLM.Admin.Endpoints
                     SystemHealth = errorStats?.TotalRequests > 0
                         ? 100 - (errorStats.ErrorCount * 100.0 / errorStats.TotalRequests)
                         : 100,
-                    ProviderHealth = 100, // Provider health tracking removed
                     ResponseTime = errorStats?.AvgLatency ?? 0,
                     RequestVolume = errorStats?.TotalRequests ?? 0,
                     ErrorRate = errorStats?.TotalRequests > 0
@@ -263,6 +251,129 @@ namespace ConduitLLM.Admin.Endpoints
             });
         }
 
+        /// <summary>
+        /// Builds the Gateway API status from its most recent heartbeat (#1067). Freshness
+        /// thresholds are derived from the interval the Gateway itself reported, so the two
+        /// services need not share configuration. Staleness is measured against the Admin's
+        /// receive time to avoid cross-service clock skew.
+        /// </summary>
+        private static ServiceStatusDto BuildGatewayStatus(ServiceHeartbeatSnapshot? heartbeat)
+        {
+            const string id = "core-api";
+            const string name = "Gateway API";
+
+            if (heartbeat == null)
+            {
+                return new ServiceStatusDto
+                {
+                    Id = id,
+                    Name = name,
+                    Status = "unknown",
+                    Uptime = null,
+                    LastCheck = DateTime.UtcNow,
+                    ResponseTime = null,
+                    Details = new
+                    {
+                        Source = "heartbeat",
+                        Reason = "No heartbeat received from the Gateway yet"
+                    }
+                };
+            }
+
+            var intervalSeconds = heartbeat.IntervalSeconds > 0
+                ? heartbeat.IntervalSeconds
+                : ServiceHeartbeatEvaluator.DefaultIntervalSeconds;
+            var ageSeconds = Math.Max(0, (DateTime.UtcNow - heartbeat.ReceivedAtUtc).TotalSeconds);
+
+            // Fresh within 2 intervals → healthy; within 4 → degraded (heartbeats delayed);
+            // older → unhealthy (heartbeats lost — the Gateway is likely down or unreachable).
+            var status = ServiceHeartbeatEvaluator.EvaluateStatus(ageSeconds, intervalSeconds);
+
+            return new ServiceStatusDto
+            {
+                Id = id,
+                Name = name,
+                Status = status,
+                Uptime = TimeSpan.FromSeconds(heartbeat.UptimeSeconds),
+                LastCheck = heartbeat.ReceivedAtUtc,
+                ResponseTime = null, // liveness signal — no request/response latency to report
+                Details = new
+                {
+                    Source = "heartbeat",
+                    heartbeat.InstanceId,
+                    heartbeat.Version,
+                    LastHeartbeatUtc = heartbeat.ReceivedAtUtc,
+                    heartbeat.ReportedAtUtc,
+                    HeartbeatAgeSeconds = Math.Round(ageSeconds, 1),
+                    HeartbeatIntervalSeconds = intervalSeconds
+                }
+            };
+        }
+
+        /// <summary>
+        /// Builds the Admin API status from this process's registered readiness health checks,
+        /// mirroring the <c>/health/ready</c> endpoint (#1067). Replaces the previous hardcoded
+        /// "healthy" with a real status and a measured response time.
+        /// </summary>
+        private static async Task<ServiceStatusDto> BuildAdminStatusAsync(
+            HealthCheckService healthCheckService,
+            int configuredKeys,
+            CancellationToken cancellationToken)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            HealthReport report;
+            try
+            {
+                // Same predicate as MapHealthChecks("/health/ready"): "ready"-tagged (or untagged) checks.
+                report = await healthCheckService.CheckHealthAsync(
+                    registration => registration.Tags.Contains("ready") || registration.Tags.Count == 0,
+                    cancellationToken);
+            }
+            catch (Exception)
+            {
+                stopwatch.Stop();
+                return new ServiceStatusDto
+                {
+                    Id = "admin-api",
+                    Name = "Admin API",
+                    Status = "unhealthy",
+                    Uptime = GetProcessUptime(),
+                    LastCheck = DateTime.UtcNow,
+                    ResponseTime = (int)stopwatch.ElapsedMilliseconds,
+                    Details = new { ConfiguredKeys = configuredKeys, Error = "Health check execution failed" }
+                };
+            }
+            stopwatch.Stop();
+
+            return new ServiceStatusDto
+            {
+                Id = "admin-api",
+                Name = "Admin API",
+                Status = MapHealthStatus(report.Status),
+                Uptime = GetProcessUptime(),
+                LastCheck = DateTime.UtcNow,
+                ResponseTime = (int)stopwatch.ElapsedMilliseconds,
+                Details = new
+                {
+                    ConfiguredKeys = configuredKeys,
+                    Checks = report.Entries.Select(entry => new
+                    {
+                        Name = entry.Key,
+                        Status = entry.Value.Status.ToString(),
+                        entry.Value.Description,
+                        DurationMs = Math.Round(entry.Value.Duration.TotalMilliseconds, 1)
+                    }).ToArray()
+                }
+            };
+        }
+
+        private static string MapHealthStatus(HealthStatus status) => status switch
+        {
+            HealthStatus.Healthy => "healthy",
+            HealthStatus.Degraded => "degraded",
+            _ => "unhealthy"
+        };
+
         private static async Task<(bool IsHealthy, int ResponseTime)> CheckDatabaseHealth(
             ConduitDbContext dbContext,
             CancellationToken cancellationToken)
@@ -277,6 +388,36 @@ namespace ConduitLLM.Admin.Endpoints
             catch
             {
                 return (false, -1);
+            }
+        }
+
+        /// <summary>
+        /// Best-effort PostgreSQL server uptime via <c>pg_postmaster_start_time()</c>. Returns
+        /// <c>null</c> on any failure or for a non-PostgreSQL provider, replacing the previous
+        /// hardcoded 30-day placeholder.
+        /// </summary>
+        private static async Task<TimeSpan?> GetDatabaseUptimeAsync(
+            ConduitDbContext dbContext,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var providerName = dbContext.Database.ProviderName ?? string.Empty;
+                if (!providerName.Contains("Npgsql", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                var seconds = await dbContext.Database
+                    .SqlQueryRaw<double>(
+                        "SELECT EXTRACT(EPOCH FROM (now() - pg_postmaster_start_time()))::double precision AS \"Value\"")
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                return seconds > 0 ? TimeSpan.FromSeconds(seconds) : null;
+            }
+            catch
+            {
+                return null; // best effort — uptime is informational only
             }
         }
 

--- a/Services/ConduitLLM.Admin/EventHandlers/GatewayHeartbeatHandler.cs
+++ b/Services/ConduitLLM.Admin/EventHandlers/GatewayHeartbeatHandler.cs
@@ -1,0 +1,58 @@
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Constants;
+using ConduitLLM.Core.Events;
+
+namespace ConduitLLM.Admin.EventHandlers
+{
+    /// <summary>
+    /// Records the Gateway's periodic liveness heartbeat (#1067) so the health dashboard can
+    /// report the Gateway's real status from staleness instead of a hardcoded literal.
+    /// </summary>
+    /// <remarks>
+    /// Failures are swallowed on purpose: a dropped heartbeat write must NOT trigger Wolverine
+    /// redelivery (the next heartbeat, seconds later, supersedes it), so this handler never
+    /// throws out of <see cref="HandleAsync"/>.
+    /// </remarks>
+    public class GatewayHeartbeatHandler : IEventHandler<GatewayHeartbeat>
+    {
+        private readonly IServiceHeartbeatStore _store;
+        private readonly ILogger<GatewayHeartbeatHandler> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GatewayHeartbeatHandler"/> class.
+        /// </summary>
+        public GatewayHeartbeatHandler(
+            IServiceHeartbeatStore store,
+            ILogger<GatewayHeartbeatHandler> logger)
+        {
+            _store = store;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task HandleAsync(GatewayHeartbeat message, IEventContext context)
+        {
+            try
+            {
+                await _store.RecordAsync(new ServiceHeartbeatSnapshot
+                {
+                    ServiceId = RedisKeys.ServiceHeartbeat.GatewayServiceId,
+                    InstanceId = message.InstanceId,
+                    Version = message.Version,
+                    UptimeSeconds = message.UptimeSeconds,
+                    IntervalSeconds = message.IntervalSeconds,
+                    ReportedAtUtc = message.Timestamp,
+                    ReceivedAtUtc = DateTime.UtcNow
+                }, context.CancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Swallow — never redeliver a heartbeat (the next one supersedes it).
+                _logger.LogWarning(ex,
+                    "Failed to record Gateway heartbeat from instance {InstanceId}",
+                    message.InstanceId);
+            }
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/Interfaces/IServiceHeartbeatStore.cs
+++ b/Services/ConduitLLM.Admin/Interfaces/IServiceHeartbeatStore.cs
@@ -1,0 +1,48 @@
+namespace ConduitLLM.Admin.Interfaces
+{
+    /// <summary>
+    /// Records and retrieves the most recent liveness heartbeat for a backend service
+    /// (currently the Gateway, #1067). Backed by Redis when available so the snapshot is shared
+    /// across Admin instances, with an in-process fallback for single-instance/dev where Redis
+    /// is absent.
+    /// </summary>
+    public interface IServiceHeartbeatStore
+    {
+        /// <summary>Records the latest heartbeat for a service.</summary>
+        Task RecordAsync(ServiceHeartbeatSnapshot heartbeat, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the most recent heartbeat for the given service id, or <c>null</c> if none has
+        /// been recorded recently (never seen, or the stored snapshot has expired).
+        /// </summary>
+        Task<ServiceHeartbeatSnapshot?> GetAsync(string serviceId, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// A recorded service heartbeat. Serialized to Redis; the reader compares
+    /// <see cref="ReceivedAtUtc"/> against <see cref="IntervalSeconds"/> to judge staleness.
+    /// </summary>
+    public sealed class ServiceHeartbeatSnapshot
+    {
+        /// <summary>Logical service identifier (e.g. "gateway").</summary>
+        public string ServiceId { get; set; } = string.Empty;
+
+        /// <summary>Reporting instance (machine name + process id).</summary>
+        public string InstanceId { get; set; } = string.Empty;
+
+        /// <summary>Reported service version.</summary>
+        public string Version { get; set; } = string.Empty;
+
+        /// <summary>Reported process uptime in seconds at the time of the heartbeat.</summary>
+        public double UptimeSeconds { get; set; }
+
+        /// <summary>The reporting service's heartbeat cadence in seconds.</summary>
+        public double IntervalSeconds { get; set; }
+
+        /// <summary>When the service reported the heartbeat (its clock).</summary>
+        public DateTime ReportedAtUtc { get; set; }
+
+        /// <summary>When the Admin recorded it (Admin's clock — used for staleness, avoiding cross-service clock skew).</summary>
+        public DateTime ReceivedAtUtc { get; set; }
+    }
+}

--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -15,6 +15,11 @@ public partial class Program
         // Backend-neutral: the shared cache-invalidation IEventHandler<T> implementations (#919).
         ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationHandlers(builder.Services);
 
+        // Gateway liveness heartbeat handler (#1067): records the Gateway's heartbeat so the
+        // health dashboard reports the Gateway's real status. The matching bridge is added in
+        // the AddConduitWolverine callback below.
+        builder.Services.AddEventHandler<ConduitLLM.Core.Events.GatewayHeartbeat, ConduitLLM.Admin.EventHandlers.GatewayHeartbeatHandler>();
+
         // Wolverine on the PostgreSQL transport is the only messaging backend as of I3.1
         // (#932, epic #909). Resolve still runs so a stale rollback backend value fails the
         // boot with a clear pointer to Wolverine (see MessagingBackendResolver) instead of
@@ -31,6 +36,11 @@ public partial class Program
         builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin", opts =>
         {
             ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
+
+            // Gateway liveness heartbeat bridge (#1067). Registered unconditionally (like the
+            // shared bridges above): on the in-memory transport the bridge alone routes the
+            // event; on Postgres the topology routing below delivers it to admin-events.
+            opts.AddEventBridge<ConduitLLM.Core.Events.GatewayHeartbeat>();
 
             // Event→queue topology (#926): the same publish routing as the Gateway
             // (so Admin publishes land on the Gateway's queues), listening only on

--- a/Services/ConduitLLM.Admin/Program.Services.cs
+++ b/Services/ConduitLLM.Admin/Program.Services.cs
@@ -56,6 +56,12 @@ public partial class Program
             startupLogger.LogWarning("Using in-memory cache — ephemeral keys will not work across instances");
         }
 
+        // Cross-service liveness heartbeat store (#1067): records the Gateway heartbeat the
+        // Admin consumes over the event bus so the health dashboard reports the Gateway's real
+        // status. Singleton so its in-process fallback (used when Redis is absent) is shared
+        // between the event handler (writer) and the dashboard endpoint (reader).
+        builder.Services.AddSingleton<ConduitLLM.Admin.Interfaces.IServiceHeartbeatStore, ConduitLLM.Admin.Services.ServiceHeartbeatStore>();
+
         // Add SignalR with shared configuration (MessagePack, Redis backplane)
         var signalRRedisConnectionString = builder.Configuration.GetConnectionString("RedisSignalR") ?? redisConnectionString;
         builder.Services.AddConduitSignalR(

--- a/Services/ConduitLLM.Admin/Services/ServiceHeartbeatEvaluator.cs
+++ b/Services/ConduitLLM.Admin/Services/ServiceHeartbeatEvaluator.cs
@@ -1,0 +1,39 @@
+namespace ConduitLLM.Admin.Services
+{
+    /// <summary>
+    /// Derives a health status string from how stale a service's heartbeat is (#1067). Kept
+    /// pure and side-effect-free so the staleness thresholds are unit-testable.
+    /// </summary>
+    public static class ServiceHeartbeatEvaluator
+    {
+        /// <summary>Fallback cadence used when a heartbeat did not report its own interval.</summary>
+        public const double DefaultIntervalSeconds = 30;
+
+        /// <summary>A heartbeat is "healthy" while its age is within this many intervals.</summary>
+        public const int HealthyIntervalMultiple = 2;
+
+        /// <summary>
+        /// A heartbeat is "degraded" while its age is within this many intervals; anything older
+        /// is "unhealthy" (heartbeats lost — the service is likely down or unreachable).
+        /// </summary>
+        public const int DegradedIntervalMultiple = 4;
+
+        /// <summary>
+        /// Maps a heartbeat age to a status: "healthy" while fresh (≤2 intervals), "degraded"
+        /// while delayed (≤4 intervals), otherwise "unhealthy".
+        /// </summary>
+        /// <param name="ageSeconds">How long ago the heartbeat was received, in seconds.</param>
+        /// <param name="intervalSeconds">The reporting service's heartbeat cadence; falls back to <see cref="DefaultIntervalSeconds"/> when not positive.</param>
+        public static string EvaluateStatus(double ageSeconds, double intervalSeconds)
+        {
+            var interval = intervalSeconds > 0 ? intervalSeconds : DefaultIntervalSeconds;
+
+            if (ageSeconds <= interval * HealthyIntervalMultiple)
+            {
+                return "healthy";
+            }
+
+            return ageSeconds <= interval * DegradedIntervalMultiple ? "degraded" : "unhealthy";
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/Services/ServiceHeartbeatStore.cs
+++ b/Services/ConduitLLM.Admin/Services/ServiceHeartbeatStore.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Core.Constants;
+
+using StackExchange.Redis;
+
+namespace ConduitLLM.Admin.Services
+{
+    /// <summary>
+    /// Redis-backed <see cref="IServiceHeartbeatStore"/> (#1067). The last heartbeat is written
+    /// under a short TTL so a present value always means "seen recently"; the reader still
+    /// derives health from the recorded age, not mere key presence. When Redis is unavailable
+    /// (single-instance/dev) it degrades to an in-process snapshot so the dashboard keeps
+    /// working — mirrors the optional-<c>IConnectionMultiplexer</c> pattern used by
+    /// <see cref="MediaCleanupStatusService"/>.
+    /// </summary>
+    public class ServiceHeartbeatStore : IServiceHeartbeatStore
+    {
+        /// <summary>
+        /// TTL for the persisted snapshot. Comfortably longer than several heartbeat intervals
+        /// so a brief gap doesn't evict it; the reader decides staleness from the age.
+        /// </summary>
+        private static readonly TimeSpan SnapshotTtl = TimeSpan.FromMinutes(5);
+
+        private readonly IConnectionMultiplexer? _redis;
+        private readonly ILogger<ServiceHeartbeatStore> _logger;
+        private readonly ConcurrentDictionary<string, ServiceHeartbeatSnapshot> _inProcess = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceHeartbeatStore"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="redis">The Redis connection, or <c>null</c> when Redis is not configured.</param>
+        public ServiceHeartbeatStore(
+            ILogger<ServiceHeartbeatStore> logger,
+            IConnectionMultiplexer? redis = null)
+        {
+            _logger = logger;
+            _redis = redis;
+        }
+
+        /// <inheritdoc />
+        public async Task RecordAsync(ServiceHeartbeatSnapshot heartbeat, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(heartbeat);
+
+            // Always keep an in-process copy so a Redis-less single instance still works.
+            _inProcess[heartbeat.ServiceId] = heartbeat;
+
+            if (_redis == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var db = _redis.GetDatabase();
+                var json = JsonSerializer.Serialize(heartbeat);
+                await db.StringSetAsync(RedisKeys.ServiceHeartbeat.For(heartbeat.ServiceId), json, SnapshotTtl);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to persist {ServiceId} heartbeat to Redis; using in-process fallback",
+                    heartbeat.ServiceId);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<ServiceHeartbeatSnapshot?> GetAsync(string serviceId, CancellationToken cancellationToken = default)
+        {
+            if (_redis != null)
+            {
+                try
+                {
+                    var db = _redis.GetDatabase();
+                    var json = await db.StringGetAsync(RedisKeys.ServiceHeartbeat.For(serviceId));
+
+                    // Redis is authoritative when present: a missing key means "not seen
+                    // recently" (TTL expired or never written), so return null rather than a
+                    // stale in-process copy.
+                    return json.IsNullOrEmpty
+                        ? null
+                        : JsonSerializer.Deserialize<ServiceHeartbeatSnapshot>(json.ToString());
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to read {ServiceId} heartbeat from Redis; falling back to in-process copy",
+                        serviceId);
+                }
+            }
+
+            return _inProcess.TryGetValue(serviceId, out var snapshot) ? snapshot : null;
+        }
+    }
+}

--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -23951,11 +23951,6 @@
             "description": "System health percentage (100 minus error rate).",
             "format": "double"
           },
-          "providerHealth": {
-            "type": "integer",
-            "description": "Provider health percentage.",
-            "format": "int32"
-          },
           "responseTime": {
             "type": "number",
             "description": "Average response time in milliseconds for the interval.",
@@ -28821,6 +28816,11 @@
             "description": "Number of unhealthy services.",
             "format": "int32"
           },
+          "unknown": {
+            "type": "integer",
+            "description": "Number of services whose status could not be determined.",
+            "format": "int32"
+          },
           "total": {
             "type": "integer",
             "description": "Total number of monitored services.",
@@ -28846,8 +28846,11 @@
           },
           "uptime": {
             "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": "string",
-            "description": "How long the service has been running."
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "How long the service has been running, or `null` when it is not known\r\n(e.g. a service reporting via heartbeat that has not been seen yet)."
           },
           "lastCheck": {
             "type": "string",
@@ -28855,8 +28858,11 @@
             "format": "date-time"
           },
           "responseTime": {
-            "type": "integer",
-            "description": "Health check response time in milliseconds.",
+            "type": [
+              "null",
+              "integer"
+            ],
+            "description": "Health check response time in milliseconds, or `null` when a response time is\r\nnot applicable (e.g. liveness derived from a heartbeat rather than a probe).",
             "format": "int32"
           },
           "details": {

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -81,5 +81,12 @@ public partial class Program
             options.MaxBatchDelay = TimeSpan.FromMilliseconds(100);
             options.ConcurrentPublishers = 3;
         });
+
+        // Gateway liveness heartbeat (#1067): every instance publishes a GatewayHeartbeat via
+        // IEventBus so the Admin health dashboard reports the Gateway's real status from
+        // staleness (keeps Admin↔Gateway event-only — no synchronous HTTP probe). Registered
+        // with a plain AddHostedService — NOT leader-elected — because a per-instance liveness
+        // signal must be emitted by every instance.
+        builder.Services.AddHostedService<ConduitLLM.Gateway.Services.GatewayHeartbeatPublisher>();
     }
 }

--- a/Services/ConduitLLM.Gateway/Services/GatewayHeartbeatPublisher.cs
+++ b/Services/ConduitLLM.Gateway/Services/GatewayHeartbeatPublisher.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Events;
+
+namespace ConduitLLM.Gateway.Services
+{
+    /// <summary>
+    /// Publishes a periodic <see cref="GatewayHeartbeat"/> so the Admin health dashboard can
+    /// report the Gateway's real liveness instead of a hardcoded status (#1067).
+    /// </summary>
+    /// <remarks>
+    /// Runs on EVERY Gateway instance (deliberately NOT leader-elected): the heartbeat is a
+    /// per-instance liveness signal, so while any instance is up the dashboard keeps seeing a
+    /// fresh heartbeat, and a full outage stops every heartbeat and surfaces as unhealthy.
+    /// Publishing via <see cref="IEventBus"/> keeps Admin↔Gateway strictly event-driven
+    /// (epic #909) — there is no synchronous Admin→Gateway HTTP probe.
+    /// </remarks>
+    public class GatewayHeartbeatPublisher : BackgroundService
+    {
+        /// <summary>Floor on the configured interval to avoid flooding the bus.</summary>
+        private const int MinimumIntervalSeconds = 5;
+
+        private static readonly string InstanceIdentifier =
+            $"{Environment.MachineName}_{Environment.ProcessId}";
+
+        private static readonly string ServiceVersion =
+            typeof(GatewayHeartbeatPublisher).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+        private static readonly DateTime ProcessStartUtc =
+            Process.GetCurrentProcess().StartTime.ToUniversalTime();
+
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<GatewayHeartbeatPublisher> _logger;
+        private readonly TimeSpan _interval;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GatewayHeartbeatPublisher"/> class.
+        /// </summary>
+        public GatewayHeartbeatPublisher(
+            IServiceProvider serviceProvider,
+            IConfiguration configuration,
+            ILogger<GatewayHeartbeatPublisher> logger)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            var seconds = configuration.GetValue("GatewayHeartbeat:IntervalSeconds", 30);
+            _interval = TimeSpan.FromSeconds(Math.Max(MinimumIntervalSeconds, seconds));
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation(
+                "Gateway heartbeat publisher started (interval {IntervalSeconds}s, instance {InstanceId})",
+                _interval.TotalSeconds, InstanceIdentifier);
+
+            try
+            {
+                // Emit one immediately so a freshly started Gateway is reflected quickly.
+                await PublishHeartbeatAsync(stoppingToken);
+
+                using var timer = new PeriodicTimer(_interval);
+                while (await timer.WaitForNextTickAsync(stoppingToken))
+                {
+                    await PublishHeartbeatAsync(stoppingToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown.
+            }
+        }
+
+        private async Task PublishHeartbeatAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // IEventBus is registered Scoped, so resolve it in a fresh scope per publish
+                // (a singleton BackgroundService cannot inject it directly).
+                using var scope = _serviceProvider.CreateScope();
+                var eventBus = scope.ServiceProvider.GetRequiredService<IEventBus>();
+
+                await eventBus.PublishAsync(new GatewayHeartbeat
+                {
+                    InstanceId = InstanceIdentifier,
+                    Version = ServiceVersion,
+                    UptimeSeconds = (DateTime.UtcNow - ProcessStartUtc).TotalSeconds,
+                    IntervalSeconds = _interval.TotalSeconds
+                }, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Shutting down — ignore.
+            }
+            catch (Exception ex)
+            {
+                // A missed heartbeat is self-correcting (the next tick supersedes it); never
+                // let it crash the background service.
+                _logger.LogWarning(ex, "Failed to publish Gateway heartbeat");
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Core/Constants/RedisKeys.cs
+++ b/Shared/ConduitLLM.Core/Constants/RedisKeys.cs
@@ -184,4 +184,22 @@ public static class RedisKeys
     }
 
     #endregion
+
+    #region Service Health
+
+    /// <summary>
+    /// Keys for cross-service liveness heartbeats (#1067). The Gateway publishes a heartbeat
+    /// event; the Admin records the last-seen snapshot under these keys so the health dashboard
+    /// can report a service's real status from staleness. Used by ServiceHeartbeatStore.
+    /// </summary>
+    public static class ServiceHeartbeat
+    {
+        /// <summary>Logical service id for the Gateway ("core-api") heartbeat.</summary>
+        public const string GatewayServiceId = "gateway";
+
+        /// <summary>Last-seen heartbeat snapshot for a service, keyed by its logical service id.</summary>
+        public static string For(string serviceId) => $"health:heartbeat:{serviceId}";
+    }
+
+    #endregion
 }

--- a/Shared/ConduitLLM.Core/Events/GatewayHeartbeat.cs
+++ b/Shared/ConduitLLM.Core/Events/GatewayHeartbeat.cs
@@ -1,0 +1,32 @@
+namespace ConduitLLM.Core.Events
+{
+    /// <summary>
+    /// Periodic liveness heartbeat published by every Gateway ("core-api") instance so the
+    /// Admin health dashboard can report the Gateway's real status from staleness instead of a
+    /// hardcoded literal (#1067). Consumed by the Admin's <c>GatewayHeartbeatHandler</c>, which
+    /// records the last-seen snapshot; the dashboard derives health from how stale that
+    /// snapshot is.
+    /// </summary>
+    /// <remarks>
+    /// Publishing liveness as an event keeps Admin↔Gateway strictly event-driven (epic #909) —
+    /// no synchronous Admin→Gateway HTTP probe. The base <see cref="DomainEvent.Timestamp"/>
+    /// carries the Gateway's publish time.
+    /// </remarks>
+    public record GatewayHeartbeat : DomainEvent
+    {
+        /// <summary>Identifies the reporting Gateway instance (machine name + process id).</summary>
+        public string InstanceId { get; init; } = string.Empty;
+
+        /// <summary>Assembly version of the reporting Gateway.</summary>
+        public string Version { get; init; } = string.Empty;
+
+        /// <summary>Wall-clock seconds the reporting Gateway process has been running.</summary>
+        public double UptimeSeconds { get; init; }
+
+        /// <summary>
+        /// The publisher's heartbeat cadence in seconds, so the consumer can judge staleness
+        /// without sharing configuration between the two services.
+        /// </summary>
+        public double IntervalSeconds { get; init; }
+    }
+}

--- a/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
+++ b/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
@@ -127,6 +127,16 @@ namespace ConduitLLM.Core.Messaging
             SharedCacheInvalidationMessagingExtensions.BridgedEventTypes;
 
         /// <summary>
+        /// Gateway→Admin liveness heartbeat (#1067). Admin-only, so it rides the default
+        /// <see cref="AdminEventsQueue"/> that Admin already listens on — no new queue or
+        /// listener needed.
+        /// </summary>
+        public static readonly IReadOnlyList<Type> AdminHeartbeatEvents = new[]
+        {
+            typeof(GatewayHeartbeat),
+        };
+
+        /// <summary>
         /// Declares the publish routing rules. Applied identically on every host so an
         /// event lands on its consumer's queue no matter which service publishes it.
         /// </summary>
@@ -141,6 +151,10 @@ namespace ConduitLLM.Core.Messaging
             // Fan-out: shared cache events go to both services' queues.
             RouteAll(options, SharedEvents, GatewayEventsQueue);
             RouteAll(options, SharedEvents, AdminEventsQueue);
+
+            // Gateway→Admin liveness heartbeat (#1067): published by the Gateway, consumed by
+            // Admin on its existing queue.
+            RouteAll(options, AdminHeartbeatEvents, AdminEventsQueue);
         }
 
         /// <summary>

--- a/Tests/ConduitLLM.Tests/Admin/EventHandlers/GatewayHeartbeatHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/EventHandlers/GatewayHeartbeatHandlerTests.cs
@@ -1,0 +1,65 @@
+using ConduitLLM.Admin.EventHandlers;
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Constants;
+using ConduitLLM.Core.Events;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Admin.EventHandlers;
+
+public class GatewayHeartbeatHandlerTests
+{
+    private readonly Mock<IServiceHeartbeatStore> _store = new();
+    private readonly GatewayHeartbeatHandler _handler;
+
+    public GatewayHeartbeatHandlerTests()
+    {
+        _handler = new GatewayHeartbeatHandler(_store.Object, Mock.Of<ILogger<GatewayHeartbeatHandler>>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_RecordsSnapshotMappedFromTheMessage()
+    {
+        ServiceHeartbeatSnapshot? recorded = null;
+        _store
+            .Setup(s => s.RecordAsync(It.IsAny<ServiceHeartbeatSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<ServiceHeartbeatSnapshot, CancellationToken>((s, _) => recorded = s)
+            .Returns(Task.CompletedTask);
+
+        var message = new GatewayHeartbeat
+        {
+            InstanceId = "host_1234",
+            Version = "1.2.3.4",
+            UptimeSeconds = 99,
+            IntervalSeconds = 30
+        };
+
+        await _handler.HandleAsync(message, Mock.Of<IEventContext>());
+
+        recorded.Should().NotBeNull();
+        recorded!.ServiceId.Should().Be(RedisKeys.ServiceHeartbeat.GatewayServiceId);
+        recorded.InstanceId.Should().Be("host_1234");
+        recorded.Version.Should().Be("1.2.3.4");
+        recorded.UptimeSeconds.Should().Be(99);
+        recorded.IntervalSeconds.Should().Be(30);
+        recorded.ReportedAtUtc.Should().Be(message.Timestamp);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenStoreThrows_DoesNotPropagate()
+    {
+        // A failed heartbeat write must not trigger Wolverine redelivery — the handler swallows.
+        _store
+            .Setup(s => s.RecordAsync(It.IsAny<ServiceHeartbeatSnapshot>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var act = async () => await _handler.HandleAsync(new GatewayHeartbeat(), Mock.Of<IEventContext>());
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatEvaluatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatEvaluatorTests.cs
@@ -1,0 +1,25 @@
+using ConduitLLM.Admin.Services;
+
+using FluentAssertions;
+
+namespace ConduitLLM.Tests.Admin.Services;
+
+public class ServiceHeartbeatEvaluatorTests
+{
+    [Theory]
+    [InlineData(0, 30, "healthy")]      // just recorded
+    [InlineData(30, 30, "healthy")]     // one interval old
+    [InlineData(60, 30, "healthy")]     // exactly 2 intervals → still healthy (boundary)
+    [InlineData(61, 30, "degraded")]    // just past 2 intervals
+    [InlineData(120, 30, "degraded")]   // exactly 4 intervals → still degraded (boundary)
+    [InlineData(121, 30, "unhealthy")]  // past 4 intervals → heartbeats lost
+    [InlineData(600, 30, "unhealthy")]  // long gone
+    [InlineData(60, 0, "healthy")]      // non-positive interval falls back to the 30s default (2x = 60)
+    [InlineData(61, 0, "degraded")]     // ...and past that default is degraded
+    [InlineData(20, 15, "healthy")]     // a different reported cadence is honored
+    [InlineData(70, 15, "unhealthy")]   // 70s with a 15s cadence is > 4 intervals
+    public void EvaluateStatus_MapsHeartbeatAgeToStatus(double ageSeconds, double intervalSeconds, string expected)
+    {
+        ServiceHeartbeatEvaluator.EvaluateStatus(ageSeconds, intervalSeconds).Should().Be(expected);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatStoreTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatStoreTests.cs
@@ -1,0 +1,68 @@
+using ConduitLLM.Admin.Interfaces;
+using ConduitLLM.Admin.Services;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Admin.Services;
+
+public class ServiceHeartbeatStoreTests
+{
+    // Constructed without a Redis connection, so every test exercises the in-process fallback
+    // path (the single-instance / Redis-absent behavior).
+    private readonly ServiceHeartbeatStore _store =
+        new(Mock.Of<ILogger<ServiceHeartbeatStore>>());
+
+    [Fact]
+    public async Task GetAsync_WhenNothingRecorded_ReturnsNull()
+    {
+        var result = await _store.GetAsync("gateway");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordAsync_ThenGetAsync_ReturnsTheStoredSnapshot()
+    {
+        var snapshot = new ServiceHeartbeatSnapshot
+        {
+            ServiceId = "gateway",
+            InstanceId = "host_1234",
+            Version = "1.2.3.4",
+            UptimeSeconds = 42,
+            IntervalSeconds = 30,
+            ReportedAtUtc = new DateTime(2026, 7, 22, 10, 0, 0, DateTimeKind.Utc),
+            ReceivedAtUtc = new DateTime(2026, 7, 22, 10, 0, 1, DateTimeKind.Utc)
+        };
+
+        await _store.RecordAsync(snapshot);
+        var result = await _store.GetAsync("gateway");
+
+        result.Should().BeSameAs(snapshot);
+    }
+
+    [Fact]
+    public async Task GetAsync_ForADifferentServiceId_ReturnsNull()
+    {
+        await _store.RecordAsync(new ServiceHeartbeatSnapshot { ServiceId = "gateway" });
+
+        var result = await _store.GetAsync("some-other-service");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordAsync_Twice_KeepsTheLatestSnapshot()
+    {
+        await _store.RecordAsync(new ServiceHeartbeatSnapshot { ServiceId = "gateway", InstanceId = "old" });
+        var latest = new ServiceHeartbeatSnapshot { ServiceId = "gateway", InstanceId = "new" };
+        await _store.RecordAsync(latest);
+
+        var result = await _store.GetAsync("gateway");
+
+        result!.InstanceId.Should().Be("new");
+    }
+}

--- a/WebAdmin/src/generated/admin-api.ts
+++ b/WebAdmin/src/generated/admin-api.ts
@@ -4283,11 +4283,6 @@ export interface components {
        */
       systemHealth?: number;
       /**
-       * Format: int32
-       * @description Provider health percentage.
-       */
-      providerHealth?: number;
-      /**
        * Format: double
        * @description Average response time in milliseconds for the interval.
        */
@@ -6399,6 +6394,11 @@ export interface components {
       unhealthy?: number;
       /**
        * Format: int32
+       * @description Number of services whose status could not be determined.
+       */
+      unknown?: number;
+      /**
+       * Format: int32
        * @description Total number of monitored services.
        */
       total?: number;
@@ -6411,8 +6411,9 @@ export interface components {
       name?: string;
       /** @description Health status of the service (healthy, degraded, or unhealthy). */
       status?: string;
-      /** @description How long the service has been running. */
-      uptime?: string;
+      /** @description How long the service has been running, or `null` when it is not known
+       *     (e.g. a service reporting via heartbeat that has not been seen yet). */
+      uptime?: null | string;
       /**
        * Format: date-time
        * @description Timestamp of the last health check (UTC).
@@ -6420,9 +6421,10 @@ export interface components {
       lastCheck?: string;
       /**
        * Format: int32
-       * @description Health check response time in milliseconds.
+       * @description Health check response time in milliseconds, or `null` when a response time is
+       *     not applicable (e.g. liveness derived from a heartbeat rather than a probe).
        */
-      responseTime?: number;
+      responseTime?: null | number;
       /** @description Service-specific detail values (shape varies per service). */
       details?: unknown;
     };


### PR DESCRIPTION
## Summary

The Admin health dashboard endpoints (`/api/health/services`, `/api/health/history`) returned **hardcoded** statuses for the Gateway and Admin services — only the database was actually probed. An outage in either service would still show green. This drives those entries from real signals.

Closes #1067.

## Approach

Admin↔Gateway communication is deliberately **event-only** (Wolverine/PostgreSQL) — there is no HTTP client from Admin to Gateway. To keep that architecture intact, Gateway liveness is reported via a **heartbeat event** rather than a synchronous HTTP probe:

- Every Gateway instance publishes a periodic `GatewayHeartbeat` over the event bus (`GatewayHeartbeatPublisher`, a plain `BackgroundService` on **every** instance — not leader-elected, since a per-instance liveness signal must come from each instance).
- The Admin consumes it (`GatewayHeartbeatHandler`) and records the last-seen snapshot in a shared store (`ServiceHeartbeatStore`: Redis-backed, with an in-process fallback for single-instance/dev).
- The dashboard derives status from **staleness** (`ServiceHeartbeatEvaluator`): fresh (≤2 intervals) → `healthy`, delayed (≤4) → `degraded`, lost → `unhealthy`, never-seen → `unknown`. A Gateway outage stops the heartbeats and surfaces as red.

## Changes

- **Gateway status** — heartbeat-driven (was `Status="healthy"`, `ResponseTime=15` literals).
- **Admin status** — real in-process `HealthCheckService` readiness result (mirrors `/health/ready`) with a measured response time and per-check breakdown (was `Status="healthy"`, `ResponseTime=10`, `ActiveSessions=1` literals).
- **Database** — real server uptime via `pg_postmaster_start_time()` (was a hardcoded 30-day placeholder); dropped the fabricated `ActiveConnections=5`.
- **`ProviderHealth`** — removed the constant `100` from the history endpoint and DTO (provider health tracking was already removed; the issue asked to drop the field rather than report a constant).
- **DTOs** — `Uptime`/`ResponseTime` are now nullable (honest "unknown/not-applicable"), and a `Summary.Unknown` count was added. Admin OpenAPI contract regenerated.
- **Messaging wiring** — new `ConduitLLM.Core.Events.GatewayHeartbeat`; publish routing to `admin-events` in `ConduitMessagingTopology`; handler DI + Wolverine bridge in the Admin.

Config: heartbeat cadence is `GatewayHeartbeat:IntervalSeconds` (default 30, floored at 5); no deployment change required.

## Verification

- Full solution builds cleanly (0 errors).
- Wolverine `codegen preview` passes for both services (the new bridge/handler chain generates; the Gateway correctly has no consumer for an event it only publishes).
- 18 new unit tests (evaluator thresholds, store fallback round-trip, handler mapping + exception-swallowing); 73 health+heartbeat tests total, no regressions.
- Admin OpenAPI contract regenerated, linted, and deterministic (drift gate passes); diff is health-only.

## Not yet done

Live end-to-end (Gateway publishes → Admin dashboard reflects) has not been exercised against a running stack — it needs a dev rebuild since the running containers carry the pre-change .NET code.
