### PR TITLE
fix(tests): migrate integration tests to v1/admin API contract

### DIFF
--- a/Tests/ConduitLLM.IntegrationTests/Core/ApiDtos.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/ApiDtos.cs
@@ -9,7 +9,7 @@ namespace ConduitLLM.IntegrationTests.Core;
 
 public class CreateProviderRequest
 {
-    public int ProviderType { get; set; }  // Enum value
+    public string ProviderType { get; set; } = "";  // Enum name (Admin API requires string enums)
     public string ProviderName { get; set; } = "";
     public string? BaseUrl { get; set; }
     public bool IsEnabled { get; set; } = true;
@@ -19,7 +19,7 @@ public class CreateProviderResponse
 {
     public int Id { get; set; }
     public string ProviderName { get; set; } = "";
-    public int ProviderType { get; set; }
+    public string ProviderType { get; set; } = "";
     public bool IsEnabled { get; set; }
 }
 
@@ -49,26 +49,58 @@ public class CreateProviderKeyResponse
 }
 
 // =====================================================
+// Model Catalog Resolution DTOs
+// Mappings/costs reference a ModelProviderTypeAssociation from the
+// bundled model catalog, resolved via bulk mapping preview.
+// =====================================================
+
+public class BulkMappingPreviewRequest
+{
+    public List<BulkMappingItem> Mappings { get; set; } = new();
+}
+
+public class BulkMappingItem
+{
+    public string ModelAlias { get; set; } = "";
+    public int ProviderId { get; set; }
+    public string ProviderModelId { get; set; } = "";
+}
+
+public class BulkMappingPreviewResponse
+{
+    public List<BulkMappingResolution> Items { get; set; } = new();
+    public int TotalProcessed { get; set; }
+    public int ConflictCount { get; set; }
+}
+
+public class BulkMappingResolution
+{
+    public int Index { get; set; }
+    public string ModelAlias { get; set; } = "";
+    public int? ModelProviderTypeAssociationId { get; set; }
+    public bool HasConflict { get; set; }
+    public string? ErrorType { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+// =====================================================
 // Model Mapping DTOs
 // =====================================================
 
 public class CreateModelMappingRequest
 {
-    public string ModelId { get; set; } = "";  // Model alias
+    public string ModelAlias { get; set; } = "";  // Model alias
     public string ProviderModelId { get; set; } = "";  // Actual model name
     public int ProviderId { get; set; }
+    public int ModelProviderTypeAssociationId { get; set; }
     public int Priority { get; set; } = 0;
     public bool IsEnabled { get; set; } = true;
-    public bool SupportsVision { get; set; } = false;
-    public bool SupportsChat { get; set; } = true;
-    public bool SupportsStreaming { get; set; } = true;
-    public bool SupportsFunctionCalling { get; set; } = false;
 }
 
 public class CreateModelMappingResponse
 {
     public int Id { get; set; }
-    public string ModelId { get; set; } = "";
+    public string ModelAlias { get; set; } = "";
     public string ProviderModelId { get; set; } = "";
     public int ProviderId { get; set; }
 }
@@ -80,8 +112,8 @@ public class CreateModelMappingResponse
 public class CreateModelCostRequest
 {
     public string CostName { get; set; } = "";
-    public int PricingModel { get; set; } = 0; // PricingModel.Standard
-    public List<int> ModelProviderMappingIds { get; set; } = new();
+    public string PricingModel { get; set; } = "standard"; // Enum name (Admin API requires string enums)
+    public List<int> ModelProviderTypeAssociationIds { get; set; } = new();
     public string ModelType { get; set; } = "chat";
     public int Priority { get; set; } = 0;
     public string? Description { get; set; }
@@ -124,10 +156,10 @@ public class CreateVirtualKeyGroupResponse
 public class CreateVirtualKeyRequest
 {
     public string KeyName { get; set; } = "";
-    public string? AllowedModels { get; set; }
+    public List<string>? AllowedModels { get; set; }
     public int VirtualKeyGroupId { get; set; }
     public DateTime? ExpiresAt { get; set; }
-    public string? Metadata { get; set; }
+    public Dictionary<string, object>? Metadata { get; set; }
     public int? RateLimitRpm { get; set; }
     public int? RateLimitRpd { get; set; }
 }

--- a/Tests/ConduitLLM.IntegrationTests/Core/ConduitApiClient.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/ConduitApiClient.cs
@@ -47,6 +47,15 @@ public class ConduitApiClient : IDisposable
     {
         return await ExecuteAsync<T>(HttpMethod.Put, _config.Environment.AdminApiUrl, endpoint, payload, true);
     }
+
+    /// <summary>
+    /// Sends a PATCH to the Admin API. Virtual keys, virtual key groups, and IP filters
+    /// require an If-Match header; "*" matches any current version.
+    /// </summary>
+    public async Task<ApiResponse<T>> AdminPatchAsync<T>(string endpoint, object? payload = null, string? ifMatch = null)
+    {
+        return await ExecuteAsync<T>(HttpMethod.Patch, _config.Environment.AdminApiUrl, endpoint, payload, true, ifMatch: ifMatch);
+    }
     
     public async Task<ApiResponse<T>> AdminDeleteAsync<T>(string endpoint)
     {
@@ -67,15 +76,21 @@ public class ConduitApiClient : IDisposable
     
     // Generic execution method
     private async Task<ApiResponse<T>> ExecuteAsync<T>(
-        HttpMethod method, 
-        string baseUrl, 
-        string endpoint, 
+        HttpMethod method,
+        string baseUrl,
+        string endpoint,
         object? payload,
         bool isAdmin,
-        string? virtualKey = null)
+        string? virtualKey = null,
+        string? ifMatch = null)
     {
         var url = $"{baseUrl}{endpoint}";
         var request = new HttpRequestMessage(method, url);
+
+        if (ifMatch != null)
+        {
+            request.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+        }
         
         // Add authentication
         if (isAdmin)

--- a/Tests/ConduitLLM.IntegrationTests/Core/ModelCatalogSetup.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/ModelCatalogSetup.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.IntegrationTests.Core;
+
+/// <summary>
+/// Resolves the ModelProviderTypeAssociation (model catalog identifier) that the v1/admin API
+/// requires before a model provider mapping or model cost can be created. Associations come
+/// from the bundled model catalog seeded at Admin startup; this helper resolves them via the
+/// bulk mapping preview endpoint rather than creating catalog entries.
+/// </summary>
+public static class ModelCatalogSetup
+{
+    public static async Task<int> ResolveAssociationAsync(
+        ConduitApiClient apiClient,
+        int providerId,
+        string modelAlias,
+        string providerModelId,
+        ILogger logger)
+    {
+        var previewResponse = await apiClient.AdminPostAsync<BulkMappingPreviewResponse>(
+            "/v1/admin/model-provider-mappings/bulk/preview",
+            new BulkMappingPreviewRequest
+            {
+                Mappings = new List<BulkMappingItem>
+                {
+                    new()
+                    {
+                        ModelAlias = modelAlias,
+                        ProviderId = providerId,
+                        ProviderModelId = providerModelId
+                    }
+                }
+            });
+
+        if (!previewResponse.Success || previewResponse.Data == null)
+        {
+            throw new InvalidOperationException($"Bulk mapping preview failed: {previewResponse.Error}");
+        }
+
+        var item = previewResponse.Data.Items.FirstOrDefault();
+        if (item?.ModelProviderTypeAssociationId == null)
+        {
+            throw new InvalidOperationException(
+                $"No model catalog association found for '{providerModelId}' " +
+                $"({item?.ErrorType}: {item?.ErrorMessage}). " +
+                "Seed the catalog via POST /v1/admin/model-catalogs/import and retry.");
+        }
+
+        logger.LogInformation(
+            "✓ Model catalog association resolved: AssociationId={AssociationId} ({Identifier})",
+            item.ModelProviderTypeAssociationId, providerModelId);
+
+        return item.ModelProviderTypeAssociationId.Value;
+    }
+}

--- a/Tests/ConduitLLM.IntegrationTests/Core/ProviderIntegrationTestBase.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/ProviderIntegrationTestBase.cs
@@ -42,7 +42,10 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
             
             // Step 2: Create Provider Key
             await CreateProviderKey();
-            
+
+            // Step 2b: Create model catalog entries (author/series/model/identifier)
+            await CreateModelCatalog();
+
             // Step 3: Create Model Mapping
             await CreateModelMapping();
             
@@ -69,18 +72,16 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
     protected async Task CreateProvider()
     {
         _logger.LogInformation("Step 1: Creating {Provider} provider", _providerConfig.Provider.Type);
-        
-        var providerTypeEnum = GetProviderTypeEnum(_providerConfig.Provider.Type);
-        
+
         var createProviderRequest = new CreateProviderRequest
         {
             ProviderName = $"{_config.Defaults.TestPrefix}{_providerConfig.Provider.Name}_{_context.TestRunId}",
-            ProviderType = providerTypeEnum,
+            ProviderType = _providerConfig.Provider.Type,
             BaseUrl = _providerConfig.Provider.BaseUrl,
             IsEnabled = true
         };
         
-        var providerResponse = await _apiClient.AdminPostAsync<CreateProviderResponse>("/api/ProviderCredentials", createProviderRequest);
+        var providerResponse = await _apiClient.AdminPostAsync<CreateProviderResponse>("/v1/admin/providers", createProviderRequest);
         providerResponse.Success.Should().BeTrue($"Provider creation should succeed: {providerResponse.Error}");
         providerResponse.Data.Should().NotBeNull();
         _context.ProviderId = providerResponse.Data!.Id;
@@ -99,7 +100,7 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
         };
         
         var keyResponse = await _apiClient.AdminPostAsync<CreateProviderKeyResponse>(
-            $"/api/ProviderCredentials/{_context.ProviderId}/keys", 
+            $"/v1/admin/providers/{_context.ProviderId}/keys",
             createKeyRequest);
         
         keyResponse.Success.Should().BeTrue($"Key creation should succeed: {keyResponse.Error}");
@@ -109,22 +110,42 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
         _logger.LogInformation("✓ Provider key created: {KeyId}", _context.ProviderKeyId);
     }
     
+    protected async Task CreateModelCatalog()
+    {
+        if (_context.ModelProviderTypeAssociationId != null)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Step 2b: Resolving model catalog association");
+
+        var modelConfig = _providerConfig.Models[0];
+        _context.ModelProviderTypeAssociationId = await ModelCatalogSetup.ResolveAssociationAsync(
+            _apiClient,
+            _context.ProviderId!.Value,
+            $"{modelConfig.Alias}_{_context.TestRunId}",
+            modelConfig.Actual,
+            _logger);
+    }
+
     protected async Task CreateModelMapping()
     {
+        // Mapping creation requires a model catalog association
+        await CreateModelCatalog();
+
         _logger.LogInformation("Step 3: Creating model mapping");
-        
+
         var modelConfig = _providerConfig.Models[0];
         var createMappingRequest = new CreateModelMappingRequest
         {
-            ModelId = $"{modelConfig.Alias}_{_context.TestRunId}",
+            ModelAlias = $"{modelConfig.Alias}_{_context.TestRunId}",
             ProviderId = _context.ProviderId!.Value,
             ProviderModelId = modelConfig.Actual,
-            SupportsChat = modelConfig.Capabilities.Chat,
-            SupportsStreaming = modelConfig.Capabilities.Streaming
+            ModelProviderTypeAssociationId = _context.ModelProviderTypeAssociationId!.Value
         };
-        
+
         var mappingResponse = await _apiClient.AdminPostAsync<CreateModelMappingResponse>(
-            "/api/ModelProviderMapping", 
+            "/v1/admin/model-provider-mappings",
             createMappingRequest);
         
         mappingResponse.Success.Should().BeTrue($"Model mapping should succeed: {mappingResponse.Error}");
@@ -143,13 +164,13 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
         var createCostRequest = new CreateModelCostRequest
         {
             CostName = $"{_context.ModelAlias}_cost",
-            ModelProviderMappingIds = new List<int> { _context.ModelMappingId!.Value },
+            ModelProviderTypeAssociationIds = new List<int> { _context.ModelProviderTypeAssociationId!.Value },
             InputCostPerMillionTokens = modelConfig.Cost.InputPerMillion,
             OutputCostPerMillionTokens = modelConfig.Cost.OutputPerMillion
         };
-        
+
         var costResponse = await _apiClient.AdminPostAsync<CreateModelCostResponse>(
-            "/api/ModelCosts", 
+            "/v1/admin/model-costs",
             createCostRequest);
         
         costResponse.Success.Should().BeTrue($"Model cost creation should succeed: {costResponse.Error}");
@@ -171,7 +192,7 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
         };
         
         var groupResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyGroupResponse>(
-            "/api/VirtualKeyGroups", 
+            "/v1/admin/virtual-key-groups",
             createGroupRequest);
         
         groupResponse.Success.Should().BeTrue($"Virtual key group creation should succeed: {groupResponse.Error}");
@@ -197,7 +218,7 @@ public abstract class ProviderIntegrationTestBase : IClassFixture<TestFixture>
         };
         
         var vkeyResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyResponse>(
-            "/api/VirtualKeys", 
+            "/v1/admin/virtual-keys",
             createVKeyRequest);
         
         vkeyResponse.Success.Should().BeTrue($"Virtual key creation should succeed: {vkeyResponse.Error}");

--- a/Tests/ConduitLLM.IntegrationTests/Core/TestConfiguration.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/TestConfiguration.cs
@@ -104,6 +104,7 @@ public class TestContext
     public int? ProviderId { get; set; }
     public string? ProviderKeyId { get; set; }
     public int? ModelMappingId { get; set; }
+    public int? ModelProviderTypeAssociationId { get; set; }
     public string? ModelAlias { get; set; }  // Store the unique model alias
     public int? ModelCostId { get; set; }
     public int? VirtualKeyGroupId { get; set; }

--- a/Tests/ConduitLLM.IntegrationTests/Infrastructure/CriticalPathTestBase.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Infrastructure/CriticalPathTestBase.cs
@@ -51,7 +51,7 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         };
 
         var groupResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyGroupResponse>(
-            "/api/VirtualKeyGroups",
+            "/v1/admin/virtual-key-groups",
             createGroupRequest);
 
         groupResponse.Success.Should().BeTrue($"Virtual key group creation should succeed: {groupResponse.Error}");
@@ -68,7 +68,7 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         };
 
         var keyResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyResponse>(
-            "/api/VirtualKeys",
+            "/v1/admin/virtual-keys",
             createKeyRequest);
 
         keyResponse.Success.Should().BeTrue($"Virtual key creation should succeed: {keyResponse.Error}");
