### PR TITLE
feat(providers): structured provider settings + Cloudflare Account ID (#1177)

### DIFF
--- a/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Providers.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Providers.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Authorization;
 using ConduitLLM.Configuration.DTOs;
 using Microsoft.AspNetCore.Mvc;
 using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Configuration;
 
 using ConduitLLM.Configuration.Interfaces;
 namespace ConduitLLM.Admin.Endpoints
@@ -151,12 +153,20 @@ namespace ConduitLLM.Admin.Endpoints
                 ProviderType = request.ProviderType,
                 ProviderName = request.ProviderName,
                 BaseUrl = request.BaseUrl,
+                Settings = request.Settings,
                 IsEnabled = request.IsEnabled,
                 TrustProviderReportedCosts = request.TrustProviderReportedCosts,
                 ProviderCostMarkupMultiplier = request.ProviderCostMarkupMultiplier,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
+
+            // Validate that required structured settings resolve (for example a Cloudflare account ID).
+            // Reuses the base-URL resolver so a full BaseUrl override is still accepted (dual-read).
+            if (!TryValidateProviderSettings(provider, out var settingsError))
+            {
+                return BadRequest(settingsError);
+            }
 
             var id = await _providerRepository.CreateAsync(provider);
             provider.Id = id;
@@ -226,6 +236,19 @@ namespace ConduitLLM.Admin.Endpoints
                 provider.ProviderCostMarkupMultiplier = request.ProviderCostMarkupMultiplier;
             }
 
+            // Settings replace wholesale when provided; null means "leave unchanged" (PATCH semantics).
+            if (request.Settings != null && !SettingsEqual(provider.Settings, request.Settings))
+            {
+                changes.Add(("Settings", null, null));
+                provider.Settings = request.Settings;
+            }
+
+            // Validate that required structured settings still resolve after the update.
+            if (!TryValidateProviderSettings(provider, out var settingsError))
+            {
+                return BadRequest(settingsError);
+            }
+
             provider.UpdatedAt = DateTime.UtcNow;
 
             await _providerRepository.UpdateAsync(provider);
@@ -257,6 +280,7 @@ namespace ConduitLLM.Admin.Endpoints
             ProviderType = provider.ProviderType,
             ProviderName = provider.ProviderName,
             BaseUrl = provider.BaseUrl,
+            Settings = provider.Settings,
             IsEnabled = provider.IsEnabled,
             TrustProviderReportedCosts = provider.TrustProviderReportedCosts,
             ProviderCostMarkupMultiplier = provider.ProviderCostMarkupMultiplier,
@@ -264,6 +288,54 @@ namespace ConduitLLM.Admin.Endpoints
             UpdatedAt = provider.UpdatedAt,
             KeyCount = provider.ProviderKeyCredentials?.Count ?? 0
         };
+
+        /// <summary>
+        /// Validates that a provider's required structured settings resolve into a usable base URL.
+        /// Reuses <see cref="ProviderConfigurationRegistry.ResolveBaseUrl"/> so a full BaseUrl override
+        /// with the identifier already embedded is still accepted (dual-read during migration).
+        /// </summary>
+        private static bool TryValidateProviderSettings(Provider provider, out string? error)
+        {
+            try
+            {
+                ProviderConfigurationRegistry.ResolveBaseUrl(provider);
+                error = null;
+                return true;
+            }
+            catch (ConfigurationException ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Ordinal equality for two structured-settings dictionaries, treating null and empty as equal.
+        /// </summary>
+        private static bool SettingsEqual(Dictionary<string, string>? left, Dictionary<string, string>? right)
+        {
+            var leftCount = left?.Count ?? 0;
+            var rightCount = right?.Count ?? 0;
+            if (leftCount != rightCount)
+            {
+                return false;
+            }
+
+            if (leftCount == 0)
+            {
+                return true;
+            }
+
+            foreach (var pair in left!)
+            {
+                if (!right!.TryGetValue(pair.Key, out var value) || !string.Equals(value, pair.Value, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Deletes a provider

--- a/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Testing.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Testing.cs
@@ -91,6 +91,7 @@ namespace ConduitLLM.Admin.Endpoints
                 ProviderType = testRequest.ProviderType,
                 ProviderName = "Test Provider",
                 BaseUrl = testRequest.BaseUrl,
+                Settings = testRequest.Settings,
                 IsEnabled = true
             };
 
@@ -129,11 +130,13 @@ namespace ConduitLLM.Admin.Endpoints
                 IsPrimary = true,
                 IsEnabled = true
             };
-            var client = _clientFactory.CreateTestClient(testProvider, testKey);
-
             var startTime = DateTime.UtcNow;
             try
             {
+                // Client construction resolves the effective base URL (substituting structured
+                // settings such as a Cloudflare account ID), so it runs inside the try to classify
+                // configuration errors as actionable test failures rather than 500s.
+                var client = _clientFactory.CreateTestClient(testProvider, testKey);
                 var models = await client.ListModelsAsync();
                 var responseTime = (DateTime.UtcNow - startTime).TotalMilliseconds;
                 var modelList = models?.Select(m => m.ToString()).ToArray();

--- a/Services/ConduitLLM.Admin/Services/ApiKeyTestResultService.cs
+++ b/Services/ConduitLLM.Admin/Services/ApiKeyTestResultService.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Core.Exceptions;
 
 namespace ConduitLLM.Admin.Services
 {
@@ -47,6 +48,21 @@ namespace ConduitLLM.Admin.Services
                 {
                     Result = ApiKeyTestResult.Ignored,
                     Message = "Your API Key was untested because this provider doesn't support API Key testing without making a real API request that can cost money",
+                    Details = new ApiKeyTestDetails
+                    {
+                        ProviderMessage = exception.Message
+                    }
+                };
+            }
+
+            // A configuration error (for example a missing required setting such as a Cloudflare
+            // account ID) carries an already-actionable message; surface it directly.
+            if (exception is ConfigurationException)
+            {
+                return new StandardApiKeyTestResponse
+                {
+                    Result = ApiKeyTestResult.Configuration,
+                    Message = exception.Message,
                     Details = new ApiKeyTestDetails
                     {
                         ProviderMessage = exception.Message
@@ -106,6 +122,23 @@ namespace ConduitLLM.Admin.Services
                 };
             }
 
+            // Other 4xx client errors (400/404/405) usually mean the endpoint or base URL is wrong
+            // rather than the key. Report the status instead of bucketing to a generic unknown error.
+            if (statusCode is 400 or 404 or 405)
+            {
+                return new StandardApiKeyTestResponse
+                {
+                    Result = ApiKeyTestResult.Configuration,
+                    Message = $"The provider rejected the test request (HTTP {statusCode}). Verify the base URL and endpoint configuration for this provider.",
+                    Details = new ApiKeyTestDetails
+                    {
+                        StatusCode = statusCode,
+                        ProviderMessage = message,
+                        ErrorCode = errorCode
+                    }
+                };
+            }
+
             // Unknown error
             return new StandardApiKeyTestResponse
             {
@@ -131,22 +164,24 @@ namespace ConduitLLM.Admin.Services
             int? statusCode = null;
             string? errorCode = null;
 
-            // Try to extract HTTP status code from common exception types
-            if (exception is HttpRequestException httpEx)
+            // Prefer the typed status code when available (HttpRequestException in .NET 5+).
+            if (exception is HttpRequestException { StatusCode: { } typedStatus })
             {
-                // Try to parse status code from message
-                if (message.Contains("401"))
-                    statusCode = 401;
-                else if (message.Contains("403"))
-                    statusCode = 403;
-                else if (message.Contains("429"))
-                    statusCode = 429;
-                else if (message.Contains("500"))
-                    statusCode = 500;
-                else if (message.Contains("502"))
-                    statusCode = 502;
-                else if (message.Contains("503"))
-                    statusCode = 503;
+                statusCode = (int)typedStatus;
+            }
+
+            // Otherwise parse a known status code out of the message. Provider exceptions
+            // (for example LLMCommunicationException) surface the HTTP status in their text.
+            if (statusCode == null && !string.IsNullOrEmpty(message))
+            {
+                foreach (var candidate in new[] { 401, 403, 429, 400, 404, 405, 408, 500, 502, 503 })
+                {
+                    if (message.Contains(candidate.ToString()))
+                    {
+                        statusCode = candidate;
+                        break;
+                    }
+                }
             }
 
             return (statusCode, message, errorCode);

--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -23205,7 +23205,8 @@
           "ignored",
           "providerDown",
           "rateLimited",
-          "unknownError"
+          "unknownError",
+          "configuration"
         ]
       },
       "ApplicationInfoDto": {
@@ -25506,6 +25507,16 @@
             "type": "number",
             "description": "Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).\r\nOnly consulted when bool CreateProviderRequest.TrustProviderReportedCosts is true.",
             "format": "double"
+          },
+          "settings": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Structured, provider-scoped settings supplied in addition to the API key (for example a\r\nCloudflare account ID). Keys correspond to the setting definitions declared for the\r\nprovider type. Non-secret values only."
           }
         },
         "description": "Request model for creating a provider"
@@ -30278,6 +30289,15 @@
               "string"
             ]
           },
+          "settings": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "keyCount": {
             "type": "integer",
             "format": "int32"
@@ -31665,6 +31685,16 @@
               "string"
             ],
             "description": "The organization to test (optional)"
+          },
+          "settings": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Structured, provider-scoped settings to test (for example a Cloudflare account ID).\r\nRequired settings must be present or the test returns an actionable configuration error."
           }
         },
         "description": "Request model for testing a provider connection"
