### PR TITLE
fix(observability): expose prometheus-net metrics

### DIFF
--- a/Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj
+++ b/Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj
@@ -43,7 +43,6 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <!-- 1.15.3 patches GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 -->
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />

--- a/Services/ConduitLLM.Admin/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Admin/Program.Monitoring.cs
@@ -1,5 +1,4 @@
 using ConduitLLM.Core.Extensions;
-using ConduitLLM.Core.Utilities;
 
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -65,14 +64,12 @@ public partial class Program
                     .AddMeter("System.Runtime")
                     .AddMeter("Microsoft.AspNetCore.Hosting")
                     .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
-                    .AddMeter("ConduitLLM.Admin.Requests")
                     .AddMeter("ConduitLLM.Providers")
                     // Bus metrics (#931). Wolverine's meter is "Wolverine:{ServiceName}",
                     // so the wildcard is required; it emits sent/succeeded/failure
                     // counters, execution/effective-time histograms, and (on the Postgres
                     // transport) inbox/outbox/scheduled depth gauges + dead-letter counts.
-                    .AddMeter("Wolverine*")
-                    .AddPrometheusExporter();
+                    .AddMeter("Wolverine*");
             });
 
         // Add distributed tracing when enabled
@@ -112,7 +109,7 @@ public partial class Program
     }
 
     /// <summary>
-    /// Maps health check, metrics, and Prometheus endpoints.
+    /// Maps health check endpoints and enables Admin HTTP metric collection.
     /// </summary>
     private static void MapMonitoringEndpoints(WebApplication app)
     {
@@ -128,12 +125,6 @@ public partial class Program
         });
 
         app.Logger.LogInformation("Health check endpoints registered: /health, /health/live, /health/ready");
-
-        // Map Prometheus metrics endpoint
-        app.UseOpenTelemetryPrometheusScrapingEndpoint(
-            context => context.Request.Path == "/metrics" &&
-                      (IpAddressHelper.IsPrivateNetworkRequest(context) ||
-                       context.User.Identity?.IsAuthenticated == true));
 
         // For the prometheus-net library metrics
         app.UseHttpMetrics(options =>

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -3,6 +3,7 @@ using ConduitLLM.Admin.Extensions;
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Core.Converters;
+using ConduitLLM.Core.Extensions;
 using ConduitLLM.Security.Middleware;
 
 using System.Text.Json;
@@ -206,6 +207,9 @@ public partial class Program
         app.UseAdminMiddleware();
 
         app.UseAuthentication();
+        // Run before authorization so private-network scrapes are not captured by the
+        // authenticated JSON API route at /metrics/.
+        app.UseConduitPrometheusMetricsEndpoint();
         app.UseAuthorization();
 
 

--- a/Services/ConduitLLM.Gateway/Authentication/VirtualKeyAuthenticationHandler.cs
+++ b/Services/ConduitLLM.Gateway/Authentication/VirtualKeyAuthenticationHandler.cs
@@ -190,7 +190,6 @@ namespace ConduitLLM.Gateway.Authentication
                 "/health",
                 "/health/ready",
                 "/health/live",
-                "/metrics",
                 "/v1/media/public"
             };
 

--- a/Services/ConduitLLM.Gateway/ConduitLLM.Gateway.csproj
+++ b/Services/ConduitLLM.Gateway/ConduitLLM.Gateway.csproj
@@ -61,7 +61,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.2" />
     <!-- 1.15.3 patches GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933 -->
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />

--- a/Services/ConduitLLM.Gateway/Extensions/ObservabilityExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/ObservabilityExtensions.cs
@@ -2,6 +2,7 @@ using ConduitLLM.Configuration.Interceptors;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Prometheus;
 
 namespace ConduitLLM.Gateway.Extensions;
 