@@ -86,10 +86,9 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
     /// </summary>
     protected async Task<decimal> FlushAndGetBalanceAsync(int groupId)
     {
-        // Trigger batch spend flush
+        // Trigger batch spend flush (parameters are query-string based on the v1 endpoint)
         var flushResponse = await _apiClient.AdminPostAsync<object>(
-            "/api/batch-spending/flush",
-            new { reason = "Critical path test balance verification", priority = "Normal" });
+            $"/v1/admin/batch-spending-jobs/flush?reason={Uri.EscapeDataString("Critical path test balance verification")}&priority=Normal");
 
         if (!flushResponse.Success)
         {
@@ -104,7 +103,7 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
 
         // Get updated balance
         var balanceResponse = await _apiClient.AdminGetAsync<CreateVirtualKeyGroupResponse>(
-            $"/api/VirtualKeyGroups/{groupId}");
+            $"/v1/admin/virtual-key-groups/{groupId}");
 
         balanceResponse.Success.Should().BeTrue($"Failed to fetch updated balance: {balanceResponse.Error}");
         return balanceResponse.Data!.Balance;
@@ -170,25 +169,25 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
 
     /// <summary>
     /// Disables a virtual key by updating it via the Admin API.
+    /// Filters the key list by group — the unfiltered list is paginated and the
+    /// newly created key may not be on the first page.
     /// </summary>