@@ -32917,6 +32947,16 @@
             "type": "number",
             "description": "Multiplier applied to the provider-reported cost when billing (1.0 = pass-through).\r\nDefaults to 1.0 when omitted, so a partial update never silently zeroes the markup.",
             "format": "double"
+          },
+          "settings": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Structured, provider-scoped settings supplied in addition to the API key (for example a\r\nCloudflare account ID). When provided, replaces the stored settings. Non-secret values only."
           }
         },
         "description": "Request model for updating a provider"

--- a/Shared/ConduitLLM.Configuration/DTOs/ProviderDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/ProviderDto.cs
@@ -25,6 +25,12 @@ namespace ConduitLLM.Configuration.DTOs
         /// </summary>
         public string? BaseUrl { get; set; }
 
+        /// <summary>
+        /// Structured, provider-scoped settings supplied in addition to the API key (for example a
+        /// Cloudflare account ID). Non-secret values only.
+        /// </summary>
+        public Dictionary<string, string>? Settings { get; set; }
+
         /// <summary>Number of configured credentials for this provider.</summary>
         public required int KeyCount { get; set; }
 

--- a/Shared/ConduitLLM.Configuration/DTOs/StandardApiKeyTestResponse.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/StandardApiKeyTestResponse.cs
@@ -13,7 +13,13 @@ namespace ConduitLLM.Configuration.DTOs
         Ignored,
         ProviderDown,
         RateLimited,
-        UnknownError
+        UnknownError,
+
+        /// <summary>
+        /// The provider is misconfigured (for example a required structured setting such as a
+        /// Cloudflare account ID is missing), so the test could not be attempted.
+        /// </summary>
+        Configuration
     }
 
     /// <summary>

--- a/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
+++ b/Shared/ConduitLLM.Configuration/Data/ConfigurationDbContext.cs
@@ -485,6 +485,9 @@ namespace ConduitLLM.Configuration
             // Apply ProviderMetadataDriftItem configuration (string enums + partial unique index)
             modelBuilder.ApplyConfiguration(new EntityConfigurations.ProviderMetadataDriftItemConfiguration());
 
+            // Apply Provider configuration (structured Settings as jsonb)
+            modelBuilder.ApplyConfiguration(new EntityConfigurations.ProviderEntityConfiguration());
+
             // Note: ModelProviderMapping and Provider are now included in test environments
             // as they are required by the application code during tests
         }

--- a/Shared/ConduitLLM.Configuration/Entities/Provider.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/Provider.cs
@@ -39,6 +39,14 @@ namespace ConduitLLM.Configuration.Entities
         // Optional: Base URL if different from default
         public string? BaseUrl { get; set; }
 
+        /// <summary>
+        /// Gets or sets structured, provider-scoped settings the operator supplies in addition to the
+        /// API key (for example a Cloudflare account ID). Keys correspond to the setting definitions
+        /// declared for the provider type in the provider configuration registry. Stored as JSONB
+        /// (mapped in <see cref="EntityConfigurations.ProviderEntityConfiguration"/>). Non-secret values only.
+        /// </summary>
+        public Dictionary<string, string>? Settings { get; set; }
+
 
         /// <summary>
         /// Gets or sets a value indicating whether this provider is enabled and available for use.