@@ -10,6 +11,15 @@ namespace ConduitLLM.Gateway.Extensions;
 /// </summary>
 public static class ObservabilityExtensions
 {
+    private static readonly double[] ProviderFirstChunkBuckets =
+        [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15];
+
+    private static readonly double[] ClientFirstFlushBuckets =
+        [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15];
+
+    private static readonly double[] AccountingFinalizationBuckets =
+        [0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
     /// <summary>
     /// Adds OpenTelemetry observability services including metrics, tracing, and query monitoring
     /// </summary>
@@ -30,33 +40,13 @@ public static class ObservabilityExtensions
                     .AddProcessInstrumentation()
                     .AddMeter("ConduitLLM.SignalR")
                     .AddMeter("ConduitLLM.MediaGeneration")
-                    .AddMeter("ConduitLLM.Gateway.Requests")
                     .AddMeter(ConduitLLM.Gateway.Metrics.SseTransportMetrics.MeterName)
-                    .AddView(
-                        "conduit.stream.time_to_provider_first_chunk",
-                        new ExplicitBucketHistogramConfiguration
-                        {
-                            Boundaries = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15]
-                        })
-                    .AddView(
-                        "conduit.stream.time_to_client_first_flush",
-                        new ExplicitBucketHistogramConfiguration
-                        {
-                            Boundaries = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15]
-                        })
-                    .AddView(
-                        "conduit.stream.accounting_finalization",
-                        new ExplicitBucketHistogramConfiguration
-                        {
-                            Boundaries = [0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-                        })
                     .AddMeter("ConduitLLM.Providers")
                     // Bus metrics (#931). Wolverine's meter is "Wolverine:{ServiceName}",
                     // so the wildcard is required; it emits sent/succeeded/failure
                     // counters, execution/effective-time histograms, and (on the Postgres
                     // transport) inbox/outbox/scheduled depth gauges + dead-letter counts.
-                    .AddMeter("Wolverine*")
-                    .AddPrometheusExporter();
+                    .AddMeter("Wolverine*");
             });
 
         // Add distributed tracing when enabled
@@ -105,5 +95,29 @@ public static class ObservabilityExtensions
         // in Program.Monitoring.cs with leader election to avoid duplicate metrics in scaled deployments
 
         return services;
+    }
+
+    internal static void ConfigurePrometheusMeterAdapter()
+    {
+        var defaultBucketResolver = MeterAdapterOptions.Default.ResolveHistogramBuckets;
+
+        Prometheus.Metrics.ConfigureMeterAdapter(options =>
+        {
+            options.ResolveHistogramBuckets = instrument =>
+                ResolvePrometheusHistogramBuckets(instrument, defaultBucketResolver);
+        });
+    }
+
+    internal static double[] ResolvePrometheusHistogramBuckets(
+        System.Diagnostics.Metrics.Instrument instrument,
+        Func<System.Diagnostics.Metrics.Instrument, double[]>? fallback = null)
+    {
+        return instrument.Name switch
+        {
+            "conduit.stream.time_to_provider_first_chunk" => ProviderFirstChunkBuckets,
+            "conduit.stream.time_to_client_first_flush" => ClientFirstFlushBuckets,
+            "conduit.stream.accounting_finalization" => AccountingFinalizationBuckets,
+            _ => (fallback ?? MeterAdapterOptions.Default.ResolveHistogramBuckets)(instrument)
+        };
     }
 }

--- a/Services/ConduitLLM.Gateway/Program.Endpoints.cs
+++ b/Services/ConduitLLM.Gateway/Program.Endpoints.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using ConduitLLM.Core.Utilities;
 using ConduitLLM.Gateway.Endpoints;
 
 public partial class Program
@@ -74,13 +73,5 @@ public partial class Program
         {
             Predicate = check => check.Tags.Contains("ready") || check.Tags.Count == 0
         });
-
-        // Map Prometheus metrics endpoint for scraping
-        // Allow unauthenticated access from private networks (Docker internal, localhost)
-        // Require authentication for external/public network requests
-        app.UseOpenTelemetryPrometheusScrapingEndpoint(
-            context => context.Request.Path == "/metrics" &&
-                      (IpAddressHelper.IsPrivateNetworkRequest(context) ||
-                       context.User.Identity?.IsAuthenticated == true));
     }
 }

--- a/Services/ConduitLLM.Gateway/Program.Middleware.cs
+++ b/Services/ConduitLLM.Gateway/Program.Middleware.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Configuration.Data;
+using ConduitLLM.Core.Extensions;
 using ConduitLLM.Core.Middleware;
 using ConduitLLM.Gateway.Extensions;
 using ConduitLLM.Gateway.Middleware;
@@ -61,6 +62,8 @@ public partial class Program
 
         // Add authentication and authorization middleware
         app.UseAuthentication();
+        // Private-network scrapes bypass authorization; external scrapes can authenticate.
+        app.UseConduitPrometheusMetricsEndpoint();
         app.UseAuthorization();
 
         // Add ephemeral key cleanup middleware (must be after authentication)

--- a/Services/ConduitLLM.Gateway/Program.cs
+++ b/Services/ConduitLLM.Gateway/Program.cs
@@ -10,6 +10,10 @@ if (ConduitLLM.Configuration.Data.MigrationCommand.Matches(args))
     return await ConduitLLM.Configuration.Data.MigrationCommand.RunAsync();
 }
 