-    protected async Task DisableVirtualKeyAsync(string virtualKey)
+    protected async Task DisableVirtualKeyAsync(int groupId)
     {
-        // Extract the key hash from the virtual key to find its ID
-        // Virtual keys are in format "cvk_xxxx" and the hash is stored in the database
-        var response = await _apiClient.AdminGetAsync<List<VirtualKeyListItem>>("/api/VirtualKeys");
+        var response = await _apiClient.AdminGetAsync<VirtualKeyListResponse>(
+            $"/v1/admin/virtual-keys?virtualKeyGroupId={groupId}");
         response.Success.Should().BeTrue($"Failed to list virtual keys: {response.Error}");
 
-        var keyInfo = response.Data?.FirstOrDefault(k => k.KeyName.Contains(_context.TestRunId));
-        if (keyInfo != null)
-        {
-            // Disable the key
-            var updateResponse = await _apiClient.AdminPutAsync<object>(
-                $"/api/VirtualKeys/{keyInfo.Id}",
-                new { isEnabled = false });
+        var keyInfo = response.Data?.Data.FirstOrDefault(k => k.KeyName.Contains(_context.TestRunId));
+        keyInfo.Should().NotBeNull($"Expected to find a key for test run {_context.TestRunId} in group {groupId}");
 
-            updateResponse.Success.Should().BeTrue($"Failed to disable virtual key: {updateResponse.Error}");
-            _logger.LogInformation("Disabled virtual key: {KeyId}", keyInfo.Id);
-        }
+        var updateResponse = await _apiClient.AdminPatchAsync<object>(
+            $"/v1/admin/virtual-keys/{keyInfo!.Id}",
+            new { isEnabled = false },
+            ifMatch: "*");
+
+        updateResponse.Success.Should().BeTrue($"Failed to disable virtual key: {updateResponse.Error}");
+        _logger.LogInformation("Disabled virtual key: {KeyId}", keyInfo.Id);
     }
 
     // =====================================================
