### PR TITLE
fix(functions): stop .gitignore from swallowing CredentialSelector source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -434,6 +434,11 @@ secrets.json
 # (the broad *credentials* rule above would otherwise silently drop the whole route).
 !WebAdmin/src/app/functions/credentials/
 !WebAdmin/src/app/functions/credentials/**
+# CredentialSelector is credential *selection* logic, not a secret. On Windows
+# (core.ignorecase=true) the *credentials* rule matches "credentialSelector"
+# case-insensitively, so it would silently drop this source file and its tests.
+!Shared/ConduitLLM.Functions/Services/CredentialSelector.cs
+!Tests/ConduitLLM.Tests/Functions/Services/CredentialSelectorTests.cs
 *secret*
 *token*.txt
 *token*.json

--- a/Shared/ConduitLLM.Functions/Services/CredentialSelector.cs
+++ b/Shared/ConduitLLM.Functions/Services/CredentialSelector.cs
@@ -1,0 +1,39 @@
+using ConduitLLM.Functions.Entities;
+
+namespace ConduitLLM.Functions.Services;
+
+/// <summary>
+/// Selects which credential to use for a given function configuration.
+/// </summary>
+/// <remarks>
+/// Config-scoped credentials (<see cref="FunctionCredential.FunctionConfigurationId"/> set — used by
+/// MCP, where each server has its own token) take precedence over provider-global credentials
+/// (null — the Exa/Tavily model). Within each tier the primary credential is preferred, then any
+/// enabled one.
+/// </remarks>
+public static class CredentialSelector
+{
+    /// <summary>
+    /// Returns the best enabled credential for the configuration, or null when none is enabled.
+    /// </summary>
+    public static FunctionCredential? SelectForConfiguration(
+        IEnumerable<FunctionCredential> credentials,
+        int functionConfigurationId)
+    {
+        var enabled = credentials.Where(c => c.IsEnabled).ToList();
+
+        var scoped = enabled.Where(c => c.FunctionConfigurationId == functionConfigurationId).ToList();
+        if (scoped.Count > 0)
+        {
+            return scoped.FirstOrDefault(c => c.IsPrimary) ?? scoped[0];
+        }
+
+        var global = enabled.Where(c => c.FunctionConfigurationId == null).ToList();
+        if (global.Count > 0)
+        {
+            return global.FirstOrDefault(c => c.IsPrimary) ?? global[0];
+        }
+
+        return null;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Functions/Services/CredentialSelectorTests.cs
+++ b/Tests/ConduitLLM.Tests/Functions/Services/CredentialSelectorTests.cs
@@ -1,0 +1,76 @@
+using ConduitLLM.Functions.Entities;
+using ConduitLLM.Functions.Enums;
+using ConduitLLM.Functions.Services;
+
+namespace ConduitLLM.Tests.Functions.Services;
+
+public class CredentialSelectorTests
+{
+    private const int ConfigId = 7;
+
+    private static FunctionCredential Cred(int id, int? configId, bool primary = false, bool enabled = true) => new()
+    {
+        Id = id,
+        ProviderType = FunctionProviderType.Mcp,
+        FunctionConfigurationId = configId,
+        IsPrimary = primary,
+        IsEnabled = enabled,
+        ApiKey = $"key-{id}"
+    };
+
+    [Fact]
+    public void PrefersConfigScopedOverGlobal()
+    {
+        var creds = new[] { Cred(1, configId: null), Cred(2, configId: ConfigId) };
+
+        var selected = CredentialSelector.SelectForConfiguration(creds, ConfigId);
+
+        Assert.Equal(2, selected!.Id);
+    }
+
+    [Fact]
+    public void FallsBackToGlobalWhenNoScopedCredential()
+    {
+        var creds = new[] { Cred(1, configId: null), Cred(2, configId: 999) };
+
+        var selected = CredentialSelector.SelectForConfiguration(creds, ConfigId);
+
+        Assert.Equal(1, selected!.Id);
+    }
+
+    [Fact]
+    public void PrefersPrimaryWithinScope()
+    {
+        var creds = new[]
+        {
+            Cred(1, configId: ConfigId, primary: false),
+            Cred(2, configId: ConfigId, primary: true)
+        };
+
+        var selected = CredentialSelector.SelectForConfiguration(creds, ConfigId);
+
+        Assert.Equal(2, selected!.Id);
+    }
+
+    [Fact]
+    public void IgnoresDisabledCredentials()
+    {
+        var creds = new[]
+        {
+            Cred(1, configId: ConfigId, enabled: false),
+            Cred(2, configId: null, enabled: true)
+        };
+
+        var selected = CredentialSelector.SelectForConfiguration(creds, ConfigId);
+
+        Assert.Equal(2, selected!.Id); // scoped one disabled => falls back to enabled global
+    }
+
+    [Fact]
+    public void ReturnsNullWhenNoneEnabled()
+    {
+        var creds = new[] { Cred(1, configId: ConfigId, enabled: false) };
+
+        Assert.Null(CredentialSelector.SelectForConfiguration(creds, ConfigId));
+    }
+}


### PR DESCRIPTION
## Problem

`CredentialSelector.cs` (and `CredentialSelectorTests.cs`) exist on disk but were **never tracked by git** — silently swallowed by the broad `*credentials*` secrets rule in `.gitignore:430`.

On Windows (`core.ignorecase=true`) that pattern matches `CredentialSelector.cs` case-insensitively: lowercased `credentialselector` contains the substring `credentials` (`credential` + the `s` from `Selector`).

This breaks a clean-checkout / CI build, because committed code depends on the class:
- `Shared/ConduitLLM.Functions/Services/FunctionClientFactory.cs:60`
- `Shared/ConduitLLM.Functions/Services/FunctionExecutionService.cs:142`

Both call `CredentialSelector.SelectForConfiguration(...)`. Local builds only worked because the untracked file happened to still be on disk.

## Fix

Add `!`-re-include exceptions for the source file and its tests (mirroring the existing exceptions already present for `*CredentialsEndpoints*.cs` and the WebAdmin `functions/credentials/` route), then commit the previously-missing source + tests.

## Notes

- `CredentialSelector` is credential **selection logic**, not a secret — safe to track.
- No functional code change; this only un-hides files the tree already depends on.