+// prometheus-net's Meter adapter owns the /metrics representation. Configure its
+// streaming histogram buckets before any application metrics can be initialized.
+ConduitLLM.Gateway.Extensions.ObservabilityExtensions.ConfigurePrometheusMeterAdapter();
+
 // DatabaseAwareLLMClientFactory now in Providers namespace
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {

--- a/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
+++ b/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="MessagePack" Version="2.5.302" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <!-- Explicit pin: the SignalR transitive floor is 2.7.27, which predates the
          Expiration StringSet API this project relies on. -->
     <PackageReference Include="StackExchange.Redis" Version="2.13.17" />

--- a/Shared/ConduitLLM.Core/Extensions/PrometheusMetricsEndpointExtensions.cs
+++ b/Shared/ConduitLLM.Core/Extensions/PrometheusMetricsEndpointExtensions.cs
@@ -1,0 +1,32 @@
+using ConduitLLM.Core.Utilities;
+
+using Microsoft.AspNetCore.Builder;
+
+using Prometheus;
+
+namespace ConduitLLM.Core.Extensions;
+
+/// <summary>
+/// Configures the shared Prometheus scrape endpoint used by Conduit services.
+/// </summary>
+public static class PrometheusMetricsEndpointExtensions
+{
+    private const string MetricsPath = "/metrics";
+
+    /// <summary>
+    /// Exposes prometheus-net's default registry to private-network or authenticated requests.
+    /// The default registry also contains instruments bridged from the .NET Meter API.
+    /// </summary>
+    public static IApplicationBuilder UseConduitPrometheusMetricsEndpoint(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseWhen(
+            context => context.Request.Path == MetricsPath &&
+                       (IpAddressHelper.IsPrivateNetworkRequest(context) ||
+                        context.User.Identity?.IsAuthenticated == true),
+            metricsApp => metricsApp.UseMetricServer(MetricsPath));
+
+        return app;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Extensions/PrometheusMetricsEndpointExtensionsTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Extensions/PrometheusMetricsEndpointExtensionsTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+using ConduitLLM.Core.Extensions;
+using ConduitLLM.Gateway.Extensions;
+using ConduitLLM.Gateway.Middleware;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Prometheus;
+
+namespace ConduitLLM.Tests.Core.Extensions;
+
+public sealed class PrometheusMetricsEndpointExtensionsTests
+{
+    private const string RemoteIpHeader = "X-Test-Remote-Ip";
+    private const string AuthenticatedHeader = "X-Test-Authenticated";
+
+    private static readonly Counter RegistryCounter = Prometheus.Metrics.CreateCounter(
+        "conduit_issue_1066_registry_total",
+        "Verifies prometheus-net registry exposition.");
+
+    private static readonly Meter TestMeter = new("ConduitLLM.Tests.Issue1066");
+    private static readonly System.Diagnostics.Metrics.Counter<long> MeterCounter = TestMeter.CreateCounter<long>(
+        "conduit.issue_1066.meter");
+
+    [Fact]
+    public async Task MetricsEndpoint_ExposesRegistryAndMeterMetrics_ToPrivateNetworks()
+    {
+        RegistryCounter.Inc();
+        MeterCounter.Add(1);
+        UsageMetrics.BillingRevenue.WithLabels("issue-1066", "test").Inc(0.01);
+
+        using var host = await StartHostAsync();
+        using var request = CreateRequest("/metrics", "10.10.0.8");
+
+        using var response = await host.GetTestClient().SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("conduit_issue_1066_registry_total");
+        body.Should().Contain("conduit_issue_1066_meter");
+        body.Should().Contain("conduit_billing_revenue_dollars_total");
+    }
+
+    [Fact]
+    public async Task MetricsEndpoint_ExposesMetrics_ToAuthenticatedExternalRequests()
+    {
+        RegistryCounter.Inc();
+
+        using var host = await StartHostAsync();
+        using var request = CreateRequest("/metrics", "203.0.113.10", authenticated: true);
+
+        using var response = await host.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("conduit_issue_1066_registry_total");
+    }
+
+    [Fact]
+    public async Task MetricsEndpoint_DoesNotExposeMetrics_ToAnonymousExternalRequests()
+    {
+        using var host = await StartHostAsync();
+        using var request = CreateRequest("/metrics", "203.0.113.10");
+
+        using var response = await host.GetTestClient().SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        body.Should().NotContain("conduit_issue_1066_registry_total");
+    }
+
+    [Fact]
+    public async Task MetricsEndpoint_DoesNotInterceptAdminJsonMetricsRoute()
+    {
+        using var host = await StartHostAsync();
+        using var request = CreateRequest("/metrics/", "203.0.113.10", authenticated: true);
+
+        using var response = await host.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("admin-json-metrics");
+    }
+
+    [Fact]
+    public void MeterAdapter_PreservesStreamingHistogramBuckets()
+    {
+        using var meter = new Meter("ConduitLLM.Tests.Issue1066.Buckets");
+        var providerFirstChunk = meter.CreateHistogram<double>("conduit.stream.time_to_provider_first_chunk");
+        var clientFirstFlush = meter.CreateHistogram<double>("conduit.stream.time_to_client_first_flush");
+        var accountingFinalization = meter.CreateHistogram<double>("conduit.stream.accounting_finalization");
+
+        ObservabilityExtensions.ResolvePrometheusHistogramBuckets(providerFirstChunk)
+            .Should().Equal(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15);
+        ObservabilityExtensions.ResolvePrometheusHistogramBuckets(clientFirstFlush)
+            .Should().Equal(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15);
+        ObservabilityExtensions.ResolvePrometheusHistogramBuckets(accountingFinalization)
+            .Should().Equal(0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10);
+    }
+
+    private static HttpRequestMessage CreateRequest(string path, string remoteIp, bool authenticated = false)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add(RemoteIpHeader, remoteIp);
+        if (authenticated)
+        {
+            request.Headers.Add(AuthenticatedHeader, "true");
+        }
+
+        return request;
+    }
+
+    private static async Task<IHost> StartHostAsync()
+    {
+        return await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddAuthentication("Test")
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>("Test", null);
+                    services.AddAuthorization();
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.Use(async (context, next) =>
+                    {
+                        context.Connection.RemoteIpAddress = IPAddress.Parse(context.Request.Headers[RemoteIpHeader]!);
+                        await next(context);
+                    });
+                    app.UseAuthentication();
+                    app.UseConduitPrometheusMetricsEndpoint();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/metrics/", () => "admin-json-metrics")
+                            .RequireAuthorization();
+                    });
+                });
+            })
+            .StartAsync();
+    }
+
+    private sealed class TestAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey(AuthenticatedHeader))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var identity = new ClaimsIdentity([new Claim(ClaimTypes.Name, "metrics-scraper")], Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name)));
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyAuthenticationHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyAuthenticationHandlerTests.cs
@@ -204,7 +204,6 @@ namespace ConduitLLM.Tests.Http.Authentication
         [InlineData("/health")]
         [InlineData("/health/ready")]
         [InlineData("/health/live")]