@@ -229,19 +228,18 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         string? overrideApiKey = null,
         string? nameSuffix = null)
     {
-        var providerTypeEnum = GetProviderTypeEnum(providerConfig.Provider.Type);
         var suffix = nameSuffix ?? "Test";
 
         var createProviderRequest = new CreateProviderRequest
         {
             ProviderName = $"{_config.Defaults.TestPrefix}{suffix}_{_context.TestRunId}",
-            ProviderType = providerTypeEnum,
+            ProviderType = providerConfig.Provider.Type,
             BaseUrl = providerConfig.Provider.BaseUrl,
             IsEnabled = true
         };
 
         var providerResponse = await _apiClient.AdminPostAsync<CreateProviderResponse>(
-            "/api/ProviderCredentials",
+            "/v1/admin/providers",
             createProviderRequest);
         providerResponse.Success.Should().BeTrue($"Provider creation failed: {providerResponse.Error}");
 
@@ -255,7 +253,7 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         };
 
         var keyResponse = await _apiClient.AdminPostAsync<CreateProviderKeyResponse>(
-            $"/api/ProviderCredentials/{providerResponse.Data!.Id}/keys",
+            $"/v1/admin/providers/{providerResponse.Data!.Id}/keys",
             createKeyRequest);
         keyResponse.Success.Should().BeTrue($"Key creation failed: {keyResponse.Error}");
 