--- a/Shared/ConduitLLM.Configuration/EntityConfigurations/ProviderEntityConfiguration.cs
+++ b/Shared/ConduitLLM.Configuration/EntityConfigurations/ProviderEntityConfiguration.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+
+using ConduitLLM.Configuration.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace ConduitLLM.Configuration.EntityConfigurations
+{
+    /// <summary>
+    /// EF Core configuration for <see cref="Provider"/>. Maps the structured <see cref="Provider.Settings"/>
+    /// dictionary to a PostgreSQL <c>jsonb</c> column with a value converter and comparer so change
+    /// tracking works on the mutable dictionary.
+    /// </summary>
+    public class ProviderEntityConfiguration : IEntityTypeConfiguration<Provider>
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+        /// <inheritdoc />
+        public void Configure(EntityTypeBuilder<Provider> builder)
+        {
+            var converter = new ValueConverter<Dictionary<string, string>?, string?>(
+                value => value == null ? null : JsonSerializer.Serialize(value, SerializerOptions),
+                json => string.IsNullOrWhiteSpace(json)
+                    ? null
+                    : JsonSerializer.Deserialize<Dictionary<string, string>>(json, SerializerOptions));
+
+            var comparer = new ValueComparer<Dictionary<string, string>?>(
+                (left, right) => JsonSerializer.Serialize(left, SerializerOptions)
+                    == JsonSerializer.Serialize(right, SerializerOptions),
+                value => value == null ? 0 : JsonSerializer.Serialize(value, SerializerOptions).GetHashCode(),
+                value => value == null ? null : new Dictionary<string, string>(value));
+
+            builder.Property(p => p.Settings)
+                .HasColumnName("Settings")
+                .HasColumnType("jsonb")
+                .HasConversion(converter, comparer);
+        }
+    }
+}

--- a/Shared/ConduitLLM.Configuration/Migrations/20260724010845_AddProviderSettings.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260724010845_AddProviderSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724010845_AddProviderSettings")]
+    partial class AddProviderSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260724010845_AddProviderSettings.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260724010845_AddProviderSettings.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Settings",
+                table: "Providers",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Settings",
+                table: "Providers");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Configuration/ProviderConfigurationRegistry.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ProviderConfigurationRegistry.cs
@@ -1,6 +1,9 @@
+using System.Text.RegularExpressions;
+
 using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Providers;
+using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Providers.Authentication;
 
 namespace ConduitLLM.Providers.Configuration
@@ -123,6 +126,19 @@ namespace ConduitLLM.Providers.Configuration
                     RateLimitExceeded = "Cloudflare Workers AI rate limit exceeded. Please try again later.",
                     ModelNotFound = "Model not found. Cloudflare Workers AI models use the @cf/provider/model-name format.",
                     MissingApiKey = "API token is required for Cloudflare Workers AI"
+                },
+                Settings = new[]
+                {
+                    new ProviderSettingDefinition
+                    {
+                        Key = "account_id",
+                        Label = "Account ID",
+                        HelpText = "Your Cloudflare account ID (shown in the dashboard URL and on the Workers AI page). Used to build the API base URL.",
+                        Required = true,
+                        Binding = ProviderSettingBinding.UrlPathToken,
+                        BindingTarget = "account_id",
+                        ValidationRegex = "^[0-9a-fA-F]{32}$"
+                    }
                 }
             },
 
@@ -269,13 +285,79 @@ namespace ConduitLLM.Providers.Configuration
         {
             ArgumentNullException.ThrowIfNull(provider);
 
-            if (!string.IsNullOrWhiteSpace(provider.BaseUrl))
+            var rawBaseUrl = !string.IsNullOrWhiteSpace(provider.BaseUrl)
+                ? provider.BaseUrl.TrimEnd('/')
+                : GetDefaultBaseUrl(provider.ProviderType)
+                    ?? throw new InvalidOperationException($"No default base URL is registered for {provider.ProviderType}.");
+
+            return ApplyUrlPathTokens(rawBaseUrl, provider.ProviderType, provider.Settings);
+        }
+
+        private static readonly Regex UnresolvedTokenPattern =
+            new(@"\{([a-zA-Z0-9_]+)\}", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Substitutes <c>{token}</c> placeholders in a base URL using the provider's structured
+        /// settings (for example Cloudflare's <c>{account_id}</c>). Any placeholder left unresolved
+        /// means a required setting was not supplied, which raises an actionable configuration error
+        /// rather than allowing a malformed request to be sent.
+        /// </summary>
+        /// <param name="baseUrl">The raw base URL, possibly containing <c>{token}</c> placeholders.</param>
+        /// <param name="providerType">The provider type whose setting definitions drive substitution.</param>
+        /// <param name="settings">The operator-supplied setting values, keyed by setting key.</param>
+        /// <returns>The base URL with all URL-path-token settings substituted.</returns>
+        /// <exception cref="ConfigurationException">Thrown when a required <c>{token}</c> is unresolved.</exception>
+        public static string ApplyUrlPathTokens(
+            string baseUrl,
+            ProviderType providerType,
+            IReadOnlyDictionary<string, string>? settings)
+        {
+            var definitions = GetConfiguration(providerType)?.Settings
+                ?? (IReadOnlyList<ProviderSettingDefinition>)Array.Empty<ProviderSettingDefinition>();
+
+            var result = baseUrl;
+            foreach (var definition in definitions)
             {
-                return provider.BaseUrl.TrimEnd('/');
+                if (definition.Binding != ProviderSettingBinding.UrlPathToken)
+                {
+                    continue;
+                }
+
+                if (settings != null
+                    && settings.TryGetValue(definition.Key, out var value)
+                    && !string.IsNullOrWhiteSpace(value))
+                {
+                    result = result.Replace("{" + definition.EffectiveBindingTarget + "}", value.Trim());
+                }
             }
 
-            return GetDefaultBaseUrl(provider.ProviderType)
-                ?? throw new InvalidOperationException($"No default base URL is registered for {provider.ProviderType}.");
+            var unresolved = UnresolvedTokenPattern.Matches(result)
+                .Select(match => match.Groups[1].Value)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (unresolved.Count > 0)
+            {
+                var missing = string.Join(", ", unresolved.Select(token => DescribeSetting(providerType, token)));
+                throw new ConfigurationException(
+                    $"{providerType} is missing required configuration: {missing}. "
+                    + "Provide the value in the provider settings.");
+            }
+
+            return result.TrimEnd('/');
+        }
+
+        /// <summary>
+        /// Resolves a human-readable label for an unresolved URL token, preferring the declared
+        /// setting label and falling back to the raw token name.
+        /// </summary>
+        private static string DescribeSetting(ProviderType providerType, string token)
+        {
+            var definition = GetConfiguration(providerType)?.Settings
+                .FirstOrDefault(setting =>
+                    string.Equals(setting.EffectiveBindingTarget, token, StringComparison.OrdinalIgnoreCase));
+
+            return definition?.Label ?? token;
         }
 
         /// <summary>
@@ -387,6 +469,12 @@ namespace ConduitLLM.Providers.Configuration
         /// Error messages specific to this provider.
         /// </summary>
         public required ProviderErrorMessages ErrorMessages { get; init; }
+
+        /// <summary>
+        /// Structured, provider-scoped settings the operator supplies in addition to the API key
+        /// (for example a Cloudflare account ID). Empty for providers that need only a key and URL.
+        /// </summary>
+        public IReadOnlyList<ProviderSettingDefinition> Settings { get; init; } = Array.Empty<ProviderSettingDefinition>();
     }
 
     /// <summary>