-        [InlineData("/metrics")]
         [InlineData("/v1/media/public")]
         public async Task HandleAuthenticateAsync_WithExcludedPaths_SkipsAuthentication(string path)
         {
@@ -221,6 +220,28 @@ namespace ConduitLLM.Tests.Http.Authentication
             Assert.False(result.Principal.Identity.IsAuthenticated);
             
             _virtualKeyServiceMock.Verify(s => s.ValidateVirtualKeyForAuthenticationAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_WithMetricsPath_AuthenticatesVirtualKey()
+        {
+            var virtualKey = CreateValidVirtualKey();
+            var keyValue = "condt_metrics";
+
+            _httpContext.Request.Headers["Authorization"] = $"Bearer {keyValue}";
+            _httpContext.Request.Path = "/metrics";
+            _virtualKeyServiceMock.Setup(s => s.ValidateVirtualKeyForAuthenticationAsync(keyValue, null))
+                .ReturnsAsync(virtualKey);
+
+            await InitializeHandler();
+
+            var result = await _handler.AuthenticateAsync();
+
+            Assert.True(result.Succeeded);
+            Assert.True(result.Principal.Identity.IsAuthenticated);
+            _virtualKeyServiceMock.Verify(
+                s => s.ValidateVirtualKeyForAuthenticationAsync(keyValue, null),
+                Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- replace the OpenTelemetry-only scrape middleware with a protected prometheus-net endpoint shared by Gateway and Admin
- expose existing conduit_* registry metrics together with adapted .NET Meter instruments on /metrics
- preserve streaming histogram buckets and remove the two no-op ActivitySource AddMeter registrations
- allow Gateway virtual-key authentication on /metrics while retaining private-network access and the Admin /metrics/ JSON route

## Testing
- dotnet build Services/ConduitLLM.Gateway/ConduitLLM.Gateway.csproj --no-restore -m:1 /nodeReuse:false
- dotnet build Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj --no-restore -m:1 /nodeReuse:false
- focused observability/authentication tests: 6 passed
- full suite: 2,876 passed and 7 skipped; the unrelated Benchmark_V2_IdempotencyOverhead timing assertion remained flaky and passed when rerun in isolation

Closes #1066