@@ -279,17 +277,24 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         var modelConfig = providerConfig.Models[0];
         var modelAlias = $"{modelConfig.Alias}_{_context.TestRunId}";
 
+        // The mapping must reference a model catalog association; resolve it first
+        _context.ModelProviderTypeAssociationId ??= await ModelCatalogSetup.ResolveAssociationAsync(
+            _apiClient,
+            providerId,
+            modelAlias,
+            modelConfig.Actual,
+            _logger);
+
         var createMappingRequest = new CreateModelMappingRequest
         {
-            ModelId = modelAlias,
+            ModelAlias = modelAlias,
             ProviderId = providerId,
             ProviderModelId = modelConfig.Actual,
-            SupportsChat = modelConfig.Capabilities.Chat,
-            SupportsStreaming = modelConfig.Capabilities.Streaming
+            ModelProviderTypeAssociationId = _context.ModelProviderTypeAssociationId.Value
         };
 
         var mappingResponse = await _apiClient.AdminPostAsync<CreateModelMappingResponse>(
-            "/api/ModelProviderMapping",
+            "/v1/admin/model-provider-mappings",
             createMappingRequest);
         mappingResponse.Success.Should().BeTrue($"Model mapping failed: {mappingResponse.Error}");
 
@@ -319,13 +324,13 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
         var createCostRequest = new CreateModelCostRequest
         {
             CostName = $"{_context.ModelAlias}_cost",
-            ModelProviderMappingIds = new List<int> { _context.ModelMappingId.Value },
+            ModelProviderTypeAssociationIds = new List<int> { _context.ModelProviderTypeAssociationId!.Value },
             InputCostPerMillionTokens = modelConfig.Cost.InputPerMillion,
             OutputCostPerMillionTokens = modelConfig.Cost.OutputPerMillion
         };
 
         var costResponse = await _apiClient.AdminPostAsync<CreateModelCostResponse>(
-            "/api/ModelCosts",
+            "/v1/admin/model-costs",
             createCostRequest);
         costResponse.Success.Should().BeTrue($"Model cost creation failed: {costResponse.Error}");
 