--- a/Shared/ConduitLLM.Providers/Configuration/ProviderSettingDefinition.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ProviderSettingDefinition.cs
@@ -1,0 +1,98 @@
+namespace ConduitLLM.Providers.Configuration
+{
+    /// <summary>
+    /// Describes how a structured provider setting value is applied to an outbound request.
+    /// </summary>
+    public enum ProviderSettingBinding
+    {
+        /// <summary>
+        /// The value replaces a <c>{token}</c> placeholder in the provider base URL
+        /// (for example Cloudflare's <c>.../accounts/{account_id}/ai/v1</c>).
+        /// </summary>
+        UrlPathToken = 0,
+
+        /// <summary>
+        /// The value is sent as an HTTP request header (for example <c>OpenAI-Organization</c>).
+        /// Declared for future phases; header application is not wired in Phase 1.
+        /// </summary>
+        Header = 1,
+
+        /// <summary>
+        /// The value is sent as a query-string parameter (for example Azure's <c>api-version</c>).
+        /// Declared for future phases; query application is not wired in Phase 1.
+        /// </summary>
+        QueryParam = 2,
+
+        /// <summary>
+        /// The value participates in request authentication/signing (for example an AWS region).
+        /// Declared for future phases; auth-scope application is not wired in Phase 1.
+        /// </summary>
+        AuthScope = 3,
+    }
+
+    /// <summary>
+    /// Declares a structured, provider-scoped configuration value that an operator supplies in
+    /// addition to the API key (for example a Cloudflare account ID or an OpenAI organization).
+    /// </summary>
+    /// <remarks>
+    /// These declarations are the single source of truth consumed by request-time resolution,
+    /// validation, and the WebAdmin provider form. Non-secret values are stored in
+    /// <c>Provider.Settings</c>; secret-valued settings are reserved for a later phase and must not
+    /// be placed in that non-encrypted bag.
+    /// </remarks>
+    public record ProviderSettingDefinition
+    {
+        /// <summary>
+        /// Stable machine key for the setting (for example <c>account_id</c>). Used as the storage
+        /// key in <c>Provider.Settings</c> and, for <see cref="ProviderSettingBinding.UrlPathToken"/>,
+        /// as the default placeholder token name when <see cref="BindingTarget"/> is not set.
+        /// </summary>
+        public required string Key { get; init; }
+
+        /// <summary>
+        /// Human-readable field label shown in the WebAdmin form (for example <c>Account ID</c>).
+        /// </summary>
+        public required string Label { get; init; }
+
+        /// <summary>
+        /// Optional help text describing where to find the value.
+        /// </summary>
+        public string? HelpText { get; init; }
+
+        /// <summary>
+        /// Whether the operator must supply this setting for the provider to function.
+        /// </summary>
+        public bool Required { get; init; }
+
+        /// <summary>
+        /// Whether the value is sensitive. Secret settings are reserved for a later phase and are not
+        /// stored in the non-encrypted <c>Provider.Settings</c> bag.
+        /// </summary>
+        public bool Secret { get; init; }
+
+        /// <summary>
+        /// Optional .NET regular expression the value must match. Used for validation in both the
+        /// backend and the WebAdmin form.
+        /// </summary>
+        public string? ValidationRegex { get; init; }
+
+        /// <summary>
+        /// How the value is applied to an outbound request.
+        /// </summary>
+        public required ProviderSettingBinding Binding { get; init; }
+
+        /// <summary>
+        /// The binding-specific target: the placeholder token name for
+        /// <see cref="ProviderSettingBinding.UrlPathToken"/>, the header name for
+        /// <see cref="ProviderSettingBinding.Header"/>, or the parameter name for
+        /// <see cref="ProviderSettingBinding.QueryParam"/>. Defaults to <see cref="Key"/> when null.
+        /// </summary>
+        public string? BindingTarget { get; init; }
+
+        /// <summary>
+        /// The effective binding target, falling back to <see cref="Key"/> when
+        /// <see cref="BindingTarget"/> is not explicitly set.
+        /// </summary>
+        public string EffectiveBindingTarget => string.IsNullOrWhiteSpace(BindingTarget) ? Key : BindingTarget;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Admin/Services/ApiKeyTestResultServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ApiKeyTestResultServiceTests.cs
@@ -1,0 +1,55 @@
+using ConduitLLM.Admin.Services;
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Core.Exceptions;
+
+using FluentAssertions;
+
+namespace ConduitLLM.Tests.Admin.Services;
+
+public class ApiKeyTestResultServiceTests
+{
+    [Fact]
+    public void CreateErrorResponse_ConfigurationException_Should_Surface_Actionable_Message()
+    {
+        var ex = new ConfigurationException("Cloudflare is missing required configuration: Account ID. Provide the value in the provider settings.");
+
+        var response = ApiKeyTestResultService.CreateErrorResponse(ex, ProviderType.Cloudflare);
+
+        response.Result.Should().Be(ApiKeyTestResult.Configuration);
+        response.Message.Should().Be(ex.Message);
+    }
+
+    [Fact]
+    public void CreateErrorResponse_405_Should_Classify_As_Configuration_Not_Unknown()
+    {
+        // The Cloudflare failure mode: "API returned an error: 405 MethodNotAllowed - ..."
+        var ex = new LLMCommunicationException("API returned an error: 405 MethodNotAllowed - GET not supported for requested URI.");
+
+        var response = ApiKeyTestResultService.CreateErrorResponse(ex, ProviderType.Cloudflare);
+
+        response.Result.Should().Be(ApiKeyTestResult.Configuration);
+        response.Message.Should().Contain("405");
+        response.Details!.StatusCode.Should().Be(405);
+    }
+
+    [Fact]
+    public void CreateErrorResponse_401_Should_Still_Classify_As_InvalidKey()
+    {
+        var ex = new LLMCommunicationException("API returned an error: 401 Unauthorized");
+
+        var response = ApiKeyTestResultService.CreateErrorResponse(ex, ProviderType.OpenAI);
+
+        response.Result.Should().Be(ApiKeyTestResult.InvalidKey);
+    }
+
+    [Fact]
+    public void CreateErrorResponse_NonTestableProvider_Should_Be_Ignored()
+    {
+        var ex = new LLMCommunicationException("anything");
+
+        var response = ApiKeyTestResultService.CreateErrorResponse(ex, ProviderType.Replicate);
+
+        response.Result.Should().Be(ApiKeyTestResult.Ignored);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/ProviderDefaultsRegistryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ProviderDefaultsRegistryTests.cs
@@ -90,4 +90,62 @@ public class ProviderDefaultsRegistryTests
             .Should()
             .Be("https://proxy.example.test/groq");
     }
+
+    [Fact]
+    public void Cloudflare_Should_Declare_A_Required_AccountId_UrlPathToken_Setting()
+    {
+        ProviderConfigurationRegistry.TryGetConfiguration(ProviderType.Cloudflare, out var config)
+            .Should().BeTrue();
+
+        var accountId = config!.Settings.Should().ContainSingle(s => s.Key == "account_id").Subject;
+        accountId.Required.Should().BeTrue();
+        accountId.Secret.Should().BeFalse();
+        accountId.Binding.Should().Be(ProviderSettingBinding.UrlPathToken);
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_Should_Substitute_AccountId_Into_The_Cloudflare_Default_Url()
+    {
+        var provider = new Provider
+        {
+            ProviderType = ProviderType.Cloudflare,
+            ProviderName = "cf",
+            Settings = new Dictionary<string, string> { ["account_id"] = "0123456789abcdef0123456789abcdef" }
+        };
+
+        ProviderConfigurationRegistry.ResolveBaseUrl(provider)
+            .Should()
+            .Be("https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1");
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_Should_Throw_Actionable_Error_When_AccountId_Missing()
+    {
+        var provider = new Provider
+        {
+            ProviderType = ProviderType.Cloudflare,
+            ProviderName = "cf"
+        };
+
+        var action = () => ProviderConfigurationRegistry.ResolveBaseUrl(provider);
+
+        action.Should().Throw<ConfigurationException>()
+            .WithMessage("*Account ID*");
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_Should_Honor_A_Raw_BaseUrl_With_The_AccountId_Already_Embedded()
+    {
+        // Dual-read: operators who configured the full URL before structured settings keep working.
+        var provider = new Provider
+        {
+            ProviderType = ProviderType.Cloudflare,
+            ProviderName = "cf",
+            BaseUrl = "https://api.cloudflare.com/client/v4/accounts/deadbeefdeadbeefdeadbeefdeadbeef/ai/v1"
+        };
+
+        ProviderConfigurationRegistry.ResolveBaseUrl(provider)
+            .Should()
+            .Be("https://api.cloudflare.com/client/v4/accounts/deadbeefdeadbeefdeadbeefdeadbeef/ai/v1");
+    }
 }

--- a/WebAdmin/src/components/providers/ProviderForm.tsx
+++ b/WebAdmin/src/components/providers/ProviderForm.tsx
@@ -203,6 +203,35 @@ export function ProviderForm({ mode, providerId }: ProviderFormProps) {
                         />
                       )}
 
+                      {config.settings?.map((field) => (
+                        field.secret ? (
+                          <PasswordInput
+                            key={field.key}
+                            label={field.label}
+                            placeholder={field.placeholder ?? ''}
+                            description={field.helpText}
+                            required={field.required}
+                            autoComplete="off"
+                            {...form.getInputProps(`settings.${field.key}`)}
+                            size="md"
+                          />
+                        ) : (
+                          <TextInput
+                            key={field.key}
+                            label={field.label}
+                            placeholder={field.placeholder ?? ''}
+                            description={field.helpText}
+                            required={field.required}
+                            autoComplete="off"
+                            aria-autocomplete="none"
+                            list="autocompleteOff"
+                            data-form-type="other"
+                            {...form.getInputProps(`settings.${field.key}`)}
+                            size="md"
+                          />
+                        )
+                      ))}
+
                       {(config.requiresEndpoint || config.supportsCustomEndpoint) && (
                         <TextInput
                           label={config.requiresEndpoint ? "API Endpoint" : "Custom API Endpoint"}

--- a/WebAdmin/src/components/providers/ProviderFormHandlers.ts
+++ b/WebAdmin/src/components/providers/ProviderFormHandlers.ts
@@ -1,13 +1,52 @@
 import { useRouter } from 'next/navigation';
 import { notify } from '@/lib/notifications';
 import { withAdminClient } from '@/lib/client/adminClient';
-import { ApiKeyTestResult, type ProviderType } from '@/lib/admin-api';
+import { ApiKeyTestResult, PROVIDER_CONFIG_REQUIREMENTS, type ProviderType } from '@/lib/admin-api';
 import type { ProviderFormData, ProviderFormLogicResult } from './ProviderFormLogic';
 
 interface UseProviderFormHandlersParams {
   mode: 'add' | 'edit';
   providerId?: number;
   logic: ProviderFormLogicResult;
+}
+
+/** The declared structured-setting fields for the selected provider type. */
+function getSettingFields(providerType: string) {
+  return PROVIDER_CONFIG_REQUIREMENTS[providerType as unknown as ProviderType]?.settings ?? [];
+}
+
+/** Collects non-empty declared settings into the map sent to the backend, or undefined when none. */
+function collectSettings(values: ProviderFormData): Record<string, string> | undefined {
+  const result: Record<string, string> = {};
+  for (const field of getSettingFields(values.providerType)) {
+    const raw = values.settings?.[field.key]?.trim() ?? '';
+    if (raw) {
+      result[field.key] = raw;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/** Validates required/format for declared settings; returns a map of form-path -> error message. */
+function validateSettings(values: ProviderFormData): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const field of getSettingFields(values.providerType)) {
+    const raw = values.settings?.[field.key]?.trim() ?? '';
+    if (field.required && !raw) {
+      errors[`settings.${field.key}`] = `${field.label} is required`;
+      continue;
+    }
+    if (raw && field.validationRegexSource) {
+      try {
+        if (!new RegExp(field.validationRegexSource).test(raw)) {
+          errors[`settings.${field.key}`] = `${field.label} is not in the expected format`;
+        }
+      } catch {
+        // Ignore a malformed regex source rather than blocking submission.
+      }
+    }
+  }
+  return errors;
 }
 
 export function useProviderFormHandlers({ mode, providerId, logic }: UseProviderFormHandlersParams) {
@@ -24,6 +63,13 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
     setIsSubmitting(true);
     try {
       if (mode === 'add') {
+        // Validate declared structured settings (for example a required Cloudflare account ID).
+        const settingsErrors = validateSettings(values);
+        if (Object.keys(settingsErrors).length > 0) {
+          Object.entries(settingsErrors).forEach(([path, message]) => form.setFieldError(path, message));
+          return;
+        }
+
         let providerName = values.providerName.trim();
         if (!providerName) {
           const selectedProvider = availableProviders.find(p => p.value === values.providerType);
@@ -35,6 +81,7 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
           providerType: values.providerType as ProviderType,
           providerName: providerName,
           baseUrl: values.apiEndpoint ?? undefined,
+          settings: collectSettings(values),
           isEnabled: values.isEnabled,
           trustProviderReportedCosts: values.trustProviderReportedCosts,
           providerCostMarkupMultiplier: values.providerCostMarkupMultiplier,
@@ -104,19 +151,27 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
       return;
     }
 
+    // Validate declared structured settings before hitting the provider.
+    const settingsErrors = validateSettings(form.values);
+    if (Object.keys(settingsErrors).length > 0) {
+      Object.entries(settingsErrors).forEach(([path, message]) => form.setFieldError(path, message));
+      return;
+    }
+
     setIsTesting(true);
     setTestResult(null);
 
     try {
       let result;
-      
+
       if (mode === 'add') {
-        result = await withAdminClient(client => 
+        result = await withAdminClient(client =>
           client.providers.testConfig({
             providerType: form.values.providerType as ProviderType,
             apiKey: form.values.apiKey,
             baseUrl: form.values.apiEndpoint ?? undefined,
             organizationId: form.values.organizationId ?? undefined,
+            settings: collectSettings(form.values),
           })
         );
       } else {

--- a/WebAdmin/src/components/providers/ProviderFormLogic.ts
+++ b/WebAdmin/src/components/providers/ProviderFormLogic.ts
@@ -15,6 +15,8 @@ export interface ProviderFormData {
   apiKey: string;
   apiEndpoint?: string;
   organizationId?: string;
+  /** Structured, provider-scoped settings (for example a Cloudflare account ID), keyed by setting key. */
+  settings: Record<string, string>;
   isEnabled: boolean;
   trustProviderReportedCosts: boolean;
   providerCostMarkupMultiplier: number;
@@ -65,6 +67,7 @@ export function useProviderFormLogic(
     apiKey: '',
     apiEndpoint: '',
     organizationId: '',
+    settings: {},
     isEnabled: true,
     trustProviderReportedCosts: false,
     providerCostMarkupMultiplier: 1,
@@ -144,6 +147,7 @@ export function useProviderFormLogic(
             apiEndpoint: apiProvider.baseUrl ?? '',
             organizationId: (provider as { organization?: string; organizationId?: string }).organization ??
                           (provider as { organization?: string; organizationId?: string }).organizationId ?? '',
+            settings: { ...(provider.settings ?? {}) },
             isEnabled: provider.isEnabled === true,
             trustProviderReportedCosts: provider.trustProviderReportedCosts === true,
             providerCostMarkupMultiplier: provider.providerCostMarkupMultiplier ?? 1,

--- a/WebAdmin/src/generated/admin-api.ts
+++ b/WebAdmin/src/generated/admin-api.ts
@@ -3146,7 +3146,8 @@ export interface components {
       | "ignored"
       | "providerDown"
       | "rateLimited"
-      | "unknownError";
+      | "unknownError"
+      | "configuration";
     /** @description Application identity information. */
     ApplicationInfoDto: {
       /** @description The application name. */
@@ -4007,6 +4008,12 @@ export interface components {
        *     Only consulted when bool CreateProviderRequest.TrustProviderReportedCosts is true.
        */
       providerCostMarkupMultiplier?: number;
+      /** @description Structured, provider-scoped settings supplied in addition to the API key (for example a
+       *     Cloudflare account ID). Keys correspond to the setting definitions declared for the
+       *     provider type. Non-secret values only. */
+      settings?: null | {
+        [key: string]: string;
+      };
     };
     CreateProviderToolDto: {
       provider: components["schemas"]["ProviderType"];
@@ -6091,6 +6098,9 @@ export interface components {
       providerType: components["schemas"]["ProviderType"];
       providerName: string;
       baseUrl?: null | string;
+      settings?: null | {
+        [key: string]: string;
+      };
       /** Format: int32 */
       keyCount: number;
       trustProviderReportedCosts: boolean;
@@ -6742,6 +6752,11 @@ export interface components {
       baseUrl?: null | string;
       /** @description The organization to test (optional) */
       organization?: null | string;
+      /** @description Structured, provider-scoped settings to test (for example a Cloudflare account ID).
+       *     Required settings must be present or the test returns an actionable configuration error. */
+      settings?: null | {
+        [key: string]: string;
+      };
     };
     /** @description Aggregate security metrics for threat analytics. */
     ThreatAnalyticsMetricsDto: {
@@ -7217,6 +7232,11 @@ export interface components {
        *     Defaults to 1.0 when omitted, so a partial update never silently zeroes the markup.
        */
       providerCostMarkupMultiplier?: number;
+      /** @description Structured, provider-scoped settings supplied in addition to the API key (for example a
+       *     Cloudflare account ID). When provided, replaces the stored settings. Non-secret values only. */
+      settings?: null | {
+        [key: string]: string;
+      };
     };
     UpdateProviderToolDto: {
       isActive?: boolean;

--- a/WebAdmin/src/lib/admin-api/models/providerConfiguration.ts
+++ b/WebAdmin/src/lib/admin-api/models/providerConfiguration.ts
@@ -52,6 +52,28 @@ export const PROVIDER_CATEGORIES: Partial<Record<ProviderType, ProviderCategory[
   [ProviderType.Meta]: [ProviderCategory.Chat],
 };
 
+/**
+ * A structured, provider-scoped setting an operator supplies in addition to the API key
+ * (for example a Cloudflare account ID). Mirrors the backend setting definitions declared in
+ * `ProviderConfigurationRegistry`; the backend remains authoritative for validation.
+ */
+export interface ProviderSettingField {
+  /** Stable machine key; also the storage key in the provider's `settings` map. */
+  key: string;
+  /** Human-readable field label. */
+  label: string;
+  /** Optional help text describing where to find the value. */
+  helpText?: string;
+  /** Whether the operator must supply this setting. */
+  required: boolean;
+  /** Whether the value is sensitive (rendered masked). */
+  secret?: boolean;
+  /** Optional regular-expression source the value must match. */
+  validationRegexSource?: string;
+  /** Optional placeholder shown in the input. */
+  placeholder?: string;
+}
+
 /** Provider-specific configuration requirements */
 export interface ProviderConfigRequirements {
   requiresApiKey: boolean;
@@ -61,6 +83,8 @@ export interface ProviderConfigRequirements {
   helpUrl?: string;
   helpText?: string;
   supportedModelTypes: ModelType[];
+  /** Structured settings supplied in addition to the API key. */
+  settings?: ProviderSettingField[];
 }
 
 export const PROVIDER_CONFIG_REQUIREMENTS: Partial<Record<ProviderType, ProviderConfigRequirements>> = {
@@ -162,12 +186,24 @@ export const PROVIDER_CONFIG_REQUIREMENTS: Partial<Record<ProviderType, Provider
   },
   [ProviderType.Cloudflare]: {
     requiresApiKey: true,
-    requiresEndpoint: true,
+    // The account ID is entered as a structured setting below; the base URL is derived from it,
+    // so an explicit endpoint is optional (advanced override only).
+    requiresEndpoint: false,
     requiresOrganizationId: false,
     supportsCustomEndpoint: true,
     helpUrl: 'https://developers.cloudflare.com/workers-ai/',
-    helpText: 'Create an API token at dash.cloudflare.com/profile/api-tokens. Base URL must include your account ID.',
-    supportedModelTypes: [ModelType.Chat, ModelType.Embedding, ModelType.Image]
+    helpText: 'Create an API token at dash.cloudflare.com/profile/api-tokens. Enter your account ID below — it is used to build the API base URL.',
+    supportedModelTypes: [ModelType.Chat, ModelType.Embedding, ModelType.Image],
+    settings: [
+      {
+        key: 'account_id',
+        label: 'Account ID',
+        helpText: 'Your Cloudflare account ID (shown in the dashboard URL and on the Workers AI page).',
+        required: true,
+        validationRegexSource: '^[0-9a-fA-F]{32}$',
+        placeholder: 'e.g. 0123456789abcdef0123456789abcdef',
+      },
+    ],
   },
   [ProviderType.OpenRouter]: {
     requiresApiKey: true,

--- a/WebAdmin/src/lib/admin-api/services/FetchProvidersService.ts
+++ b/WebAdmin/src/lib/admin-api/services/FetchProvidersService.ts
@@ -21,6 +21,8 @@ interface ProviderConfig {
   apiKey: string;
   baseUrl?: string;
   organizationId?: string;
+  /** Structured, provider-scoped settings (for example a Cloudflare account ID). */
+  settings?: Record<string, string>;
   additionalConfig?: ProviderSettings;
 }
 

--- a/docs/decisions/0002-provider-structured-settings.md
+++ b/docs/decisions/0002-provider-structured-settings.md
@@ -1,0 +1,115 @@
+# ADR 0002: Registry-driven structured provider settings
+
+- Status: Proposed
+- Date: 2026-07-23
+- Epic: #1177
+
+## Context
+
+Some providers require **structured, provider-scoping identifiers in addition to
+the API key**. Conduit models only a free-text `Provider.BaseUrl`
+(`Shared/ConduitLLM.Configuration/Entities/Provider.cs`) plus an unused
+per-key `Organization`, so operators are expected to encode those identifiers by
+hand-crafting a URL. That approach is already failing in three concrete ways:
+
+- **Cloudflare Workers AI** needs an **account ID** in the URL path. The default
+  base URL is a template,
+  `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1`
+  (`ProviderAdapterDefaultsRegistry.cs`), and nothing substitutes
+  `{account_id}`. When the endpoint field is left blank, `ResolveBaseUrl`
+  returns the literal template, the request is sent to
+  `.../accounts/%7Baccount_id%7D/ai/v1/models`, and Cloudflare answers `405`.
+  WebAdmin has no Account ID field, so there is no correct way to supply it
+  except knowing Cloudflare's URL grammar.
+- **OpenAI `Organization`** is stored on `ProviderKeyCredential` and collected by
+  the form, but **no provider client reads it** — it is silently dropped.
+- **Azure OpenAI** needs a resource endpoint, a deployment name, and an
+  api-version. It has no `ProviderType`; `OpenAIClient` detects it by matching
+  the string `"azure"` and overloads `BaseUrl`, the model ID, and a hardcoded
+  api-version constant.
+
+The pattern recurs for providers we are likely to add (AWS Bedrock: region plus
+two secrets; Google Vertex: project plus location plus a service-account
+credential).
+
+Two independent problems compound this. First, `BaseUrl` **structurally cannot
+express** identifiers that are not URL components — an OpenAI organization is a
+header, a Bedrock region is part of request signing. Second, provider
+configuration is described in two hand-mirrored places, `ProviderConfigurationRegistry`
+(C#) and `PROVIDER_CONFIG_REQUIREMENTS` (TypeScript), which drift.
+
+## Decision
+
+Introduce **registry-driven structured provider settings**.
+
+### Settings schema (single source of truth)
+
+Each `ProviderType` declares its settings as data in the C# provider registry.
+Every setting has:
+
+- `key` (stable identifier, e.g. `account_id`);
+- `label`, `helpText`;
+- `required` and, where useful, a `validationRegex`;
+- `secret` (whether the value is sensitive);
+- a **binding** that states how the value is applied at request time, one of:
+  `UrlPathToken` (fills a `{token}` in the base URL), `Header`, `QueryParam`, or
+  `AuthScope`.
+
+This declaration is the one source consumed by validation, the request-time
+resolver, and the WebAdmin form. WebAdmin renders its fields from the schema
+(served over the Admin API or generated), so the C#/TypeScript mirror is
+retired.
+
+### Storage
+
+Non-secret setting values are stored in a new nullable **JSONB `Settings`**
+column on `Provider` (a string-to-string map). Secret-valued settings are **not**
+placed in this bag; they remain in the credential store with the same protection
+as the API key. Phase 1 covers non-secret settings only.
+
+### Resolution
+
+A resolver composes the effective base URL, headers, query parameters, and auth
+from `Settings` against the registry, replacing the raw pass-through in
+`ResolveBaseUrl`. If a resolved URL still contains an unsubstituted `{token}`,
+the resolver raises an explicit configuration error instead of issuing the
+request. Test Connection surfaces missing required settings as actionable
+messages, and `405` is classified rather than reported as an unknown error.
+
+### Migration
+
+Following the expand/contract policy (ADR-002), the `Settings` column is added
+nullable, existing Cloudflare account IDs are backfilled by parsing current
+`BaseUrl` values, and the resolver reads `Settings` first while falling back to
+raw `BaseUrl` during a dual-read window. Removing the `BaseUrl` fallback is a
+later contract step.
+
+### Phasing
+
+1. Mechanism plus Cloudflare `account_id` end-to-end, dynamic WebAdmin fields,
+   backfill, and the improved Test Connection errors. This resolves the live bug.
+2. Bind OpenAI `organization` and add `project` as header settings; retire the
+   orphaned field.
+3. Promote Azure OpenAI to a first-class `ProviderType` with resource,
+   deployment, and api-version settings.
+4. Multi-secret credentials for Bedrock and Vertex.
+
+Issue breakdown: #1178–#1187 under epic #1177.
+
+## Consequences
+
+Cloudflare is configured by entering an API token and a labeled, validated
+Account ID; no operator needs to know the URL grammar, and a blank or malformed
+identifier produces an actionable error rather than a `405`. Structured
+identifiers gain a real home, so the OpenAI organization is actually sent and
+Azure loses its string-matching special cases. New providers add settings as
+data instead of new bespoke columns or client-specific hacks, and the settings
+schema drives both backend validation and the WebAdmin form from one definition.
+
+Costs and boundaries: JSONB values are less strongly typed than columns, so the
+registry's `validationRegex` and required-ness carry validation weight. Secret
+material is deliberately excluded from the `Settings` bag; multi-secret
+providers (Phase 4) require a separate credential design and are not solved by
+this ADR. During the dual-read window both `Settings` and raw `BaseUrl` are
+honored for Cloudflare, and the contract step that removes the fallback ships in
+a later release.


### PR DESCRIPTION
## What & why

Testing a Cloudflare token on **Add LLM Provider** failed with the opaque *"An unexpected error occurred during testing."* Root cause: Cloudflare's base URL is a template `.../accounts/{account_id}/ai/v1`, nothing substituted `{account_id}`, and there was **no Account ID field** — the identifier had to be hand-encoded into the base URL. Investigation (ADR [0002](../blob/feature/1177-provider-structured-settings/docs/decisions/0002-provider-structured-settings.md)) showed this is a **pattern**, not Cloudflare-only: OpenAI's `Organization` is collected but dropped, and Azure is faked with `_isAzure` string-matching.

This is **Phase 1 of epic #1177**: a registry-driven mechanism for structured, provider-scoped identifiers, tracked in the database, used to give Cloudflare a first-class **Account ID**.

## Changes

**Backend**
- **#1178** `ProviderSettingDefinition` schema on `ProviderConfiguration` (key, label, required, secret, `ValidationRegex`, and a binding: `UrlPathToken` / `Header` / `QueryParam` / `AuthScope`). Cloudflare declares a required `account_id` (UrlPathToken). Only `UrlPathToken` is applied in Phase 1.
- **#1179** `Provider.Settings` `jsonb` column (`Dictionary<string,string>`) via an EF value converter + comparer (`ProviderEntityConfiguration`); expand-safe migration `AddProviderSettings` (nullable add).
- **#1180 / #1181** `ResolveBaseUrl` substitutes `{token}` settings and **guards unresolved placeholders** with an actionable `ConfigurationException` instead of firing a malformed request. A raw `BaseUrl` with the id already embedded still works (**dual-read**), so existing installs need no backfill.
- `Settings` plumbed through `CreateProviderRequest` / `UpdateProviderRequest` / `TestProviderRequest` / `ProviderDto` + endpoints; create/update validated by re-resolving the base URL.
- **#1184** Test Connection: client construction moved inside the `try` so config errors are classified; new `ApiKeyTestResult.Configuration`; `405`/4xx are classified instead of bucketed to `UnknownError`; status parsing broadened beyond `HttpRequestException`.

**WebAdmin (#1182)**
- Renders declared settings fields (Cloudflare **Account ID**, with format validation) in the add form; the base URL becomes an optional advanced override (`requiresEndpoint: false`); `settings` sent in the create and test payloads.
- Regenerated `openapi-admin.json` + `admin-api.ts` (satisfies the CI drift gate).

## How it behaves now

| Before | After |
|---|---|
| No Account ID field; must hand-craft the URL | Labeled, validated **Account ID** field |
| Blank endpoint → 405 → "An unexpected error occurred" | Missing id → *"Cloudflare is missing required configuration: Account ID…"* |
| Account ID lives in a free-text URL | Stored in `Provider.Settings` (jsonb), returned on `ProviderDto` |

## Testing

- `dotnet build Conduit.slnx` clean; **509** provider tests pass; **13** new (`ProviderDefaultsRegistryTests` resolver/guard/dual-read + `ApiKeyTestResultServiceTests` classification).
- WebAdmin `npm run type-check` + `npm run lint` clean.
- `npm run validate:openapi` — no new invariant/ratchet violations.

## Deliberately deferred (follow-ups)

- **#1183** backfill account IDs from existing `BaseUrl` — not required for correctness because of dual-read; needed only before the eventual contract step.
- Remainder of **#1182**: serve the settings schema from the backend to fully retire the hand-mirrored `PROVIDER_CONFIG_REQUIREMENTS`. For now the Cloudflare field is mirrored in TS, but **the backend is authoritative for validation**.
- One thing to verify live: with a valid Account ID, Cloudflare's `/ai/v1/models` (the endpoint the test calls) — Cloudflare is configured `SupportsModelsList = false`, and the test still calls `ListModelsAsync`. The guard + 405 classification turn any residual failure into an actionable message, but a live token check should confirm the happy path. Tracked under #1181/#1184.

Closes #1178, #1179, #1180, #1181. Advances #1182 and #1184. Part of #1177.