@@ -337,8 +342,8 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
     /// </summary>
     protected async Task DisableProviderAsync(int providerId)
     {
-        var updateResponse = await _apiClient.AdminPutAsync<object>(
-            $"/api/ProviderCredentials/{providerId}",
+        var updateResponse = await _apiClient.AdminPatchAsync<object>(
+            $"/v1/admin/providers/{providerId}",
             new { isEnabled = false });
 
         updateResponse.Success.Should().BeTrue($"Failed to disable provider: {updateResponse.Error}");
@@ -350,8 +355,8 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
     /// </summary>
     protected async Task DisableModelMappingAsync(int mappingId)
     {
-        var updateResponse = await _apiClient.AdminPutAsync<object>(
-            $"/api/ModelProviderMapping/{mappingId}",
+        var updateResponse = await _apiClient.AdminPatchAsync<object>(
+            $"/v1/admin/model-provider-mappings/{mappingId}",
             new { isEnabled = false });
 
         updateResponse.Success.Should().BeTrue($"Failed to disable mapping: {updateResponse.Error}");
@@ -360,8 +365,13 @@ public abstract class CriticalPathTestBase : IClassFixture<TestFixture>, IClassF
 }
 
 /// <summary>
-/// DTO for listing virtual keys.
+/// DTO for listing virtual keys. The v1 endpoint wraps the list in a {data: [...]} envelope.
 /// </summary>
+public class VirtualKeyListResponse
+{
+    public List<VirtualKeyListItem> Data { get; set; } = new();
+}
+
 public class VirtualKeyListItem
 {
     public int Id { get; set; }

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/AuthenticationIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/AuthenticationIntegrationTests.cs
@@ -72,10 +72,20 @@ public class AuthenticationIntegrationTests : CriticalPathTestBase
         var (virtualKey, groupId, balance) = await CreateRateLimitedKeyAsync(initialCredit: 10.00m);
 
         // Disable the key
-        await DisableVirtualKeyAsync(virtualKey);
+        await DisableVirtualKeyAsync(groupId);
 
-        // Act - Try to use the disabled key
-        var response = await _apiClient.CoreGetAsync<object>("/v1/models", virtualKey);
+        // Act - Try to use the disabled key. Key-state changes propagate via events,
+        // so poll briefly until the Gateway observes the disable.
+        ApiResponse<object> response = null!;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            response = await _apiClient.CoreGetAsync<object>("/v1/models", virtualKey);
+            if (!response.Success)
+            {
+                break;
+            }
+            await Task.Delay(1000);
+        }
 
         // Assert
         response.Success.Should().BeFalse("Disabled virtual key should be rejected");
@@ -98,7 +108,7 @@ public class AuthenticationIntegrationTests : CriticalPathTestBase
         };
 
         var groupResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyGroupResponse>(
-            "/api/VirtualKeyGroups",
+            "/v1/admin/virtual-key-groups",
             createGroupRequest);
         groupResponse.Success.Should().BeTrue();
 
@@ -109,7 +119,7 @@ public class AuthenticationIntegrationTests : CriticalPathTestBase
         };
 
         var keyResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyResponse>(
-            "/api/VirtualKeys",
+            "/v1/admin/virtual-keys",
             createKeyRequest);
         keyResponse.Success.Should().BeTrue();
 

--- a/Tests/ConduitLLM.IntegrationTests/Tests/GroqEndToEndTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/GroqEndToEndTest.cs
@@ -42,22 +42,16 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             // Step 1: Create Provider
             // ========================================
             _logger.LogInformation("Step 1: Creating Groq provider");
-            
-            var providerTypeEnum = _providerConfig.Provider.Type.ToLower() switch
-            {
-                "groq" => 2,
-                _ => throw new InvalidOperationException($"Unknown provider type: {_providerConfig.Provider.Type}")
-            };
-            
+
             var createProviderRequest = new CreateProviderRequest
             {
                 ProviderName = $"{_config.Defaults.TestPrefix}{_providerConfig.Provider.Name}_{context.TestRunId}",
-                ProviderType = providerTypeEnum,
+                ProviderType = _providerConfig.Provider.Type,
                 BaseUrl = _providerConfig.Provider.BaseUrl,
                 IsEnabled = true
             };
             
-            var providerResponse = await _apiClient.AdminPostAsync<CreateProviderResponse>("/api/ProviderCredentials", createProviderRequest);
+            var providerResponse = await _apiClient.AdminPostAsync<CreateProviderResponse>("/v1/admin/providers", createProviderRequest);
             providerResponse.Success.Should().BeTrue($"Provider creation should succeed: {providerResponse.Error}");
             providerResponse.Data.Should().NotBeNull();
             context.ProviderId = providerResponse.Data!.Id;
@@ -76,7 +70,7 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             };
             
             var keyResponse = await _apiClient.AdminPostAsync<CreateProviderKeyResponse>(
-                $"/api/ProviderCredentials/{context.ProviderId}/keys", 
+                $"/v1/admin/providers/{context.ProviderId}/keys",
                 createKeyRequest);
             
             keyResponse.Success.Should().BeTrue($"Key creation should succeed: {keyResponse.Error}");
@@ -86,22 +80,33 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             _logger.LogInformation("✓ Provider key created: {KeyId}", context.ProviderKeyId);
             
             // ========================================
+            // Step 2b: Resolve Model Catalog Association
+            // ========================================
+            _logger.LogInformation("Step 2b: Resolving model catalog association");
+
+            var modelConfig = _providerConfig.Models[0];
+            context.ModelProviderTypeAssociationId = await ModelCatalogSetup.ResolveAssociationAsync(
+                _apiClient,
+                context.ProviderId!.Value,
+                $"{modelConfig.Alias}_{context.TestRunId}",
+                modelConfig.Actual,
+                _logger);
+
+            // ========================================
             // Step 3: Create Model Mapping
             // ========================================
             _logger.LogInformation("Step 3: Creating model mapping");
-            
-            var modelConfig = _providerConfig.Models[0];
+
             var createMappingRequest = new CreateModelMappingRequest
             {
-                ModelId = $"{modelConfig.Alias}_{context.TestRunId}",
+                ModelAlias = $"{modelConfig.Alias}_{context.TestRunId}",
                 ProviderId = context.ProviderId!.Value,
                 ProviderModelId = modelConfig.Actual,
-                SupportsChat = modelConfig.Capabilities.Chat,
-                SupportsStreaming = modelConfig.Capabilities.Streaming
+                ModelProviderTypeAssociationId = context.ModelProviderTypeAssociationId!.Value
             };
-            
+
             var mappingResponse = await _apiClient.AdminPostAsync<CreateModelMappingResponse>(
-                "/api/ModelProviderMapping", 
+                "/v1/admin/model-provider-mappings",
                 createMappingRequest);
             
             mappingResponse.Success.Should().BeTrue($"Model mapping should succeed: {mappingResponse.Error}");
@@ -119,13 +124,13 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             var createCostRequest = new CreateModelCostRequest
             {
                 CostName = $"{context.ModelAlias}_cost",
-                ModelProviderMappingIds = new List<int> { context.ModelMappingId!.Value },
+                ModelProviderTypeAssociationIds = new List<int> { context.ModelProviderTypeAssociationId!.Value },
                 InputCostPerMillionTokens = modelConfig.Cost.InputPerMillion,
                 OutputCostPerMillionTokens = modelConfig.Cost.OutputPerMillion
             };
-            
+
             var costResponse = await _apiClient.AdminPostAsync<CreateModelCostResponse>(
-                "/api/ModelCosts", 
+                "/v1/admin/model-costs",
                 createCostRequest);
             
             costResponse.Success.Should().BeTrue($"Model cost creation should succeed: {costResponse.Error}");
@@ -147,7 +152,7 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             };
             
             var groupResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyGroupResponse>(
-                "/api/VirtualKeyGroups", 
+                "/v1/admin/virtual-key-groups",
                 createGroupRequest);
             
             groupResponse.Success.Should().BeTrue($"Virtual key group creation should succeed: {groupResponse.Error}");
@@ -174,7 +179,7 @@ public class GroqEndToEndTest : IClassFixture<TestFixture>
             };
             
             var vkeyResponse = await _apiClient.AdminPostAsync<CreateVirtualKeyResponse>(
-                "/api/VirtualKeys", 
+                "/v1/admin/virtual-keys",
                 createVKeyRequest);
             
             vkeyResponse.Success.Should().BeTrue($"Virtual key creation should succeed: {vkeyResponse.Error}");

--- a/Tests/ConduitLLM.IntegrationTests/Tests/ProviderBillingIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/ProviderBillingIntegrationTests.cs
@@ -126,8 +126,7 @@ public class ProviderBillingIntegrationTests : ProviderIntegrationTestBase
             _output.WriteLine($"  ⏳ Triggering batch spend flush via Admin API...");
             
             var flushResponse = await _apiClient.AdminPostAsync<object>(
-                "/api/batch-spending/flush",
-                new { reason = "Integration test billing verification", priority = "Normal" });
+                $"/v1/admin/batch-spending-jobs/flush?reason={Uri.EscapeDataString("Integration test billing verification")}&priority=Normal");
             
             if (!flushResponse.Success)
             {
@@ -143,7 +142,7 @@ public class ProviderBillingIntegrationTests : ProviderIntegrationTestBase
             }
             
             var balanceResponse = await _apiClient.AdminGetAsync<CreateVirtualKeyGroupResponse>(
-                $"/api/VirtualKeyGroups/{groupId}");
+                $"/v1/admin/virtual-key-groups/{groupId}");
             
             balanceResponse.Success.Should().BeTrue("Failed to fetch updated balance");
             balanceResponse.Data.Should().NotBeNull();

--- a/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithToolCallsTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithToolCallsTest.cs
@@ -24,7 +24,9 @@ public class StreamingWithToolCallsTest : ProviderIntegrationTestBase
         return _fixture.ServiceProvider.GetRequiredService<ILogger<StreamingWithToolCallsTest>>();
     }
 
-    [Fact(DisplayName = "Streaming with Tool Calls - Should Emit tool-executing Events")]
+    [Fact(DisplayName = "Streaming with Tool Calls - Should Emit tool-executing Events",
+        Skip = "Inline JavaScript function configurations were removed; functions are now provider-typed " +
+               "(Exa, Tavily, MCP, ...). Rewrite against a function provider or a local MCP server.")]
     public async Task StreamingWithToolCalls_ShouldEmitToolExecutingEvents()
     {
         // This test verifies the complete tool execution lifecycle during streaming:


### PR DESCRIPTION
## Summary

`ConduitLLM.IntegrationTests` was never updated for the Gateway & Admin API contract reset (epic #1148): every Admin call still targeted legacy `/api/*` routes, which now 404. Against a healthy dev stack the suite failed **40/88**. This PR migrates the suite to the current contract; it now passes **78 / 1 skipped / 9 failing**, with every remaining failure external to the tests (details below).

## Contract changes applied

- **Routes**: `/api/{ProviderCredentials, VirtualKeys, VirtualKeyGroups, ModelProviderMapping, ModelCosts, batch-spending}` → `/v1/admin/{providers, virtual-keys, virtual-key-groups, model-provider-mappings, model-costs, batch-spending-jobs}`
- **Verbs**: updates are `PATCH`, not `PUT` (new `AdminPatchAsync` on the test client); batch flush takes query-string parameters
- **Enums**: sent/received as camelCase strings — the Admin API rejects integer enums (`JsonStringEnumConverter(allowIntegerValues: false)`)
- **Model catalog**: mapping creation now requires a `ModelProviderTypeAssociationId`. New `Core/ModelCatalogSetup.cs` resolves it from the startup-seeded bundled catalog via `POST /v1/admin/model-provider-mappings/bulk/preview`. Model costs attach to association IDs (not mapping IDs) and repoint the association at the test cost, keeping billing assertions deterministic
- **Pagination**: `GET /v1/admin/virtual-keys` returns a paginated `{data, pagination}` envelope; the disable-key helper now filters by `virtualKeyGroupId` instead of scanning page 1
- **Concurrency**: virtual-key PATCH requires an `If-Match` ETag header (HTTP 428 otherwise); the client supports it and the tests send `If-Match: *`
- **Skipped**: `StreamingWithToolCallsTest` — inline JavaScript function configurations no longer exist (functions are provider-typed: Exa, Tavily, MCP, ...); the test needs a redesign, not a route fix

Also fixed setup ergonomics: the admin-key auto-detect (`GetAdminApiKeyFromDockerCompose`) probes only three `..` levels and has been broken since the test projects moved under `Tests/` — documented workaround is setting `adminApiKey` in `test-config.yaml` (config files are gitignored; no secrets in this PR).

## Remaining failures (not addressable in test code)

| Cause | Tests |
|---|---|
| Gateway maps client errors to 500 (#1191) | unknown-model 404, disabled-mapping 404, disabled-provider 404/503, bad-request 400 |
| No Cerebras API key configured | Cerebras basic chat, streaming-with-reasoning |
| SambaNova account credits exhausted | SambaNova e2e, SambaNova billing |
| Flaky (passes in isolation) | Recovery after failure |

Filed while migrating: #1191 (Gateway 500-vs-4xx error mapping), #1192 (`POST /v1/admin/models` cascades a blank ModelAuthor/ModelSeries insert — the tests avoid that endpoint via bulk/preview resolution).

## Test plan

- `dotnet build` clean
- Full suite run against the dev stack (`./scripts/dev.ps1`) with a valid Groq key: 78 pass / 1 skip / 9 fail as tabulated above
- Groq end-to-end flow verified live: provider → key → catalog association → mapping → cost → virtual key → chat → token tracking → micro-cent billing accuracy