### PR TITLE
feat: harden provider key auto-disable and recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,9 @@ if (isMetricsData(event.data)) {
 - **ProviderKeyCredential Entity**: API keys with ProviderAccountGroup for account separation
 - **ModelProviderMapping**: Links model aliases to Provider.Id (NOT ProviderType!)
 - **ModelCost**: Flexible cost configs via ModelCostMapping
+- **Provider key resilience**: Fatal credential/account errors disable keys, not healthy sibling
+  capacity. See [ADR 0003](docs/decisions/0003-provider-key-auto-disable-policy.md) and the
+  [operator runbook](docs/operations/provider-key-auto-disable.md).
 
 ### Available Provider Types
 ```csharp

--- a/Services/ConduitLLM.Admin/Endpoints/ProviderErrorsEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderErrorsEndpoints.cs
@@ -3,8 +3,10 @@ using ConduitLLM.Admin.Auditing;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Events;
 using ConduitLLM.Configuration.DTOs;
+using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -212,6 +214,9 @@ namespace ConduitLLM.Admin.Endpoints
             // Look up the key to get its providerId for proper cleanup
             var key = await _keyRepo.GetByIdAsync(keyId);
             int? providerId = key?.ProviderId;
+            var keyErrorDetails = key != null
+                ? await _errorService.GetKeyErrorDetailsAsync(keyId)
+                : null;
             var providerSummary = providerId.HasValue
                 ? await _errorService.GetProviderSummaryAsync(providerId.Value)
                 : null;
@@ -219,27 +224,72 @@ namespace ConduitLLM.Admin.Endpoints
                 providerSummary?.ProviderDisabledAt != null &&
                 providerSummary.ProviderDisableReason == ProviderErrorTrackingService.AllKeysDisabledReason;
 
-            // Clear errors from Redis (including provider disabled keys cleanup)
-            await _errorService.ClearErrorsForKeyAsync(keyId, providerId);
-
-            // Re-enable the key if requested
-            if (request.ReenableKey && key != null && !key.IsEnabled)
+            var keysToRecover = new List<ConduitLLM.Configuration.Entities.ProviderKeyCredential>();
+            if (key != null)
             {
-                key.IsEnabled = true;
-                await _keyRepo.UpdateAsync(key);
+                keysToRecover.Add(key);
 
-                // Publish event for UI update
+                var recoverAccountGroup =
+                    request.ReenableKey &&
+                    key.ProviderAccountGroup > 0 &&
+                    keyErrorDetails?.FatalError?.ErrorType == ProviderErrorType.InsufficientBalance;
+                if (recoverAccountGroup)
+                {
+                    var allProviderKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                        _keyRepo.GetByProviderIdPaginatedAsync, key.ProviderId);
+                    foreach (var candidate in allProviderKeys.Where(candidate =>
+                                 candidate.Id != keyId &&
+                                 candidate.ProviderAccountGroup == key.ProviderAccountGroup))
+                    {
+                        var candidateErrors =
+                            await _errorService.GetKeyErrorDetailsAsync(candidate.Id);
+                        if (candidateErrors?.FatalError?.ErrorType ==
+                            ProviderErrorType.InsufficientBalance)
+                        {
+                            keysToRecover.Add(candidate);
+                        }
+                    }
+                }
+            }
+
+            // Clear error state for every key that will be restored together.
+            if (keysToRecover.Count > 0)
+            {
+                foreach (var recoveryKey in keysToRecover)
+                {
+                    await _errorService.ClearErrorsForKeyAsync(
+                        recoveryKey.Id, recoveryKey.ProviderId);
+                }
+            }
+            else
+            {
+                await _errorService.ClearErrorsForKeyAsync(keyId, providerId);
+            }
+
+            // Re-enable the key or its nonzero shared-account group if requested.
+            if (request.ReenableKey && key != null)
+            {
+                foreach (var recoveryKey in keysToRecover.Where(candidate => !candidate.IsEnabled))
+                {
+                    recoveryKey.IsEnabled = true;
+                    await _keyRepo.UpdateAsync(recoveryKey);
+                }
+
                 _eventPublisher.PublishFireAndForget(new ProviderKeyReenabledEvent
                 {
                     KeyId = keyId,
                     ProviderId = key.ProviderId,
                     ReenabledBy = _httpContextAccessor.HttpContext?.User.Identity?.Name ?? "Admin",
                     Reason = request.Reason ?? "Manual re-enable after error resolution",
-                    ReenabledAt = DateTime.UtcNow
+                    ReenabledAt = DateTime.UtcNow,
+                    AffectedKeyIds = keysToRecover.Select(candidate => candidate.Id).ToArray(),
+                    ProviderAccountGroup = keysToRecover.Count > 1
+                        ? key.ProviderAccountGroup
+                        : (short)0
                 }, "ClearKeyErrors");
 
                 LogAdminAudit("ClearedErrorsAndReenabled", "ProviderKeyCredential", keyId,
-                    $"ProviderId: {key.ProviderId}");
+                    $"ProviderId: {key.ProviderId}, KeyIds: {string.Join(",", keysToRecover.Select(candidate => candidate.Id))}");
             }
             else
             {

--- a/Services/ConduitLLM.Admin/Endpoints/ProviderErrorsEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderErrorsEndpoints.cs
@@ -212,6 +212,12 @@ namespace ConduitLLM.Admin.Endpoints
             // Look up the key to get its providerId for proper cleanup
             var key = await _keyRepo.GetByIdAsync(keyId);
             int? providerId = key?.ProviderId;
+            var providerSummary = providerId.HasValue
+                ? await _errorService.GetProviderSummaryAsync(providerId.Value)
+                : null;
+            var providerWasAutoDisabled =
+                providerSummary?.ProviderDisabledAt != null &&
+                providerSummary.ProviderDisableReason == ProviderErrorTrackingService.AllKeysDisabledReason;
 
             // Clear errors from Redis (including provider disabled keys cleanup)
             await _errorService.ClearErrorsForKeyAsync(keyId, providerId);
@@ -238,6 +244,18 @@ namespace ConduitLLM.Admin.Endpoints
             else
             {
                 LogAdminAudit("ClearedErrors", "ProviderKeyCredential", keyId);
+            }
+
+            if (request.ReenableKey && providerWasAutoDisabled && providerId.HasValue)
+            {
+                var provider = await _providerRepo.GetByIdAsync(providerId.Value);
+                if (provider != null && !provider.IsEnabled)
+                {
+                    provider.IsEnabled = true;
+                    await _providerRepo.UpdateAsync(provider);
+                }
+
+                await _errorService.ClearProviderDisabledAsync(providerId.Value);
             }
 
             return Results.Ok(new ClearKeyErrorsResponseDto

--- a/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/RepositoryExtensions.cs
@@ -90,6 +90,8 @@ namespace ConduitLLM.Admin.Extensions
                 Id = notification.Id,
                 VirtualKeyId = notification.VirtualKeyId,
                 VirtualKeyName = virtualKeyName ?? notification.VirtualKey?.KeyName,
+                ProviderId = notification.ProviderId,
+                ProviderKeyCredentialId = notification.ProviderKeyCredentialId,
                 Type = notification.Type,
                 Severity = notification.Severity,
                 Message = notification.Message,

--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -30584,6 +30584,20 @@
               "string"
             ]
           },
+          "providerId": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "providerKeyCredentialId": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
           "type": {
             "$ref": "#/components/schemas/NotificationType"
           },
@@ -30613,7 +30627,9 @@
         "enum": [
           "budgetWarning",
           "expirationWarning",
-          "system"
+          "system",
+          "providerKeyDisabled",
+          "providerKeyReenabled"
         ]
       },
       "OperatorInfo": {

--- a/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyCredentialCacheInvalidationHandler.cs
+++ b/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyCredentialCacheInvalidationHandler.cs
@@ -16,7 +16,9 @@ namespace ConduitLLM.Gateway.EventHandlers
         IEventHandler<ProviderKeyCredentialCreated>,
         IEventHandler<ProviderKeyCredentialUpdated>,
         IEventHandler<ProviderKeyCredentialDeleted>,
-        IEventHandler<ProviderKeyCredentialPrimaryChanged>
+        IEventHandler<ProviderKeyCredentialPrimaryChanged>,
+        IEventHandler<ProviderKeyDisabledEvent>,
+        IEventHandler<ProviderKeyReenabledEvent>
     {
         private readonly IProviderCache _cache;
         private readonly ILogger<ProviderKeyCredentialCacheInvalidationHandler> _logger;
@@ -145,6 +147,44 @@ namespace ConduitLLM.Gateway.EventHandlers
                     "Failed to invalidate cache after changing primary key for provider {ProviderId}",
                     @event.ProviderId);
                 throw; // Re-throw to trigger the endpoint retry policy
+            }
+        }
+
+        /// <summary>
+        /// Handles automatic and manual key disables.
+        /// </summary>
+        public Task HandleAsync(ProviderKeyDisabledEvent @event, IEventContext context) =>
+            InvalidateKeyStatusAsync(@event.ProviderId, @event.KeyId, "disabled");
+
+        /// <summary>
+        /// Handles automatic and manual key re-enables.
+        /// </summary>
+        public Task HandleAsync(ProviderKeyReenabledEvent @event, IEventContext context) =>
+            InvalidateKeyStatusAsync(@event.ProviderId, @event.KeyId, "re-enabled");
+
+        private async Task InvalidateKeyStatusAsync(int providerId, int keyId, string status)
+        {
+            try
+            {
+                _logger.LogInformation(
+                    "Invalidating provider {ProviderId} cache because key {KeyId} was {Status}",
+                    providerId,
+                    keyId,
+                    status);
+
+                // The cache entry contains both provider enabled state and all key states,
+                // so this also covers provider-level changes when the last key is disabled.
+                await _cache.InvalidateProviderAsync(providerId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to invalidate provider {ProviderId} cache after key {KeyId} was {Status}",
+                    providerId,
+                    keyId,
+                    status);
+                throw;
             }
         }
     }

--- a/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyStatusNotificationHandler.cs
+++ b/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyStatusNotificationHandler.cs
@@ -47,8 +47,14 @@ public sealed class ProviderKeyStatusNotificationHandler :
         var providerError = ToSingleLine(
             string.IsNullOrWhiteSpace(@event.ErrorMessage) ? @event.Reason : @event.ErrorMessage,
             MaxProviderErrorLength);
+        var affectedKeyIds = @event.AffectedKeyIds.Count > 0
+            ? @event.AffectedKeyIds
+            : new[] { @event.KeyId };
+        var affectedDescription = @event.ProviderAccountGroup > 0
+            ? $"account group {@event.ProviderAccountGroup} keys [{string.Join(", ", affectedKeyIds)}]"
+            : $"key \"{keyName}\" (ID {@event.KeyId})";
         var message = Truncate(
-            $"Provider \"{providerName}\" key \"{keyName}\" (ID {@event.KeyId}) was {origin} disabled. " +
+            $"Provider \"{providerName}\" {affectedDescription} was {origin} disabled. " +
             $"Error type: {errorType}. Provider error: {providerError}",
             MaxNotificationLength);
 
@@ -69,8 +75,14 @@ public sealed class ProviderKeyStatusNotificationHandler :
         var (providerName, keyName, providerExists, keyExists) =
             await ResolveNamesAsync(@event.ProviderId, @event.KeyId);
         var reason = ToSingleLine(@event.Reason, MaxProviderErrorLength);
+        var affectedKeyIds = @event.AffectedKeyIds.Count > 0
+            ? @event.AffectedKeyIds
+            : new[] { @event.KeyId };
+        var affectedDescription = @event.ProviderAccountGroup > 0
+            ? $"account group {@event.ProviderAccountGroup} keys [{string.Join(", ", affectedKeyIds)}]"
+            : $"key \"{keyName}\" (ID {@event.KeyId})";
         var message = Truncate(
-            $"Provider \"{providerName}\" key \"{keyName}\" (ID {@event.KeyId}) was re-enabled " +
+            $"Provider \"{providerName}\" {affectedDescription} was re-enabled " +
             $"by {@event.ReenabledBy}. Reason: {reason}",
             MaxNotificationLength);
 

--- a/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyStatusNotificationHandler.cs
+++ b/Services/ConduitLLM.Gateway/EventHandlers/ProviderKeyStatusNotificationHandler.cs
@@ -1,0 +1,151 @@
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Interfaces;
+
+namespace ConduitLLM.Gateway.EventHandlers;
+
+/// <summary>
+/// Persists provider-key status notifications and broadcasts them to connected admins.
+/// </summary>
+public sealed class ProviderKeyStatusNotificationHandler :
+    IEventHandler<ProviderKeyDisabledEvent>,
+    IEventHandler<ProviderKeyReenabledEvent>
+{
+    private const int MaxNotificationLength = 500;
+    private const int MaxProviderErrorLength = 240;
+
+    private readonly IProviderRepository _providerRepository;
+    private readonly IProviderKeyCredentialRepository _keyRepository;
+    private readonly INotificationRepository _notificationRepository;
+    private readonly ISystemNotificationService _notificationService;
+    private readonly ILogger<ProviderKeyStatusNotificationHandler> _logger;
+
+    public ProviderKeyStatusNotificationHandler(
+        IProviderRepository providerRepository,
+        IProviderKeyCredentialRepository keyRepository,
+        INotificationRepository notificationRepository,
+        ISystemNotificationService notificationService,
+        ILogger<ProviderKeyStatusNotificationHandler> logger)
+    {
+        _providerRepository = providerRepository;
+        _keyRepository = keyRepository;
+        _notificationRepository = notificationRepository;
+        _notificationService = notificationService;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(ProviderKeyDisabledEvent @event, IEventContext context)
+    {
+        var (providerName, keyName, providerExists, keyExists) =
+            await ResolveNamesAsync(@event.ProviderId, @event.KeyId);
+        var origin = @event.IsAutomatic ? "automatically" : "manually";
+        var errorType = string.IsNullOrWhiteSpace(@event.ErrorType)
+            ? "Unknown"
+            : @event.ErrorType;
+        var providerError = ToSingleLine(
+            string.IsNullOrWhiteSpace(@event.ErrorMessage) ? @event.Reason : @event.ErrorMessage,
+            MaxProviderErrorLength);
+        var message = Truncate(
+            $"Provider \"{providerName}\" key \"{keyName}\" (ID {@event.KeyId}) was {origin} disabled. " +
+            $"Error type: {errorType}. Provider error: {providerError}",
+            MaxNotificationLength);
+
+        await PersistAsync(
+            NotificationType.ProviderKeyDisabled,
+            NotificationSeverity.Error,
+            message,
+            @event.ProviderId,
+            @event.KeyId,
+            providerExists,
+            keyExists,
+            context.CancellationToken);
+        await BroadcastBestEffortAsync(message, NotificationSeverity.Error);
+    }
+
+    public async Task HandleAsync(ProviderKeyReenabledEvent @event, IEventContext context)
+    {
+        var (providerName, keyName, providerExists, keyExists) =
+            await ResolveNamesAsync(@event.ProviderId, @event.KeyId);
+        var reason = ToSingleLine(@event.Reason, MaxProviderErrorLength);
+        var message = Truncate(
+            $"Provider \"{providerName}\" key \"{keyName}\" (ID {@event.KeyId}) was re-enabled " +
+            $"by {@event.ReenabledBy}. Reason: {reason}",
+            MaxNotificationLength);
+
+        await PersistAsync(
+            NotificationType.ProviderKeyReenabled,
+            NotificationSeverity.Info,
+            message,
+            @event.ProviderId,
+            @event.KeyId,
+            providerExists,
+            keyExists,
+            context.CancellationToken);
+        await BroadcastBestEffortAsync(message, NotificationSeverity.Info);
+    }
+
+    private async Task<(string ProviderName, string KeyName, bool ProviderExists, bool KeyExists)>
+        ResolveNamesAsync(int providerId, int keyId)
+    {
+        var providerTask = _providerRepository.GetByIdAsync(providerId);
+        var keyTask = _keyRepository.GetByIdAsync(keyId);
+        await Task.WhenAll(providerTask, keyTask);
+
+        var provider = await providerTask;
+        var key = await keyTask;
+
+        return (
+            provider?.ProviderName ?? $"Provider {providerId}",
+            key?.KeyName ?? $"Key {keyId}",
+            provider != null,
+            key != null);
+    }
+
+    private async Task PersistAsync(
+        NotificationType type,
+        NotificationSeverity severity,
+        string message,
+        int providerId,
+        int keyId,
+        bool providerExists,
+        bool keyExists,
+        CancellationToken cancellationToken)
+    {
+        await _notificationRepository.CreateAsync(new Notification
+        {
+            ProviderId = providerExists ? providerId : null,
+            ProviderKeyCredentialId = keyExists ? keyId : null,
+            Type = type,
+            Severity = severity,
+            Message = message,
+            IsRead = false
+        }, cancellationToken);
+    }
+
+    private async Task BroadcastBestEffortAsync(string message, NotificationSeverity severity)
+    {
+        try
+        {
+            await _notificationService.NotifySystemAnnouncement(message, severity);
+        }
+        catch (Exception ex)
+        {
+            // The durable notification has already been saved. Do not redeliver the
+            // transport message and create duplicates solely because a live client failed.
+            _logger.LogWarning(ex, "Failed to broadcast provider key status notification");
+        }
+    }
+
+    private static string ToSingleLine(string? value, int maxLength)
+    {
+        var singleLine = string.IsNullOrWhiteSpace(value)
+            ? "No provider error text was supplied."
+            : value.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return Truncate(singleLine, maxLength);
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..(maxLength - 1)] + "…";
+}

--- a/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
@@ -62,6 +62,8 @@ namespace ConduitLLM.Gateway.Extensions
             services.AddEventHandler<Configuration.Events.ProviderKeyCredentialUpdated, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
             services.AddEventHandler<Configuration.Events.ProviderKeyCredentialDeleted, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
             services.AddEventHandler<Configuration.Events.ProviderKeyCredentialPrimaryChanged, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
+            services.AddEventHandler<Configuration.Events.ProviderKeyDisabledEvent, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
+            services.AddEventHandler<Configuration.Events.ProviderKeyReenabledEvent, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
 
             return services;
         }

--- a/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
+++ b/Services/ConduitLLM.Gateway/Extensions/CacheInvalidationMessagingExtensions.cs
@@ -64,6 +64,8 @@ namespace ConduitLLM.Gateway.Extensions
             services.AddEventHandler<Configuration.Events.ProviderKeyCredentialPrimaryChanged, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
             services.AddEventHandler<Configuration.Events.ProviderKeyDisabledEvent, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
             services.AddEventHandler<Configuration.Events.ProviderKeyReenabledEvent, Gateway.EventHandlers.ProviderKeyCredentialCacheInvalidationHandler>();
+            services.AddEventHandler<Configuration.Events.ProviderKeyDisabledEvent, Gateway.EventHandlers.ProviderKeyStatusNotificationHandler>();
+            services.AddEventHandler<Configuration.Events.ProviderKeyReenabledEvent, Gateway.EventHandlers.ProviderKeyStatusNotificationHandler>();
 
             return services;
         }

--- a/Services/ConduitLLM.Gateway/Options/ProviderKeyReprobeOptions.cs
+++ b/Services/ConduitLLM.Gateway/Options/ProviderKeyReprobeOptions.cs
@@ -1,0 +1,27 @@
+namespace ConduitLLM.Gateway.Options;
+
+/// <summary>
+/// Controls half-open probes for keys disabled because their provider account lacked balance.
+/// </summary>
+public sealed class ProviderKeyReprobeOptions
+{
+    public const string SectionName = "ProviderKeyReprobe";
+
+    /// <summary>Whether automatic balance recovery probes are enabled.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>How often the worker scans Redis for eligible keys.</summary>
+    public TimeSpan ScanInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Cooldown before the first probe and base for exponential backoff.</summary>
+    public TimeSpan InitialCooldown { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>Maximum delay between failed probes.</summary>
+    public TimeSpan MaxCooldown { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>Distributed per-key lock duration for a single probe.</summary>
+    public TimeSpan ProbeLockTtl { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>Maximum keys probed during one scan.</summary>
+    public int BatchSize { get; set; } = 50;
+}

--- a/Services/ConduitLLM.Gateway/Program.CoreServices.cs
+++ b/Services/ConduitLLM.Gateway/Program.CoreServices.cs
@@ -7,6 +7,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Extensions;
 using ConduitLLM.Gateway.Endpoints;
+using ConduitLLM.Gateway.Options;
 using ConduitLLM.Gateway.Services;
 using ConduitLLM.Providers.Extensions;
 using Microsoft.Extensions.Caching.Distributed;
@@ -72,6 +73,9 @@ public partial class Program
         // Provider error tracking service
         builder.Services.AddSingleton<IRedisErrorStore, RedisErrorStore>();
         builder.Services.AddSingleton<IProviderErrorTrackingService, ProviderErrorTrackingService>();
+        builder.Services.Configure<ProviderKeyReprobeOptions>(
+            builder.Configuration.GetSection(ProviderKeyReprobeOptions.SectionName));
+        builder.Services.AddHostedService<ProviderKeyReprobeService>();
 
         // Add performance metrics service
         builder.Services.AddSingleton<IPerformanceMetricsService, PerformanceMetricsService>();

--- a/Services/ConduitLLM.Gateway/Services/ProviderKeyReprobeService.cs
+++ b/Services/ConduitLLM.Gateway/Services/ProviderKeyReprobeService.cs
@@ -1,0 +1,262 @@
+using System.Net;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+using ConduitLLM.Gateway.Options;
+using Microsoft.Extensions.Options;
+
+namespace ConduitLLM.Gateway.Services;
+
+/// <summary>
+/// Half-open recovery worker for provider keys disabled due to insufficient balance.
+/// </summary>
+public sealed class ProviderKeyReprobeService : BackgroundService
+{
+    private readonly IRedisErrorStore _errorStore;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ProviderKeyReprobeOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ProviderKeyReprobeService> _logger;
+
+    public ProviderKeyReprobeService(
+        IRedisErrorStore errorStore,
+        IServiceScopeFactory scopeFactory,
+        IOptions<ProviderKeyReprobeOptions> options,
+        ILogger<ProviderKeyReprobeService> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _errorStore = errorStore;
+        _scopeFactory = scopeFactory;
+        _options = options.Value;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Provider key balance reprobes are disabled");
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Provider key reprobe scan failed");
+            }
+
+            await Task.Delay(_options.ScanInterval, _timeProvider, stoppingToken);
+        }
+    }
+
+    /// <summary>
+    /// Executes one scan. Public for deterministic operational tests.
+    /// </summary>
+    public async Task RunOnceAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var states = await _errorStore.GetDisabledKeyReprobeStatesAsync();
+        var eligibleStates = states
+            .Where(state =>
+                state.ErrorType == ProviderErrorType.InsufficientBalance &&
+                GetNextEligibleAt(state) <= now)
+            .OrderBy(GetNextEligibleAt)
+            .Take(Math.Max(1, _options.BatchSize));
+
+        foreach (var state in eligibleStates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!await _errorStore.TryAcquireKeyReprobeAsync(
+                    state.KeyId, _options.ProbeLockTtl))
+            {
+                continue;
+            }
+
+            await ProbeKeyAsync(state, now, cancellationToken);
+        }
+    }
+
+    private DateTime GetNextEligibleAt(DisabledKeyReprobeState state) =>
+        state.NextAttemptAt ?? state.DisabledAt + _options.InitialCooldown;
+
+    private async Task ProbeKeyAsync(
+        DisabledKeyReprobeState state,
+        DateTime attemptedAt,
+        CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var keyRepository =
+            scope.ServiceProvider.GetRequiredService<IProviderKeyCredentialRepository>();
+        var providerRepository =
+            scope.ServiceProvider.GetRequiredService<IProviderRepository>();
+        var clientFactory = scope.ServiceProvider.GetRequiredService<ILLMClientFactory>();
+
+        var key = await keyRepository.GetByIdAsync(state.KeyId);
+        if (key == null)
+        {
+            await _errorStore.ClearErrorsForKeyAsync(state.KeyId);
+            return;
+        }
+
+        var provider = await providerRepository.GetByIdAsync(key.ProviderId);
+        if (provider == null)
+        {
+            await _errorStore.ClearErrorsForKeyAsync(state.KeyId);
+            return;
+        }
+
+        try
+        {
+            var client = clientFactory.CreateTestClient(provider, key);
+            await client.ListModelsAsync(cancellationToken: cancellationToken);
+            await ReenableAsync(
+                scope.ServiceProvider,
+                providerRepository,
+                keyRepository,
+                provider,
+                key,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var classification = ClassifyProbeFailure(ex);
+            if (classification == ProviderErrorType.InvalidApiKey)
+            {
+                await _errorStore.MarkKeyReprobeRequiresManualAsync(
+                    state.KeyId, ProviderErrorType.InvalidApiKey);
+                _logger.LogWarning(
+                    "Balance reprobe for key {KeyId} returned 401; manual credential repair is required",
+                    state.KeyId);
+                return;
+            }
+
+            var attemptCount = state.AttemptCount + 1;
+            var nextAttemptAt = attemptedAt + CalculateBackoff(attemptCount);
+            await _errorStore.RecordKeyReprobeAttemptAsync(
+                state.KeyId,
+                attemptCount,
+                attemptedAt,
+                nextAttemptAt);
+            _logger.LogInformation(
+                ex,
+                "Balance reprobe for key {KeyId} failed; next attempt at {NextAttemptAt}",
+                state.KeyId,
+                nextAttemptAt);
+        }
+    }
+
+    private async Task ReenableAsync(
+        IServiceProvider serviceProvider,
+        IProviderRepository providerRepository,
+        IProviderKeyCredentialRepository keyRepository,
+        Provider provider,
+        ProviderKeyCredential key,
+        CancellationToken cancellationToken)
+    {
+        var summary = await _errorStore.GetProviderSummaryAsync(provider.Id);
+        var providerWasAutoDisabled =
+            summary?.ProviderDisabledAt != null &&
+            summary.ProviderDisableReason == ProviderErrorTrackingService.AllKeysDisabledReason;
+
+        if (!key.IsEnabled)
+        {
+            key.IsEnabled = true;
+            await keyRepository.UpdateAsync(key, cancellationToken);
+        }
+
+        if (providerWasAutoDisabled && !provider.IsEnabled)
+        {
+            provider.IsEnabled = true;
+            await providerRepository.UpdateAsync(provider, cancellationToken);
+            await _errorStore.ClearProviderDisabledAsync(provider.Id);
+        }
+
+        await _errorStore.ClearErrorsForKeyAsync(key.Id, provider.Id);
+
+        var eventBus = serviceProvider.GetService<IEventBus>();
+        if (eventBus != null)
+        {
+            await eventBus.PublishAsync(new ProviderKeyReenabledEvent
+            {
+                KeyId = key.Id,
+                ProviderId = provider.Id,
+                ReenabledBy = "auto-reprobe",
+                Reason = "Provider balance or quota recovered",
+                ReenabledAt = _timeProvider.GetUtcNow().UtcDateTime
+            }, cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Automatically re-enabled provider key {KeyId} after a successful balance reprobe",
+            key.Id);
+    }
+
+    private TimeSpan CalculateBackoff(int attemptCount)
+    {
+        var multiplier = Math.Pow(2, Math.Min(attemptCount, 30));
+        var ticks = Math.Min(
+            _options.InitialCooldown.Ticks * multiplier,
+            _options.MaxCooldown.Ticks);
+        return TimeSpan.FromTicks((long)ticks);
+    }
+
+    internal static ProviderErrorType ClassifyProbeFailure(Exception exception)
+    {
+        var communicationException = FindCommunicationException(exception);
+        if (communicationException?.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            return ProviderErrorType.InvalidApiKey;
+        }
+
+        if (communicationException?.StatusCode == HttpStatusCode.PaymentRequired)
+        {
+            return ProviderErrorType.InsufficientBalance;
+        }
+
+        var details = $"{communicationException?.ResponseBody} {exception.Message}";
+        return details.Contains("balance", StringComparison.OrdinalIgnoreCase) ||
+               details.Contains("quota", StringComparison.OrdinalIgnoreCase) ||
+               details.Contains("payment required", StringComparison.OrdinalIgnoreCase)
+            ? ProviderErrorType.InsufficientBalance
+            : ProviderErrorType.Unknown;
+    }
+
+    private static LLMCommunicationException? FindCommunicationException(Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException!)
+        {
+            if (current is LLMCommunicationException communicationException)
+            {
+                return communicationException;
+            }
+
+            if (current.InnerException == null)
+            {
+                break;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Services/ConduitLLM.Gateway/Services/ProviderKeyReprobeService.cs
+++ b/Services/ConduitLLM.Gateway/Services/ProviderKeyReprobeService.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Events;
+using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Core.Exceptions;
@@ -179,10 +180,26 @@ public sealed class ProviderKeyReprobeService : BackgroundService
             summary?.ProviderDisabledAt != null &&
             summary.ProviderDisableReason == ProviderErrorTrackingService.AllKeysDisabledReason;
 
-        if (!key.IsEnabled)
+        var keysToRecover = new List<ProviderKeyCredential> { key };
+        if (key.ProviderAccountGroup > 0)
         {
-            key.IsEnabled = true;
-            await keyRepository.UpdateAsync(key, cancellationToken);
+            var reprobeStates = await _errorStore.GetDisabledKeyReprobeStatesAsync();
+            var balanceDisabledIds = reprobeStates
+                .Where(state => state.ErrorType == ProviderErrorType.InsufficientBalance)
+                .Select(state => state.KeyId)
+                .ToHashSet();
+            var allProviderKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                keyRepository.GetByProviderIdPaginatedAsync, provider.Id);
+            keysToRecover.AddRange(allProviderKeys.Where(candidate =>
+                candidate.Id != key.Id &&
+                candidate.ProviderAccountGroup == key.ProviderAccountGroup &&
+                balanceDisabledIds.Contains(candidate.Id)));
+        }
+
+        foreach (var recoveryKey in keysToRecover.Where(candidate => !candidate.IsEnabled))
+        {
+            recoveryKey.IsEnabled = true;
+            await keyRepository.UpdateAsync(recoveryKey, cancellationToken);
         }
 
         if (providerWasAutoDisabled && !provider.IsEnabled)
@@ -192,7 +209,10 @@ public sealed class ProviderKeyReprobeService : BackgroundService
             await _errorStore.ClearProviderDisabledAsync(provider.Id);
         }
 
-        await _errorStore.ClearErrorsForKeyAsync(key.Id, provider.Id);
+        foreach (var recoveryKey in keysToRecover)
+        {
+            await _errorStore.ClearErrorsForKeyAsync(recoveryKey.Id, provider.Id);
+        }
 
         var eventBus = serviceProvider.GetService<IEventBus>();
         if (eventBus != null)
@@ -203,7 +223,11 @@ public sealed class ProviderKeyReprobeService : BackgroundService
                 ProviderId = provider.Id,
                 ReenabledBy = "auto-reprobe",
                 Reason = "Provider balance or quota recovered",
-                ReenabledAt = _timeProvider.GetUtcNow().UtcDateTime
+                ReenabledAt = _timeProvider.GetUtcNow().UtcDateTime,
+                AffectedKeyIds = keysToRecover.Select(candidate => candidate.Id).ToArray(),
+                ProviderAccountGroup = keysToRecover.Count > 1
+                    ? key.ProviderAccountGroup
+                    : (short)0
             }, cancellationToken);
         }
 

--- a/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
+++ b/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
@@ -273,6 +273,9 @@ public static class CacheKeys
         /// <summary>Key for recent errors feed (global)</summary>
         public const string RecentFeed = "provider:errors:recent";
 
+        /// <summary>Set of disabled key IDs considered by the balance reprobe worker.</summary>
+        public const string DisabledKeys = "provider:errors:disabled_keys";
+
         /// <summary>Builds a key for fatal error data by credential key ID</summary>
         /// <param name="keyId">The provider key credential ID</param>
         /// <returns>Full key like "provider:errors:key:123:fatal"</returns>
@@ -284,6 +287,9 @@ public static class CacheKeys
 
         /// <summary>Builds the short-lived guard key for a credential disable operation.</summary>
         public static string DisableGuard(int keyId) => $"provider:errors:key:{keyId}:disabling";
+
+        /// <summary>Builds the distributed lock key for a balance reprobe.</summary>
+        public static string ReprobeGuard(int keyId) => $"provider:errors:key:{keyId}:reprobing";
 
         /// <summary>Builds a key for warning data by credential key ID</summary>
         /// <param name="keyId">The provider key credential ID</param>

--- a/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
+++ b/Shared/ConduitLLM.Configuration/Constants/CacheKeys.cs
@@ -278,6 +278,13 @@ public static class CacheKeys
         /// <returns>Full key like "provider:errors:key:123:fatal"</returns>
         public static string FatalByKey(int keyId) => $"provider:errors:key:{keyId}:fatal";
 
+        /// <summary>Builds a key for distinct fatal request IDs by key and error type.</summary>
+        public static string FatalRequestsByType(int keyId, string errorType) =>
+            $"provider:errors:key:{keyId}:fatal:{errorType.ToLowerInvariant()}:requests";
+
+        /// <summary>Builds the short-lived guard key for a credential disable operation.</summary>
+        public static string DisableGuard(int keyId) => $"provider:errors:key:{keyId}:disabling";
+
         /// <summary>Builds a key for warning data by credential key ID</summary>
         /// <param name="keyId">The provider key credential ID</param>
         /// <returns>Full key like "provider:errors:key:123:warnings"</returns>

--- a/Shared/ConduitLLM.Configuration/DTOs/NotificationDto.cs
+++ b/Shared/ConduitLLM.Configuration/DTOs/NotificationDto.cs
@@ -23,6 +23,16 @@ namespace ConduitLLM.Configuration.DTOs
         public string? VirtualKeyName { get; set; }
 
         /// <summary>
+        /// ID of the related provider, if applicable.
+        /// </summary>
+        public int? ProviderId { get; set; }
+
+        /// <summary>
+        /// ID of the related provider key credential, if applicable.
+        /// </summary>
+        public int? ProviderKeyCredentialId { get; set; }
+
+        /// <summary>
         /// Type of the notification
         /// </summary>
         public NotificationType Type { get; set; }

--- a/Shared/ConduitLLM.Configuration/Data/EntityConfigurationExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Data/EntityConfigurationExtensions.cs
@@ -95,6 +95,23 @@ namespace ConduitLLM.Configuration.Data
                 });
             });
 
+            // Provider-related notification references are nullable so notification history
+            // survives provider or key deletion (expand phase of the schema change).
+            modelBuilder.Entity<ConduitLLM.Configuration.Entities.Notification>(entity =>
+            {
+                entity.HasOne(e => e.Provider)
+                    .WithMany()
+                    .HasForeignKey(e => e.ProviderId)
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .IsRequired(false);
+
+                entity.HasOne(e => e.ProviderKeyCredential)
+                    .WithMany()
+                    .HasForeignKey(e => e.ProviderKeyCredentialId)
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .IsRequired(false);
+            });
+
 
             // Model entity configuration is now handled by ModelEntityConfiguration
             // via modelBuilder.ApplyModelConfigurations() in DbContext

--- a/Shared/ConduitLLM.Configuration/Entities/Notification.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/Notification.cs
@@ -23,7 +23,17 @@ namespace ConduitLLM.Configuration.Entities
         /// <summary>
         /// A system notification
         /// </summary>
-        System
+        System,
+
+        /// <summary>
+        /// A provider credential was disabled.
+        /// </summary>
+        ProviderKeyDisabled,
+
+        /// <summary>
+        /// A provider credential was re-enabled.
+        /// </summary>
+        ProviderKeyReenabled
     }
 
     /// <summary>
@@ -68,6 +78,28 @@ namespace ConduitLLM.Configuration.Entities
         /// </summary>
         [ForeignKey("VirtualKeyId")]
         public virtual VirtualKey? VirtualKey { get; set; }
+
+        /// <summary>
+        /// ID of the provider related to this notification, if applicable.
+        /// </summary>
+        public int? ProviderId { get; set; }
+
+        /// <summary>
+        /// Provider related to this notification.
+        /// </summary>
+        [ForeignKey(nameof(ProviderId))]
+        public virtual Provider? Provider { get; set; }
+
+        /// <summary>
+        /// ID of the provider key credential related to this notification, if applicable.
+        /// </summary>
+        public int? ProviderKeyCredentialId { get; set; }
+
+        /// <summary>
+        /// Provider key credential related to this notification.
+        /// </summary>
+        [ForeignKey(nameof(ProviderKeyCredentialId))]
+        public virtual ProviderKeyCredential? ProviderKeyCredential { get; set; }
 
         /// <summary>
         /// Type of the notification

--- a/Shared/ConduitLLM.Configuration/Entities/ProviderKeyCredential.cs
+++ b/Shared/ConduitLLM.Configuration/Entities/ProviderKeyCredential.cs
@@ -40,6 +40,7 @@ namespace ConduitLLM.Configuration.Entities
         /// Keys with the same ProviderAccountGroup share quota limits and billing.
         /// This is used for intelligent failover - if one account hits rate limits,
         /// the system can switch to keys from a different account group.
+        /// Group 0 means ungrouped: errors for one group-0 key never propagate to another.
         /// Note: This refers to external provider accounts, not Conduit user accounts.
         /// </summary>
         // Each key can be part of an account on that LLM Provider. This is not related to our own concept of accounts as this is solely for tracking the external account.

--- a/Shared/ConduitLLM.Configuration/Events/ProviderKeyEvents.cs
+++ b/Shared/ConduitLLM.Configuration/Events/ProviderKeyEvents.cs
@@ -26,6 +26,11 @@ namespace ConduitLLM.Configuration.Events
         /// Type of error that caused the disable
         /// </summary>
         public string ErrorType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Raw provider error text, truncated by consumers before display.
+        /// </summary>
+        public string ErrorMessage { get; set; } = string.Empty;
         
         /// <summary>
         /// When the key was disabled

--- a/Shared/ConduitLLM.Configuration/Events/ProviderKeyEvents.cs
+++ b/Shared/ConduitLLM.Configuration/Events/ProviderKeyEvents.cs
@@ -41,6 +41,16 @@ namespace ConduitLLM.Configuration.Events
         /// Whether this was an automatic disable
         /// </summary>
         public bool IsAutomatic { get; set; } = true;
+
+        /// <summary>
+        /// All key IDs affected by this operation. Contains KeyId for a single-key disable.
+        /// </summary>
+        public IReadOnlyList<int> AffectedKeyIds { get; set; } = Array.Empty<int>();
+
+        /// <summary>
+        /// Shared provider account group, or 0 for an ungrouped key.
+        /// </summary>
+        public short ProviderAccountGroup { get; set; }
     }
     
     /// <summary>
@@ -72,6 +82,16 @@ namespace ConduitLLM.Configuration.Events
         /// When the key was re-enabled
         /// </summary>
         public DateTime ReenabledAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// All key IDs restored by this operation.
+        /// </summary>
+        public IReadOnlyList<int> AffectedKeyIds { get; set; } = Array.Empty<int>();
+
+        /// <summary>
+        /// Shared provider account group, or 0 for an ungrouped key.
+        /// </summary>
+        public short ProviderAccountGroup { get; set; }
     }
     
     /// <summary>

--- a/Shared/ConduitLLM.Configuration/Migrations/20260724070639_AddProviderKeyNotifications.Designer.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260724070639_AddProviderKeyNotifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConduitLLM.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConduitLLM.Configuration.Migrations
 {
     [DbContext(typeof(ConduitDbContext))]
-    partial class ConduitDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724070639_AddProviderKeyNotifications")]
+    partial class AddProviderKeyNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Shared/ConduitLLM.Configuration/Migrations/20260724070639_AddProviderKeyNotifications.cs
+++ b/Shared/ConduitLLM.Configuration/Migrations/20260724070639_AddProviderKeyNotifications.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConduitLLM.Configuration.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProviderKeyNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ProviderId",
+                table: "Notifications",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProviderKeyCredentialId",
+                table: "Notifications",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_ProviderId",
+                table: "Notifications",
+                column: "ProviderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_ProviderKeyCredentialId",
+                table: "Notifications",
+                column: "ProviderKeyCredentialId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Notifications_ProviderKeyCredentials_ProviderKeyCredentialId",
+                table: "Notifications",
+                column: "ProviderKeyCredentialId",
+                principalTable: "ProviderKeyCredentials",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Notifications_Providers_ProviderId",
+                table: "Notifications",
+                column: "ProviderId",
+                principalTable: "Providers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Notifications_ProviderKeyCredentials_ProviderKeyCredentialId",
+                table: "Notifications");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Notifications_Providers_ProviderId",
+                table: "Notifications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Notifications_ProviderId",
+                table: "Notifications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Notifications_ProviderKeyCredentialId",
+                table: "Notifications");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderId",
+                table: "Notifications");
+
+            migrationBuilder.DropColumn(
+                name: "ProviderKeyCredentialId",
+                table: "Notifications");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
@@ -339,7 +339,9 @@ namespace ConduitLLM.Core.Decorators
                     ErrorMessage = ex.Message,
                     HttpStatusCode = (int?)ex.StatusCode,
                     RetryAttempt = 0, // Direct error, not from retry
-                    RequestId = null
+                    RequestId = _serviceProvider
+                        .GetService<Microsoft.AspNetCore.Http.IHttpContextAccessor>()
+                        ?.HttpContext?.TraceIdentifier
                 });
 
                 _logger?.LogInformation(

--- a/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
+++ b/Shared/ConduitLLM.Core/Decorators/ContextAwareLLMClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -323,7 +322,9 @@ namespace ConduitLLM.Core.Decorators
                     return;
                 }
 
-                var errorType = ClassifyError(ex.StatusCode);
+                var errorType = ProviderErrorClassifier.Classify(
+                    ex.StatusCode,
+                    $"{ex.ResponseBody} {ex.Message}");
                 
                 // Only track errors that are meaningful for provider health
                 if (errorType == ProviderErrorType.Unknown)
@@ -355,21 +356,5 @@ namespace ConduitLLM.Core.Decorators
             }
         }
 
-        private static ProviderErrorType ClassifyError(HttpStatusCode? statusCode)
-        {
-            return statusCode switch
-            {
-                HttpStatusCode.Unauthorized => ProviderErrorType.InvalidApiKey,
-                HttpStatusCode.PaymentRequired => ProviderErrorType.InsufficientBalance,
-                HttpStatusCode.Forbidden => ProviderErrorType.AccessForbidden,
-                HttpStatusCode.TooManyRequests => ProviderErrorType.RateLimitExceeded,
-                HttpStatusCode.NotFound => ProviderErrorType.ModelNotFound,
-                HttpStatusCode.ServiceUnavailable => ProviderErrorType.ServiceUnavailable,
-                HttpStatusCode.BadGateway => ProviderErrorType.ServiceUnavailable,
-                HttpStatusCode.GatewayTimeout => ProviderErrorType.Timeout,
-                HttpStatusCode.InternalServerError => ProviderErrorType.ServiceUnavailable,
-                _ => ProviderErrorType.Unknown
-            };
-        }
     }
 }

--- a/Shared/ConduitLLM.Core/Interfaces/IProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IProviderErrorTrackingService.cs
@@ -29,7 +29,15 @@ namespace ConduitLLM.Core.Interfaces
         /// </summary>
         /// <param name="keyId">ID of the key to disable</param>
         /// <param name="reason">Reason for disabling</param>
-        Task DisableKeyAsync(int keyId, string reason);
+        /// <param name="errorType">Classified provider error type, or Unknown for a manual disable</param>
+        /// <param name="isAutomatic">Whether policy automatically initiated the disable</param>
+        /// <param name="errorMessage">Raw provider error text for operator notification</param>
+        Task DisableKeyAsync(
+            int keyId,
+            string reason,
+            ProviderErrorType errorType = ProviderErrorType.Unknown,
+            bool isAutomatic = false,
+            string? errorMessage = null);
         
         /// <summary>
         /// Get recent errors for monitoring

--- a/Shared/ConduitLLM.Core/Interfaces/IProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IProviderErrorTrackingService.cs
@@ -57,6 +57,11 @@ namespace ConduitLLM.Core.Interfaces
         /// <param name="keyId">ID of the key to clear errors for</param>
         /// <param name="providerId">Optional provider ID to also clean up the provider's disabled keys tracking</param>
         Task ClearErrorsForKeyAsync(int keyId, int? providerId = null);
+
+        /// <summary>
+        /// Clear the marker recording that all keys automatically disabled a provider.
+        /// </summary>
+        Task ClearProviderDisabledAsync(int providerId);
         
         /// <summary>
         /// Get detailed error information for a specific key
@@ -128,6 +133,8 @@ namespace ConduitLLM.Core.Interfaces
         public int Warnings { get; set; }
         public List<int> DisabledKeyIds { get; set; } = new();
         public DateTime? LastError { get; set; }
+        public DateTime? ProviderDisabledAt { get; set; }
+        public string? ProviderDisableReason { get; set; }
     }
     
     /// <summary>

--- a/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
@@ -62,7 +62,37 @@ namespace ConduitLLM.Core.Interfaces
         /// </summary>
         /// <param name="keyId">The key credential ID</param>
         /// <param name="disabledAt">When the key was disabled</param>
-        Task MarkKeyDisabledAsync(int keyId, DateTime disabledAt);
+        /// <param name="errorType">Classified error responsible for the disable</param>
+        Task MarkKeyDisabledAsync(
+            int keyId,
+            DateTime disabledAt,
+            ProviderErrorType errorType);
+
+        /// <summary>
+        /// Get disabled-key state used by the balance reprobe worker.
+        /// </summary>
+        Task<IReadOnlyList<DisabledKeyReprobeState>> GetDisabledKeyReprobeStatesAsync();
+
+        /// <summary>
+        /// Acquire the distributed single-prober guard for a key.
+        /// </summary>
+        Task<bool> TryAcquireKeyReprobeAsync(int keyId, TimeSpan ttl);
+
+        /// <summary>
+        /// Record a failed reprobe and its next eligible time.
+        /// </summary>
+        Task RecordKeyReprobeAttemptAsync(
+            int keyId,
+            int attemptCount,
+            DateTime attemptedAt,
+            DateTime nextAttemptAt);
+
+        /// <summary>
+        /// Reclassify a reprobe as requiring manual credential repair.
+        /// </summary>
+        Task MarkKeyReprobeRequiresManualAsync(
+            int keyId,
+            ProviderErrorType errorType);
 
         /// <summary>
         /// Update provider disabled status
@@ -149,6 +179,19 @@ namespace ConduitLLM.Core.Interfaces
         public string? LastErrorMessage { get; set; }
         public int? LastStatusCode { get; set; }
         public DateTime? DisabledAt { get; set; }
+    }
+
+    /// <summary>
+    /// Redis-backed state for an automatically disabled key awaiting a balance reprobe.
+    /// </summary>
+    public class DisabledKeyReprobeState
+    {
+        public int KeyId { get; set; }
+        public ProviderErrorType ErrorType { get; set; }
+        public DateTime DisabledAt { get; set; }
+        public int AttemptCount { get; set; }
+        public DateTime? LastAttemptAt { get; set; }
+        public DateTime? NextAttemptAt { get; set; }
     }
 
     /// <summary>

--- a/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
@@ -60,6 +60,12 @@ namespace ConduitLLM.Core.Interfaces
         Task MarkProviderDisabledAsync(int providerId, DateTime disabledAt, string reason);
 
         /// <summary>
+        /// Clear the automatic provider-disabled marker after recovery.
+        /// </summary>
+        /// <param name="providerId">The provider ID</param>
+        Task ClearProviderDisabledAsync(int providerId);
+
+        /// <summary>
         /// Add a key to the provider's disabled keys set
         /// </summary>
         /// <param name="providerId">The provider ID</param>

--- a/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IRedisErrorStore.cs
@@ -45,6 +45,19 @@ namespace ConduitLLM.Core.Interfaces
         Task<FatalErrorData?> GetFatalErrorDataAsync(int keyId);
 
         /// <summary>
+        /// Count distinct request IDs for an error type within a rolling window.
+        /// </summary>
+        Task<long> GetDistinctFatalRequestCountAsync(
+            int keyId,
+            ProviderErrorType errorType,
+            TimeSpan window);
+
+        /// <summary>
+        /// Acquire the short-lived single-writer guard for disabling a key.
+        /// </summary>
+        Task<bool> TryAcquireKeyDisableAsync(int keyId, TimeSpan ttl);
+
+        /// <summary>
         /// Mark a key as disabled in Redis
         /// </summary>
         /// <param name="keyId">The key credential ID</param>

--- a/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
+++ b/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
@@ -95,6 +95,8 @@ namespace ConduitLLM.Core.Messaging
             typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialUpdated),
             typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialDeleted),
             typeof(ConduitLLM.Configuration.Events.ProviderKeyCredentialPrimaryChanged),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyDisabledEvent),
+            typeof(ConduitLLM.Configuration.Events.ProviderKeyReenabledEvent),
         };
 
         /// <summary>

--- a/Shared/ConduitLLM.Core/Models/ProviderErrorClassifier.cs
+++ b/Shared/ConduitLLM.Core/Models/ProviderErrorClassifier.cs
@@ -1,0 +1,56 @@
+using System.Net;
+
+namespace ConduitLLM.Core.Models;
+
+/// <summary>
+/// Provides the common status/body classification used by provider-key tracking
+/// and same-request failover.
+/// </summary>
+public static class ProviderErrorClassifier
+{
+    public static ProviderErrorType Classify(HttpStatusCode? statusCode, string? responseDetails = null)
+    {
+        var errorType = statusCode switch
+        {
+            HttpStatusCode.Unauthorized => ProviderErrorType.InvalidApiKey,
+            HttpStatusCode.PaymentRequired => ProviderErrorType.InsufficientBalance,
+            HttpStatusCode.Forbidden => ProviderErrorType.AccessForbidden,
+            HttpStatusCode.TooManyRequests => ProviderErrorType.RateLimitExceeded,
+            HttpStatusCode.NotFound => ProviderErrorType.ModelNotFound,
+            HttpStatusCode.ServiceUnavailable => ProviderErrorType.ServiceUnavailable,
+            HttpStatusCode.BadGateway => ProviderErrorType.ServiceUnavailable,
+            HttpStatusCode.GatewayTimeout => ProviderErrorType.Timeout,
+            HttpStatusCode.RequestTimeout => ProviderErrorType.Timeout,
+            HttpStatusCode.InternalServerError => ProviderErrorType.ServiceUnavailable,
+            _ => ProviderErrorType.Unknown
+        };
+
+        if (errorType == ProviderErrorType.AccessForbidden &&
+            IsBalanceResponse(responseDetails))
+        {
+            return ProviderErrorType.InsufficientBalance;
+        }
+
+        return errorType;
+    }
+
+    public static bool IsFatal(ProviderErrorType errorType)
+        => errorType is ProviderErrorType.InvalidApiKey
+            or ProviderErrorType.InsufficientBalance
+            or ProviderErrorType.AccessForbidden;
+
+    private static bool IsBalanceResponse(string? responseDetails)
+    {
+        if (string.IsNullOrWhiteSpace(responseDetails))
+        {
+            return false;
+        }
+
+        var details = responseDetails.ToLowerInvariant();
+        return details.Contains("insufficient_quota", StringComparison.Ordinal) ||
+               details.Contains("exceeded your current quota", StringComparison.Ordinal) ||
+               details.Contains("billing", StringComparison.Ordinal) ||
+               details.Contains("payment", StringComparison.Ordinal) ||
+               details.Contains("credit", StringComparison.Ordinal);
+    }
+}

--- a/Shared/ConduitLLM.Core/Models/ProviderErrorModels.cs
+++ b/Shared/ConduitLLM.Core/Models/ProviderErrorModels.cs
@@ -177,7 +177,9 @@ namespace ConduitLLM.Core.Models
         {
             [ProviderErrorType.InvalidApiKey] = new DisablePolicy
             {
-                DisableImmediately = true,
+                DisableImmediately = false,
+                RequiredOccurrences = 2,
+                TimeWindow = TimeSpan.FromSeconds(60),
                 RequiresManualReenable = true
             },
             

--- a/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
@@ -57,7 +57,10 @@ namespace ConduitLLM.Core.Services
                 if (error.IsFatal && await ShouldDisableKeyAsync(error.KeyCredentialId, error.ErrorType))
                 {
                     await DisableKeyAsync(error.KeyCredentialId, 
-                        $"Auto-disabled due to {error.ErrorType}: {error.ErrorMessage}");
+                        $"Auto-disabled due to {error.ErrorType}: {error.ErrorMessage}",
+                        error.ErrorType,
+                        isAutomatic: true,
+                        errorMessage: error.ErrorMessage);
                 }
                 
                 _logger.LogInformation(
@@ -111,7 +114,12 @@ namespace ConduitLLM.Core.Services
             return false;
         }
 
-        public async Task DisableKeyAsync(int keyId, string reason)
+        public async Task DisableKeyAsync(
+            int keyId,
+            string reason,
+            ProviderErrorType errorType = ProviderErrorType.Unknown,
+            bool isAutomatic = false,
+            string? errorMessage = null)
         {
             try
             {
@@ -182,7 +190,10 @@ namespace ConduitLLM.Core.Services
                         KeyId = keyId,
                         ProviderId = key.ProviderId,
                         Reason = reason,
-                        DisabledAt = disabledAt
+                        ErrorType = errorType.ToString(),
+                        ErrorMessage = errorMessage ?? reason,
+                        DisabledAt = disabledAt,
+                        IsAutomatic = isAutomatic
                     });
                 }
             }

--- a/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
@@ -18,6 +18,8 @@ namespace ConduitLLM.Core.Services
     /// </summary>
     public class ProviderErrorTrackingService : IProviderErrorTrackingService
     {
+        public const string AllKeysDisabledReason = "All provider keys disabled automatically";
+
         private readonly IRedisErrorStore _errorStore;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<ProviderErrorTrackingService> _logger;
@@ -125,82 +127,63 @@ namespace ConduitLLM.Core.Services
                     return;
                 }
 
-                // Check if this is a primary key
-                if (key.IsPrimary)
+                if (!key.IsEnabled)
                 {
-                    // For primary keys, disable the provider instead
+                    _logger.LogDebug("Key {KeyId} is already disabled", keyId);
+                    return;
+                }
+
+                var allKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                    keyRepo.GetByProviderIdPaginatedAsync, key.ProviderId);
+                var wasPrimary = key.IsPrimary;
+                var fallbackKey = allKeys.FirstOrDefault(k => k.Id != keyId && k.IsEnabled);
+                var disabledAt = DateTime.UtcNow;
+
+                // A primary key cannot remain primary while disabled because of the database
+                // constraint. Demote it before persisting; an enabled sibling is promoted below.
+                key.IsPrimary = false;
+                key.IsEnabled = false;
+                await keyRepo.UpdateAsync(key);
+
+                if (wasPrimary && fallbackKey != null)
+                {
+                    await keyRepo.SetPrimaryKeyAsync(key.ProviderId, fallbackKey.Id);
+                }
+
+                _logger.LogWarning("Disabled key {KeyId} for provider {ProviderId}: {Reason}",
+                    keyId, key.ProviderId, reason);
+
+                await _errorStore.MarkKeyDisabledAsync(keyId, disabledAt);
+                await _errorStore.AddDisabledKeyToProviderAsync(key.ProviderId, keyId);
+
+                // The provider itself is only disabled when this was its last enabled key.
+                if (fallbackKey == null)
+                {
                     var provider = await providerRepo.GetByIdAsync(key.ProviderId);
                     if (provider != null && provider.IsEnabled)
                     {
                         provider.IsEnabled = false;
                         await providerRepo.UpdateAsync(provider);
-                        
+
                         _logger.LogWarning(
-                            "Disabled provider {ProviderId} ({ProviderName}) due to primary key failure: {Reason}",
-                            provider.Id, provider.ProviderName, reason);
-                        
-                        // Update Redis to track provider disable
-                        await _errorStore.MarkProviderDisabledAsync(provider.Id, DateTime.UtcNow, reason);
-                        
-                        // Publish event for UI update (could create a ProviderDisabledEvent)
-                        var eventBus = scope.ServiceProvider.GetService<IEventBus>();
-                        if (eventBus != null)
-                        {
-                            // Still publish key disabled event so UI knows something happened
-                            await eventBus.PublishAsync(new ProviderKeyDisabledEvent
-                            {
-                                KeyId = keyId,
-                                ProviderId = key.ProviderId,
-                                Reason = $"Provider disabled: {reason}",
-                                DisabledAt = DateTime.UtcNow
-                            });
-                        }
+                            "Disabled provider {ProviderId} ({ProviderName}) - all keys are disabled",
+                            provider.Id, provider.ProviderName);
+
+                        await _errorStore.MarkProviderDisabledAsync(
+                            provider.Id, disabledAt, AllKeysDisabledReason);
                     }
                 }
-                else if (key.IsEnabled)
+
+                var eventBus = scope.ServiceProvider.GetService<IEventBus>();
+                if (eventBus != null)
                 {
-                    // For secondary keys, disable the key normally
-                    key.IsEnabled = false;
-                    await keyRepo.UpdateAsync(key);
-                    
-                    _logger.LogWarning("Disabled secondary key {KeyId} for provider {ProviderId}: {Reason}",
-                        keyId, key.ProviderId, reason);
-                    
-                    // Update Redis
-                    await _errorStore.MarkKeyDisabledAsync(keyId, DateTime.UtcNow);
-                    await _errorStore.AddDisabledKeyToProviderAsync(key.ProviderId, keyId);
-                    
-                    // Check if all keys are now disabled - if so, disable the provider
-                    var allKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
-                        keyRepo.GetByProviderIdPaginatedAsync, key.ProviderId);
-                    if (allKeys.All(k => !k.IsEnabled))
+                    await eventBus.PublishAsync(new ProviderKeyDisabledEvent
                     {
-                        var provider = await providerRepo.GetByIdAsync(key.ProviderId);
-                        if (provider != null && provider.IsEnabled)
-                        {
-                            provider.IsEnabled = false;
-                            await providerRepo.UpdateAsync(provider);
-                            
-                            _logger.LogWarning(
-                                "Disabled provider {ProviderId} ({ProviderName}) - all keys are disabled",
-                                provider.Id, provider.ProviderName);
-                            
-                            await _errorStore.MarkProviderDisabledAsync(provider.Id, DateTime.UtcNow, "All keys disabled");
-                        }
-                    }
-                    
-                    // Publish event for UI update
-                    var eventBus = scope.ServiceProvider.GetService<IEventBus>();
-                    if (eventBus != null)
-                    {
-                        await eventBus.PublishAsync(new ProviderKeyDisabledEvent
-                        {
-                            KeyId = keyId,
-                            ProviderId = key.ProviderId,
-                            Reason = reason,
-                            DisabledAt = DateTime.UtcNow
-                        });
-                    }
+                        KeyId = keyId,
+                        ProviderId = key.ProviderId,
+                        Reason = reason,
+                        DisabledAt = disabledAt
+                    });
                 }
             }
             catch (Exception ex)
@@ -268,6 +251,11 @@ namespace ConduitLLM.Core.Services
             await _errorStore.ClearErrorsForKeyAsync(keyId, providerId);
         }
 
+        public async Task ClearProviderDisabledAsync(int providerId)
+        {
+            await _errorStore.ClearProviderDisabledAsync(providerId);
+        }
+
         public async Task<KeyErrorDetails?> GetKeyErrorDetailsAsync(int keyId)
         {
             using var scope = _scopeFactory.CreateScope();
@@ -331,7 +319,9 @@ namespace ConduitLLM.Core.Services
                 FatalErrors = summaryData.FatalErrors,
                 Warnings = summaryData.Warnings,
                 DisabledKeyIds = summaryData.DisabledKeyIds,
-                LastError = summaryData.LastError
+                LastError = summaryData.LastError,
+                ProviderDisabledAt = summaryData.ProviderDisabledAt,
+                ProviderDisableReason = summaryData.ProviderDisableReason
             };
         }
 

--- a/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
@@ -166,7 +166,7 @@ namespace ConduitLLM.Core.Services
                 _logger.LogWarning("Disabled key {KeyId} for provider {ProviderId}: {Reason}",
                     keyId, key.ProviderId, reason);
 
-                await _errorStore.MarkKeyDisabledAsync(keyId, disabledAt);
+                await _errorStore.MarkKeyDisabledAsync(keyId, disabledAt, errorType);
                 await _errorStore.AddDisabledKeyToProviderAsync(key.ProviderId, keyId);
 
                 // The provider itself is only disabled when this was its last enabled key.

--- a/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Events;
 using ConduitLLM.Configuration.Extensions;
 using ConduitLLM.Configuration.Interfaces;
@@ -148,26 +149,55 @@ namespace ConduitLLM.Core.Services
 
                 var allKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
                     keyRepo.GetByProviderIdPaginatedAsync, key.ProviderId);
-                var wasPrimary = key.IsPrimary;
-                var fallbackKey = allKeys.FirstOrDefault(k => k.Id != keyId && k.IsEnabled);
-                var disabledAt = DateTime.UtcNow;
+                var propagateBalanceFailure =
+                    errorType == ProviderErrorType.InsufficientBalance &&
+                    key.ProviderAccountGroup > 0;
+                var affectedKeys = propagateBalanceFailure
+                    ? allKeys
+                        .Where(candidate =>
+                            candidate.IsEnabled &&
+                            candidate.ProviderAccountGroup == key.ProviderAccountGroup)
+                        .ToList()
+                    : new List<ProviderKeyCredential> { key };
+                if (affectedKeys.All(candidate => candidate.Id != keyId))
+                {
+                    affectedKeys.Add(key);
+                }
 
-                // A primary key cannot remain primary while disabled because of the database
-                // constraint. Demote it before persisting; an enabled sibling is promoted below.
-                key.IsPrimary = false;
-                key.IsEnabled = false;
-                await keyRepo.UpdateAsync(key);
+                var affectedKeyIds = affectedKeys.Select(candidate => candidate.Id).ToHashSet();
+                var wasPrimary = affectedKeys.Any(candidate => candidate.IsPrimary);
+                var fallbackKey = allKeys.FirstOrDefault(candidate =>
+                    candidate.IsEnabled && !affectedKeyIds.Contains(candidate.Id));
+                var disabledAt = DateTime.UtcNow;
+                var effectiveReason = propagateBalanceFailure
+                    ? $"Shared account group {key.ProviderAccountGroup} balance exhausted " +
+                      $"(triggered by key {keyId}): {reason}"
+                    : reason;
+
+                foreach (var affectedKey in affectedKeys)
+                {
+                    // A primary key cannot remain primary while disabled because of the
+                    // database constraint.
+                    affectedKey.IsPrimary = false;
+                    affectedKey.IsEnabled = false;
+                    await keyRepo.UpdateAsync(affectedKey);
+
+                    await _errorStore.MarkKeyDisabledAsync(
+                        affectedKey.Id, disabledAt, errorType);
+                    await _errorStore.AddDisabledKeyToProviderAsync(
+                        key.ProviderId, affectedKey.Id);
+                }
 
                 if (wasPrimary && fallbackKey != null)
                 {
                     await keyRepo.SetPrimaryKeyAsync(key.ProviderId, fallbackKey.Id);
                 }
 
-                _logger.LogWarning("Disabled key {KeyId} for provider {ProviderId}: {Reason}",
-                    keyId, key.ProviderId, reason);
-
-                await _errorStore.MarkKeyDisabledAsync(keyId, disabledAt, errorType);
-                await _errorStore.AddDisabledKeyToProviderAsync(key.ProviderId, keyId);
+                _logger.LogWarning(
+                    "Disabled provider keys {KeyIds} for provider {ProviderId}: {Reason}",
+                    string.Join(",", affectedKeyIds),
+                    key.ProviderId,
+                    effectiveReason);
 
                 // The provider itself is only disabled when this was its last enabled key.
                 if (fallbackKey == null)
@@ -194,11 +224,15 @@ namespace ConduitLLM.Core.Services
                     {
                         KeyId = keyId,
                         ProviderId = key.ProviderId,
-                        Reason = reason,
+                        Reason = effectiveReason,
                         ErrorType = errorType.ToString(),
                         ErrorMessage = errorMessage ?? reason,
                         DisabledAt = disabledAt,
-                        IsAutomatic = isAutomatic
+                        IsAutomatic = isAutomatic,
+                        AffectedKeyIds = affectedKeyIds.OrderBy(id => id).ToArray(),
+                        ProviderAccountGroup = propagateBalanceFailure
+                            ? key.ProviderAccountGroup
+                            : (short)0
                     });
                 }
             }

--- a/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
+++ b/Shared/ConduitLLM.Core/Services/ProviderErrorTrackingService.cs
@@ -19,6 +19,7 @@ namespace ConduitLLM.Core.Services
     public class ProviderErrorTrackingService : IProviderErrorTrackingService
     {
         public const string AllKeysDisabledReason = "All provider keys disabled automatically";
+        private static readonly TimeSpan DisableGuardTtl = TimeSpan.FromSeconds(30);
 
         private readonly IRedisErrorStore _errorStore;
         private readonly IServiceScopeFactory _scopeFactory;
@@ -92,25 +93,21 @@ namespace ConduitLLM.Core.Services
                 return true;
             }
             
-            // Check occurrence count within time window
-            var fatalData = await _errorStore.GetFatalErrorDataAsync(keyId);
-            
-            if (fatalData != null && 
-                fatalData.ErrorType == errorType.ToString() &&
-                fatalData.LastSeen.HasValue)
+            // Count distinct request IDs so retries within one request cannot disable a key.
+            var occurrenceCount = await _errorStore.GetDistinctFatalRequestCountAsync(
+                keyId, errorType, policy.TimeWindow);
+
+            if (occurrenceCount >= policy.RequiredOccurrences)
             {
-                var timeSinceLastError = DateTime.UtcNow - fatalData.LastSeen.Value;
-                
-                if (timeSinceLastError <= policy.TimeWindow && 
-                    fatalData.Count >= policy.RequiredOccurrences)
-                {
-                    _logger.LogWarning(
-                        "Key {KeyId} will be disabled: {Count} occurrences of {ErrorType} within {Window}",
-                        keyId, fatalData.Count, errorType, policy.TimeWindow);
-                    return true;
-                }
+                _logger.LogWarning(
+                    "Key {KeyId} will be disabled: {Count} distinct requests returned {ErrorType} within {Window}",
+                    keyId, occurrenceCount, errorType, policy.TimeWindow);
+                return true;
             }
-            
+
+            _logger.LogWarning(
+                "Key {KeyId} recorded {Count}/{RequiredCount} distinct {ErrorType} failures within {Window}; not disabling yet",
+                keyId, occurrenceCount, policy.RequiredOccurrences, errorType, policy.TimeWindow);
             return false;
         }
 
@@ -123,6 +120,14 @@ namespace ConduitLLM.Core.Services
         {
             try
             {
+                if (!await _errorStore.TryAcquireKeyDisableAsync(keyId, DisableGuardTtl))
+                {
+                    _logger.LogDebug(
+                        "Another request is already disabling key {KeyId}; skipping duplicate disable",
+                        keyId);
+                    return;
+                }
+
                 // Update database
                 using var scope = _scopeFactory.CreateScope();
                 var keyRepo = scope.ServiceProvider.GetRequiredService<IProviderKeyCredentialRepository>();

--- a/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
@@ -31,6 +31,12 @@ namespace ConduitLLM.Core.Services
         public async Task TrackFatalErrorAsync(int keyId, ProviderErrorInfo error)
         {
             var fatalKey = CacheKeys.ProviderError.FatalByKey(keyId);
+            var requestKey = CacheKeys.ProviderError.FatalRequestsByType(
+                keyId, error.ErrorType.ToString());
+            var requestId = string.IsNullOrWhiteSpace(error.RequestId)
+                ? $"{error.OccurredAt.Ticks}:{Guid.NewGuid():N}"
+                : error.RequestId;
+            var requestScore = new DateTimeOffset(error.OccurredAt).ToUnixTimeMilliseconds();
             
             var tasks = new List<Task>
             {
@@ -41,7 +47,8 @@ namespace ConduitLLM.Core.Services
                     new HashEntry("last_seen", error.OccurredAt.ToString("O")),
                     new HashEntry("last_error_message", error.ErrorMessage),
                     new HashEntry("last_status_code", error.HttpStatusCode ?? 0)
-                })
+                }),
+                _db.SortedSetAddAsync(requestKey, requestId, requestScore)
             };
             
             // Set first_seen only if it doesn't exist
@@ -51,7 +58,9 @@ namespace ConduitLLM.Core.Services
             await Task.WhenAll(tasks);
 
             // Set TTL of 30 days (same as warnings) to prevent unbounded growth
-            await _db.KeyExpireAsync(fatalKey, TimeSpan.FromDays(30));
+            await Task.WhenAll(
+                _db.KeyExpireAsync(fatalKey, TimeSpan.FromDays(30)),
+                _db.KeyExpireAsync(requestKey, TimeSpan.FromDays(30)));
         }
 
         public async Task TrackWarningAsync(int keyId, ProviderErrorInfo error)
@@ -141,6 +150,35 @@ namespace ConduitLLM.Core.Services
                 DisabledAt = dict.TryGetValue("disabled_at", out var disabledAt)
                     ? DateTime.Parse(disabledAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind) : null
             };
+        }
+
+        public async Task<long> GetDistinctFatalRequestCountAsync(
+            int keyId,
+            ProviderErrorType errorType,
+            TimeSpan window)
+        {
+            var requestKey = CacheKeys.ProviderError.FatalRequestsByType(
+                keyId, errorType.ToString());
+            var cutoff = new DateTimeOffset(DateTime.UtcNow - window).ToUnixTimeMilliseconds();
+
+            await _db.SortedSetRemoveRangeByScoreAsync(
+                requestKey,
+                double.NegativeInfinity,
+                cutoff - 1);
+
+            return await _db.SortedSetLengthAsync(
+                requestKey,
+                cutoff,
+                double.PositiveInfinity);
+        }
+
+        public Task<bool> TryAcquireKeyDisableAsync(int keyId, TimeSpan ttl)
+        {
+            return _db.StringSetAsync(
+                CacheKeys.ProviderError.DisableGuard(keyId),
+                "1",
+                ttl,
+                When.NotExists);
         }
 
         public async Task MarkKeyDisabledAsync(int keyId, DateTime disabledAt)
@@ -249,12 +287,18 @@ namespace ConduitLLM.Core.Services
 
         public async Task ClearErrorsForKeyAsync(int keyId, int? providerId = null)
         {
-            // Delete error keys
-            await _db.KeyDeleteAsync(new RedisKey[]
+            var keysToDelete = new List<RedisKey>
             {
                 CacheKeys.ProviderError.FatalByKey(keyId),
-                CacheKeys.ProviderError.WarningsByKey(keyId)
-            });
+                CacheKeys.ProviderError.WarningsByKey(keyId),
+                CacheKeys.ProviderError.DisableGuard(keyId)
+            };
+            keysToDelete.AddRange(ErrorThresholdConfiguration.FatalErrorPolicies.Keys.Select(
+                errorType => (RedisKey)CacheKeys.ProviderError.FatalRequestsByType(
+                    keyId, errorType.ToString())));
+
+            // Delete error keys
+            await _db.KeyDeleteAsync(keysToDelete.ToArray());
 
             // Remove from provider's disabled keys set if providerId is known
             if (providerId.HasValue)

--- a/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
@@ -158,6 +158,16 @@ namespace ConduitLLM.Core.Services
             );
         }
 
+        public async Task ClearProviderDisabledAsync(int providerId)
+        {
+            var summaryKey = CacheKeys.ProviderError.ProviderSummary(providerId);
+            await _db.HashDeleteAsync(summaryKey, new RedisValue[]
+            {
+                "provider_disabled_at",
+                "provider_disable_reason"
+            });
+        }
+
         public async Task AddDisabledKeyToProviderAsync(int providerId, int keyId)
         {
             var setKey = CacheKeys.ProviderError.DisabledKeysByProvider(providerId);

--- a/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
+++ b/Shared/ConduitLLM.Core/Services/RedisErrorStore.cs
@@ -181,10 +181,119 @@ namespace ConduitLLM.Core.Services
                 When.NotExists);
         }
 
-        public async Task MarkKeyDisabledAsync(int keyId, DateTime disabledAt)
+        public async Task MarkKeyDisabledAsync(
+            int keyId,
+            DateTime disabledAt,
+            ProviderErrorType errorType)
         {
             var fatalKey = CacheKeys.ProviderError.FatalByKey(keyId);
-            await _db.HashSetAsync(fatalKey, "disabled_at", disabledAt.ToString("O"));
+            await Task.WhenAll(
+                _db.HashSetAsync(fatalKey, new HashEntry[]
+                {
+                    new("disabled_at", disabledAt.ToString("O")),
+                    new("error_type", errorType.ToString()),
+                    new("reprobe_attempt_count", 0)
+                }),
+                _db.HashDeleteAsync(fatalKey, new RedisValue[]
+                {
+                    "last_reprobe_at",
+                    "next_reprobe_at"
+                }),
+                _db.SetAddAsync(CacheKeys.ProviderError.DisabledKeys, keyId));
+        }
+
+        public async Task<IReadOnlyList<DisabledKeyReprobeState>> GetDisabledKeyReprobeStatesAsync()
+        {
+            var members = await _db.SetMembersAsync(CacheKeys.ProviderError.DisabledKeys);
+            if (members.Length == 0)
+            {
+                return Array.Empty<DisabledKeyReprobeState>();
+            }
+
+            var stateTasks = members
+                .Where(member => member.HasValue)
+                .Select(async member =>
+                {
+                    var keyId = (int)member;
+                    var entries = await _db.HashGetAllAsync(
+                        CacheKeys.ProviderError.FatalByKey(keyId));
+                    if (entries.Length == 0)
+                    {
+                        await _db.SetRemoveAsync(CacheKeys.ProviderError.DisabledKeys, keyId);
+                        return null;
+                    }
+
+                    var values = entries.ToDictionary(
+                        entry => entry.Name.ToString(),
+                        entry => entry.Value.ToString());
+                    if (!Enum.TryParse<ProviderErrorType>(
+                            values.GetValueOrDefault("error_type"),
+                            out var errorType) ||
+                        !values.TryGetValue("disabled_at", out var disabledAtValue) ||
+                        !DateTime.TryParse(
+                            disabledAtValue,
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind,
+                            out var disabledAt))
+                    {
+                        return null;
+                    }
+
+                    return new DisabledKeyReprobeState
+                    {
+                        KeyId = keyId,
+                        ErrorType = errorType,
+                        DisabledAt = disabledAt,
+                        AttemptCount = int.TryParse(
+                            values.GetValueOrDefault("reprobe_attempt_count"),
+                            out var attempts) ? attempts : 0,
+                        LastAttemptAt = ParseOptionalDateTime(
+                            values.GetValueOrDefault("last_reprobe_at")),
+                        NextAttemptAt = ParseOptionalDateTime(
+                            values.GetValueOrDefault("next_reprobe_at"))
+                    };
+                })
+                .ToList();
+
+            var states = await Task.WhenAll(stateTasks);
+            return states.Where(state => state != null).Select(state => state!).ToList();
+        }
+
+        public Task<bool> TryAcquireKeyReprobeAsync(int keyId, TimeSpan ttl)
+        {
+            return _db.StringSetAsync(
+                CacheKeys.ProviderError.ReprobeGuard(keyId),
+                "1",
+                ttl,
+                When.NotExists);
+        }
+
+        public async Task RecordKeyReprobeAttemptAsync(
+            int keyId,
+            int attemptCount,
+            DateTime attemptedAt,
+            DateTime nextAttemptAt)
+        {
+            await _db.HashSetAsync(
+                CacheKeys.ProviderError.FatalByKey(keyId),
+                new HashEntry[]
+                {
+                    new("reprobe_attempt_count", attemptCount),
+                    new("last_reprobe_at", attemptedAt.ToString("O")),
+                    new("next_reprobe_at", nextAttemptAt.ToString("O"))
+                });
+        }
+
+        public async Task MarkKeyReprobeRequiresManualAsync(
+            int keyId,
+            ProviderErrorType errorType)
+        {
+            await Task.WhenAll(
+                _db.HashSetAsync(
+                    CacheKeys.ProviderError.FatalByKey(keyId),
+                    "error_type",
+                    errorType.ToString()),
+                _db.SetRemoveAsync(CacheKeys.ProviderError.DisabledKeys, keyId));
         }
 
         public async Task MarkProviderDisabledAsync(int providerId, DateTime disabledAt, string reason)
@@ -291,7 +400,8 @@ namespace ConduitLLM.Core.Services
             {
                 CacheKeys.ProviderError.FatalByKey(keyId),
                 CacheKeys.ProviderError.WarningsByKey(keyId),
-                CacheKeys.ProviderError.DisableGuard(keyId)
+                CacheKeys.ProviderError.DisableGuard(keyId),
+                CacheKeys.ProviderError.ReprobeGuard(keyId)
             };
             keysToDelete.AddRange(ErrorThresholdConfiguration.FatalErrorPolicies.Keys.Select(
                 errorType => (RedisKey)CacheKeys.ProviderError.FatalRequestsByType(
@@ -299,6 +409,7 @@ namespace ConduitLLM.Core.Services
 
             // Delete error keys
             await _db.KeyDeleteAsync(keysToDelete.ToArray());
+            await _db.SetRemoveAsync(CacheKeys.ProviderError.DisabledKeys, keyId);
 
             // Remove from provider's disabled keys set if providerId is known
             if (providerId.HasValue)
@@ -308,6 +419,13 @@ namespace ConduitLLM.Core.Services
 
             _logger.LogInformation("Cleared errors for key {KeyId}", keyId);
         }
+
+        private static DateTime? ParseOptionalDateTime(string? value) =>
+            DateTime.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var parsed) ? parsed : null;
 
         public async Task<KeyErrorData?> GetKeyErrorDataAsync(int keyId)
         {

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -120,8 +120,8 @@ namespace ConduitLLM.Providers
             {
                 var provider = await _credentialService.GetProviderByIdAsync(route.Mapping.ProviderId);
                 if (provider is null || !provider.IsEnabled) continue;
-                var credential = await ValidateProviderAndGetCredentialAsync(provider);
-                routes.Add((route.Mapping, CreateClientForProvider(provider, credential,
+                var credentials = await ValidateProviderAndGetCredentialsAsync(provider);
+                routes.Add((route.Mapping, CreateClientForProvider(provider, credentials,
                     route.Mapping.ProviderModelId, route.Mapping.ProviderOptions)));
             }
             if (routes.Count == 0)
@@ -188,8 +188,8 @@ namespace ConduitLLM.Providers
                 throw new ServiceUnavailableException($"Provider for model '{modelName}' is not available.", "Provider");
             }
 
-            var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
-            return CreateClientForProvider(provider, primaryKey, mapping.ProviderModelId, mapping.ProviderOptions);
+            var credentials = await ValidateProviderAndGetCredentialsAsync(provider);
+            return CreateClientForProvider(provider, credentials, mapping.ProviderModelId, mapping.ProviderOptions);
         }
 
         /// <inheritdoc />
@@ -210,8 +210,8 @@ namespace ConduitLLM.Providers
                 throw new InvalidRequestException($"Provider with ID '{providerId}' not found.", "provider_not_found", "providerId");
             }
 
-            var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
-            return CreateClientForProvider(provider, primaryKey, providerModelId);
+            var credentials = await ValidateProviderAndGetCredentialsAsync(provider);
+            return CreateClientForProvider(provider, credentials, providerModelId);
         }
 
         /// <inheritdoc />
@@ -236,8 +236,8 @@ namespace ConduitLLM.Providers
                 throw new InvalidRequestException($"No provider configured for type '{providerType}'.", "provider_type_not_found", "providerType");
             }
 
-            var primaryKey = await ValidateProviderAndGetCredentialAsync(provider);
-            return CreateClientForProvider(provider, primaryKey, "default-model-id");
+            var credentials = await ValidateProviderAndGetCredentialsAsync(provider);
+            return CreateClientForProvider(provider, credentials, "default-model-id");
         }
 
         /// <inheritdoc />
@@ -263,13 +263,13 @@ namespace ConduitLLM.Providers
             // Use a minimal model ID for testing - providers should accept this for auth verification
             const string testModelId = "test-model";
 
-            return CreateClientForProvider(provider, keyCredential, testModelId);
+            return CreateSingleClientForProvider(provider, keyCredential, testModelId);
         }
 
         /// <summary>
         /// Validates that a provider is enabled, then retrieves its primary key credential.
         /// </summary>
-        private async Task<ProviderKeyCredential> ValidateProviderAndGetCredentialAsync(Provider provider)
+        private async Task<IReadOnlyList<ProviderKeyCredential>> ValidateProviderAndGetCredentialsAsync(Provider provider)
         {
             if (!provider.IsEnabled)
             {
@@ -278,26 +278,66 @@ namespace ConduitLLM.Providers
                     $"Provider '{provider.ProviderName}' is currently disabled.", provider.ProviderName);
             }
 
-            return await GetPrimaryKeyCredentialAsync(provider);
+            return await GetEnabledKeyCredentialsAsync(provider);
         }
 
-        private async Task<ProviderKeyCredential> GetPrimaryKeyCredentialAsync(Provider provider)
+        private async Task<IReadOnlyList<ProviderKeyCredential>> GetEnabledKeyCredentialsAsync(Provider provider)
         {
             var keyCredentials = await _credentialService.GetKeyCredentialsByProviderIdAsync(provider.Id);
 
-            var primaryKey = keyCredentials.FirstOrDefault(k => k.IsPrimary && k.IsEnabled)
-                ?? keyCredentials.FirstOrDefault(k => k.IsEnabled);
+            var enabledKeys = keyCredentials
+                .Where(key => key.IsEnabled)
+                .OrderByDescending(key => key.IsPrimary)
+                .ThenBy(key => key.Id)
+                .ToArray();
 
-            if (primaryKey == null)
+            if (enabledKeys.Length == 0)
             {
                 _logger.LogWarning("No enabled API key found for provider {ProviderId}", provider.Id);
                 throw new ConfigurationException($"No API key configured for provider '{provider.ProviderName}'.");
             }
 
-            return primaryKey;
+            return enabledKeys;
         }
 
-        private ILLMClient CreateClientForProvider(Provider provider, ProviderKeyCredential keyCredential, string modelId, string? providerOptionsJson = null)
+        private ILLMClient CreateClientForProvider(
+            Provider provider,
+            IReadOnlyList<ProviderKeyCredential> keyCredentials,
+            string modelId,
+            string? providerOptionsJson = null)
+        {
+            var primaryClient = CreateSingleClientForProvider(
+                provider,
+                keyCredentials[0],
+                modelId,
+                providerOptionsJson);
+
+            if (keyCredentials.Count == 1)
+            {
+                return primaryClient;
+            }
+
+            var targets = keyCredentials
+                .Select((credential, index) => new ProviderKeyFailoverTarget(
+                    credential.Id,
+                    credential.ProviderAccountGroup,
+                    index == 0
+                        ? () => primaryClient
+                        : () => CreateSingleClientForProvider(
+                            provider,
+                            credential,
+                            modelId,
+                            providerOptionsJson)))
+                .ToArray();
+
+            return new ProviderKeyFailoverLLMClient(targets, _logger);
+        }
+
+        private ILLMClient CreateSingleClientForProvider(
+            Provider provider,
+            ProviderKeyCredential keyCredential,
+            string modelId,
+            string? providerOptionsJson = null)
         {
             var providerName = provider.ProviderType.ToString().ToLowerInvariant();
 

--- a/Shared/ConduitLLM.Providers/ProviderKeyFailoverLLMClient.cs
+++ b/Shared/ConduitLLM.Providers/ProviderKeyFailoverLLMClient.cs
@@ -1,0 +1,340 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers;
+
+/// <summary>
+/// Retries fatal provider failures against another enabled key for the same provider.
+/// Key-specific clients are expected to include <c>ContextAwareLLMClient</c>, so a
+/// failed attempt is tracked and disabled before the next target is invoked.
+/// </summary>
+internal sealed class ProviderKeyFailoverLLMClient :
+    ILLMClient,
+    ILLMClientDecorator,
+    IAuthenticationVerifiable
+{
+    private const int MaxAttempts = 3;
+
+    private readonly IReadOnlyList<ProviderKeyFailoverTarget> _targets;
+    private readonly ILogger? _logger;
+
+    public ProviderKeyFailoverLLMClient(
+        IReadOnlyList<ProviderKeyFailoverTarget> targets,
+        ILogger? logger = null)
+    {
+        if (targets is null || targets.Count == 0)
+        {
+            throw new ArgumentException("At least one provider key target is required.", nameof(targets));
+        }
+
+        _targets = targets;
+        _logger = logger;
+    }
+
+    public ILLMClient InnerClient => _targets[0].Client;
+
+    public Task<ChatCompletionResponse> CreateChatCompletionAsync(
+        ChatCompletionRequest request,
+        string? apiKey = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(
+            client => client.CreateChatCompletionAsync(request, apiKey, cancellationToken),
+            allowFailover: string.IsNullOrWhiteSpace(apiKey));
+
+    public async IAsyncEnumerable<ChatCompletionChunk> StreamChatCompletionAsync(
+        ChatCompletionRequest request,
+        string? apiKey = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ExceptionDispatchInfo? originalError = null;
+        var excludedGroups = new HashSet<int>();
+        var attemptCount = 0;
+
+        foreach (var target in _targets)
+        {
+            if (attemptCount >= MaxAttempts ||
+                (target.ProviderAccountGroup > 0 && excludedGroups.Contains(target.ProviderAccountGroup)))
+            {
+                continue;
+            }
+
+            attemptCount++;
+            var enumerator = target.Client
+                .StreamChatCompletionAsync(request, apiKey, cancellationToken)
+                .GetAsyncEnumerator(cancellationToken);
+
+            bool hasFirst;
+            try
+            {
+                hasFirst = await enumerator.MoveNextAsync();
+            }
+            catch (Exception exception)
+            {
+                await enumerator.DisposeAsync();
+                var fatalKind = ClassifyFatalError(exception);
+                if (!string.IsNullOrWhiteSpace(apiKey) || fatalKind == FatalErrorKind.None)
+                {
+                    throw;
+                }
+
+                originalError ??= ExceptionDispatchInfo.Capture(exception);
+                ExcludeAccountGroupIfNeeded(target, fatalKind, excludedGroups);
+                LogFailover(target, fatalKind, attemptCount);
+                continue;
+            }
+
+            if (!hasFirst)
+            {
+                await enumerator.DisposeAsync();
+                yield break;
+            }
+
+            try
+            {
+                // Once any chunk is visible to the caller, retrying could duplicate output.
+                yield return enumerator.Current;
+                while (await enumerator.MoveNextAsync())
+                {
+                    yield return enumerator.Current;
+                }
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
+
+            yield break;
+        }
+
+        ThrowOriginalOrNoEligibleTarget(originalError);
+    }
+
+    public Task<List<string>> ListModelsAsync(
+        string? apiKey = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(
+            client => client.ListModelsAsync(apiKey, cancellationToken),
+            allowFailover: string.IsNullOrWhiteSpace(apiKey));
+
+    public Task<EmbeddingResponse> CreateEmbeddingAsync(
+        EmbeddingRequest request,
+        string? apiKey = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(
+            client => client.CreateEmbeddingAsync(request, apiKey, cancellationToken),
+            allowFailover: string.IsNullOrWhiteSpace(apiKey));
+
+    public Task<ImageGenerationResponse> CreateImageAsync(
+        ImageGenerationRequest request,
+        string? apiKey = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(
+            client => client.CreateImageAsync(request, apiKey, cancellationToken),
+            allowFailover: string.IsNullOrWhiteSpace(apiKey));
+
+    public Task<VideoGenerationResponse> CreateVideoAsync(
+        VideoGenerationRequest request,
+        string? apiKey = null,
+        CancellationToken cancellationToken = default)
+        => ExecuteAsync(
+            client => InvokeVideoAsync(client, request, apiKey, cancellationToken),
+            allowFailover: string.IsNullOrWhiteSpace(apiKey));
+
+    public Task<ProviderCapabilities> GetCapabilitiesAsync(string? modelId = null)
+        => ExecuteAsync(client => client.GetCapabilitiesAsync(modelId), allowFailover: true);
+
+    public Task<AuthenticationResult> VerifyAuthenticationAsync(
+        string? apiKey = null,
+        string? baseUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (InnerClient is IAuthenticationVerifiable authenticationVerifiable)
+        {
+            return authenticationVerifiable.VerifyAuthenticationAsync(apiKey, baseUrl, cancellationToken);
+        }
+
+        return Task.FromResult(AuthenticationResult.Failure(
+            "Provider does not support authentication verification",
+            $"The {InnerClient.GetType().Name} client has not implemented authentication verification"));
+    }
+
+    public string GetHealthCheckUrl(string? baseUrl = null)
+    {
+        return InnerClient is IAuthenticationVerifiable authenticationVerifiable
+            ? authenticationVerifiable.GetHealthCheckUrl(baseUrl)
+            : baseUrl ?? "https://api.provider.com/health";
+    }
+
+    private async Task<T> ExecuteAsync<T>(
+        Func<ILLMClient, Task<T>> operation,
+        bool allowFailover)
+    {
+        ExceptionDispatchInfo? originalError = null;
+        var excludedGroups = new HashSet<int>();
+        var attemptCount = 0;
+
+        foreach (var target in _targets)
+        {
+            if (attemptCount >= MaxAttempts ||
+                (target.ProviderAccountGroup > 0 && excludedGroups.Contains(target.ProviderAccountGroup)))
+            {
+                continue;
+            }
+
+            attemptCount++;
+            try
+            {
+                return await operation(target.Client);
+            }
+            catch (Exception exception)
+            {
+                var fatalKind = ClassifyFatalError(exception);
+                if (!allowFailover || fatalKind == FatalErrorKind.None)
+                {
+                    throw;
+                }
+
+                originalError ??= ExceptionDispatchInfo.Capture(exception);
+                ExcludeAccountGroupIfNeeded(target, fatalKind, excludedGroups);
+                LogFailover(target, fatalKind, attemptCount);
+            }
+        }
+
+        ThrowOriginalOrNoEligibleTarget(originalError);
+        throw new InvalidOperationException("Unreachable.");
+    }
+
+    private void LogFailover(
+        ProviderKeyFailoverTarget target,
+        FatalErrorKind fatalKind,
+        int attemptCount)
+    {
+        _logger?.LogWarning(
+            "Provider key {KeyId} failed with {FatalErrorKind}; trying another key after attempt {Attempt}/{MaxAttempts}",
+            target.KeyId,
+            fatalKind,
+            attemptCount,
+            MaxAttempts);
+    }
+
+    private static void ExcludeAccountGroupIfNeeded(
+        ProviderKeyFailoverTarget target,
+        FatalErrorKind fatalKind,
+        ISet<int> excludedGroups)
+    {
+        if (fatalKind == FatalErrorKind.InsufficientBalance &&
+            target.ProviderAccountGroup > 0)
+        {
+            excludedGroups.Add(target.ProviderAccountGroup);
+        }
+    }
+
+    private static FatalErrorKind ClassifyFatalError(Exception exception)
+    {
+        var communicationException = ExtractCommunicationException(exception);
+        if (communicationException is null)
+        {
+            return FatalErrorKind.None;
+        }
+
+        var errorType = ProviderErrorClassifier.Classify(
+            communicationException.StatusCode,
+            $"{communicationException.ResponseBody} {communicationException.Message}");
+
+        return errorType switch
+        {
+            ProviderErrorType.InvalidApiKey => FatalErrorKind.Credential,
+            ProviderErrorType.InsufficientBalance => FatalErrorKind.InsufficientBalance,
+            ProviderErrorType.AccessForbidden => FatalErrorKind.Credential,
+            _ => FatalErrorKind.None
+        };
+    }
+
+    private static LLMCommunicationException? ExtractCommunicationException(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is LLMCommunicationException communicationException)
+            {
+                return communicationException;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<VideoGenerationResponse> InvokeVideoAsync(
+        ILLMClient client,
+        VideoGenerationRequest request,
+        string? apiKey,
+        CancellationToken cancellationToken)
+    {
+        object target = client.UnwrapInnermost();
+        System.Reflection.MethodInfo? method = null;
+        for (ILLMClient? current = client; current is not null;
+             current = (current as ILLMClientDecorator)?.InnerClient)
+        {
+            method = current.GetType().GetMethod(
+                nameof(CreateVideoAsync),
+                new[] { typeof(VideoGenerationRequest), typeof(string), typeof(CancellationToken) });
+            if (method is not null)
+            {
+                target = current;
+                break;
+            }
+        }
+
+        if (method?.Invoke(target, new object?[] { request, apiKey, cancellationToken })
+            is not Task<VideoGenerationResponse> task)
+        {
+            throw new NotSupportedException(
+                $"The underlying client {target.GetType().Name} does not support video generation");
+        }
+
+        return await task;
+    }
+
+    private static void ThrowOriginalOrNoEligibleTarget(ExceptionDispatchInfo? originalError)
+    {
+        if (originalError is not null)
+        {
+            originalError.Throw();
+        }
+
+        throw new InvalidOperationException("No eligible provider key was available for failover.");
+    }
+
+    private enum FatalErrorKind
+    {
+        None,
+        Credential,
+        InsufficientBalance
+    }
+}
+
+internal sealed class ProviderKeyFailoverTarget
+{
+    private readonly Lazy<ILLMClient> _client;
+
+    public ProviderKeyFailoverTarget(
+        int keyId,
+        int providerAccountGroup,
+        Func<ILLMClient> clientFactory)
+    {
+        KeyId = keyId;
+        ProviderAccountGroup = providerAccountGroup;
+        _client = new Lazy<ILLMClient>(
+            clientFactory ?? throw new ArgumentNullException(nameof(clientFactory)),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public int KeyId { get; }
+    public int ProviderAccountGroup { get; }
+    public ILLMClient Client => _client.Value;
+}

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderErrorsEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderErrorsEndpointsTests.cs
@@ -1,8 +1,10 @@
 using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Events;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -119,4 +121,82 @@ public class ProviderErrorsEndpointsTests
             x => x.ClearProviderDisabledAsync(It.IsAny<int>()),
             Times.Never);
     }
+
+    [Fact]
+    public async Task ClearKeyErrors_BalanceGroup_ReenablesEveryGroupDisabledKey()
+    {
+        const int providerId = 22;
+        var requestedKey = new ProviderKeyCredential
+        {
+            Id = 11,
+            ProviderId = providerId,
+            ProviderAccountGroup = 3,
+            IsEnabled = false
+        };
+        var sharedAccountKey = new ProviderKeyCredential
+        {
+            Id = 12,
+            ProviderId = providerId,
+            ProviderAccountGroup = 3,
+            IsEnabled = false
+        };
+        var unrelatedKey = new ProviderKeyCredential
+        {
+            Id = 13,
+            ProviderId = providerId,
+            ProviderAccountGroup = 4,
+            IsEnabled = false
+        };
+        var providerKeys = new List<ProviderKeyCredential>
+        {
+            requestedKey,
+            sharedAccountKey,
+            unrelatedKey
+        };
+
+        _keyRepository.Setup(x => x.GetByIdAsync(requestedKey.Id))
+            .ReturnsAsync(requestedKey);
+        _keyRepository.Setup(x => x.GetByProviderIdPaginatedAsync(
+                providerId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((providerKeys, providerKeys.Count));
+        _errorService.Setup(x => x.GetKeyErrorDetailsAsync(requestedKey.Id))
+            .ReturnsAsync(BalanceErrorDetails(requestedKey.Id));
+        _errorService.Setup(x => x.GetKeyErrorDetailsAsync(sharedAccountKey.Id))
+            .ReturnsAsync(BalanceErrorDetails(sharedAccountKey.Id));
+
+        await _endpoints.ClearKeyErrors(requestedKey.Id, new ClearErrorsRequest
+        {
+            ReenableKey = true,
+            ConfirmReenable = true
+        });
+
+        _keyRepository.Verify(x => x.UpdateAsync(
+            It.Is<ProviderKeyCredential>(key =>
+                (key.Id == requestedKey.Id || key.Id == sharedAccountKey.Id) &&
+                key.IsEnabled),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _keyRepository.Verify(x => x.UpdateAsync(
+            It.Is<ProviderKeyCredential>(key => key.Id == unrelatedKey.Id),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _errorService.Verify(x => x.ClearErrorsForKeyAsync(
+            requestedKey.Id, providerId), Times.Once);
+        _errorService.Verify(x => x.ClearErrorsForKeyAsync(
+            sharedAccountKey.Id, providerId), Times.Once);
+        _eventPublisher.Verify(x => x.PublishFireAndForget(
+            It.Is<ProviderKeyReenabledEvent>(message =>
+                message.ProviderAccountGroup == 3 &&
+                message.AffectedKeyIds.OrderBy(id => id)
+                    .SequenceEqual(new[] { 11, 12 })),
+            "ClearKeyErrors",
+            It.IsAny<object?>()), Times.Once);
+    }
+
+    private static KeyErrorDetails BalanceErrorDetails(int keyId) => new()
+    {
+        KeyId = keyId,
+        FatalError = new FatalErrorInfo
+        {
+            ErrorType = ProviderErrorType.InsufficientBalance
+        }
+    };
 }

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderErrorsEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderErrorsEndpointsTests.cs
@@ -1,0 +1,122 @@
+using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Admin.Endpoints;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ConduitLLM.Tests.Admin.Endpoints;
+
+public class ProviderErrorsEndpointsTests
+{
+    private readonly Mock<IProviderErrorTrackingService> _errorService = new();
+    private readonly Mock<IProviderKeyCredentialRepository> _keyRepository = new();
+    private readonly Mock<IProviderRepository> _providerRepository = new();
+    private readonly Mock<IEventPublisher> _eventPublisher = new();
+    private readonly ProviderErrorsEndpoints _endpoints;
+
+    public ProviderErrorsEndpointsTests()
+    {
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        _endpoints = new ProviderErrorsEndpoints(
+            _errorService.Object,
+            _keyRepository.Object,
+            _providerRepository.Object,
+            _eventPublisher.Object,
+            httpContextAccessor,
+            Mock.Of<ILogger<ProviderErrorsEndpoints>>());
+    }
+
+    [Fact]
+    public async Task ClearKeyErrors_ReenablesProviderWhenAllKeysAutoDisabledIt()
+    {
+        const int keyId = 11;
+        const int providerId = 22;
+        var key = new ProviderKeyCredential
+        {
+            Id = keyId,
+            ProviderId = providerId,
+            IsEnabled = false
+        };
+        var provider = new Provider
+        {
+            Id = providerId,
+            IsEnabled = false
+        };
+
+        _keyRepository.Setup(x => x.GetByIdAsync(keyId)).ReturnsAsync(key);
+        _providerRepository
+            .Setup(x => x.GetByIdAsync(providerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(provider);
+        _errorService
+            .Setup(x => x.GetProviderSummaryAsync(providerId))
+            .ReturnsAsync(new ProviderErrorSummary
+            {
+                ProviderId = providerId,
+                ProviderDisabledAt = DateTime.UtcNow,
+                ProviderDisableReason = ProviderErrorTrackingService.AllKeysDisabledReason
+            });
+
+        await _endpoints.ClearKeyErrors(keyId, new ClearErrorsRequest
+        {
+            ReenableKey = true,
+            ConfirmReenable = true
+        });
+
+        _keyRepository.Verify(
+            x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(candidate => candidate.Id == keyId && candidate.IsEnabled),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _providerRepository.Verify(
+            x => x.UpdateAsync(
+                It.Is<Provider>(candidate => candidate.Id == providerId && candidate.IsEnabled),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _errorService.Verify(x => x.ClearProviderDisabledAsync(providerId), Times.Once);
+    }
+
+    [Fact]
+    public async Task ClearKeyErrors_DoesNotOverrideManualProviderDisable()
+    {
+        const int keyId = 11;
+        const int providerId = 22;
+        var key = new ProviderKeyCredential
+        {
+            Id = keyId,
+            ProviderId = providerId,
+            IsEnabled = false
+        };
+
+        _keyRepository.Setup(x => x.GetByIdAsync(keyId)).ReturnsAsync(key);
+        _errorService
+            .Setup(x => x.GetProviderSummaryAsync(providerId))
+            .ReturnsAsync(new ProviderErrorSummary
+            {
+                ProviderId = providerId,
+                ProviderDisabledAt = null,
+                ProviderDisableReason = null
+            });
+
+        await _endpoints.ClearKeyErrors(keyId, new ClearErrorsRequest
+        {
+            ReenableKey = true,
+            ConfirmReenable = true
+        });
+
+        _providerRepository.Verify(
+            x => x.UpdateAsync(It.IsAny<Provider>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _errorService.Verify(
+            x => x.ClearProviderDisabledAsync(It.IsAny<int>()),
+            Times.Never);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/EventHandlers/ProviderKeyCredentialCacheInvalidationHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/EventHandlers/ProviderKeyCredentialCacheInvalidationHandlerTests.cs
@@ -1,0 +1,65 @@
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Gateway.EventHandlers;
+using ConduitLLM.Tests.Messaging;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ConduitLLM.Tests.Gateway.EventHandlers;
+
+public class ProviderKeyCredentialCacheInvalidationHandlerTests
+{
+    private readonly Mock<IProviderCache> _cache = new();
+    private readonly ProviderKeyCredentialCacheInvalidationHandler _handler;
+
+    public ProviderKeyCredentialCacheInvalidationHandlerTests()
+    {
+        _handler = new ProviderKeyCredentialCacheInvalidationHandler(
+            _cache.Object,
+            Mock.Of<ILogger<ProviderKeyCredentialCacheInvalidationHandler>>());
+    }
+
+    [Fact]
+    public async Task DisabledEvent_InvalidatesProviderCredentialCache()
+    {
+        const int providerId = 42;
+
+        await _handler.HandleAsync(new ProviderKeyDisabledEvent
+        {
+            KeyId = 7,
+            ProviderId = providerId
+        }, new TestEventContext());
+
+        _cache.Verify(x => x.InvalidateProviderAsync(providerId), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReenabledEvent_InvalidatesProviderCredentialCache()
+    {
+        const int providerId = 42;
+
+        await _handler.HandleAsync(new ProviderKeyReenabledEvent
+        {
+            KeyId = 7,
+            ProviderId = providerId
+        }, new TestEventContext());
+
+        _cache.Verify(x => x.InvalidateProviderAsync(providerId), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisabledEvent_PropagatesCacheFailureForTransportRetry()
+    {
+        _cache
+            .Setup(x => x.InvalidateProviderAsync(42))
+            .ThrowsAsync(new InvalidOperationException("cache unavailable"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _handler.HandleAsync(new ProviderKeyDisabledEvent
+            {
+                KeyId = 7,
+                ProviderId = 42
+            }, new TestEventContext()));
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/EventHandlers/ProviderKeyStatusNotificationHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/EventHandlers/ProviderKeyStatusNotificationHandlerTests.cs
@@ -1,0 +1,111 @@
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Gateway.EventHandlers;
+using ConduitLLM.Tests.Messaging;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ConduitLLM.Tests.Gateway.EventHandlers;
+
+public class ProviderKeyStatusNotificationHandlerTests
+{
+    private readonly Mock<IProviderRepository> _providerRepository = new();
+    private readonly Mock<IProviderKeyCredentialRepository> _keyRepository = new();
+    private readonly Mock<INotificationRepository> _notificationRepository = new();
+    private readonly Mock<ISystemNotificationService> _notificationService = new();
+    private readonly ProviderKeyStatusNotificationHandler _handler;
+
+    public ProviderKeyStatusNotificationHandlerTests()
+    {
+        _providerRepository
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Provider { Id = 42, ProviderName = "OpenAI" });
+        _keyRepository
+            .Setup(x => x.GetByIdAsync(7))
+            .ReturnsAsync(new ProviderKeyCredential { Id = 7, ProviderId = 42, KeyName = "Primary" });
+
+        _handler = new ProviderKeyStatusNotificationHandler(
+            _providerRepository.Object,
+            _keyRepository.Object,
+            _notificationRepository.Object,
+            _notificationService.Object,
+            Mock.Of<ILogger<ProviderKeyStatusNotificationHandler>>());
+    }
+
+    [Fact]
+    public async Task DisabledEvent_PersistsActionableNotificationAndBroadcasts()
+    {
+        await _handler.HandleAsync(new ProviderKeyDisabledEvent
+        {
+            ProviderId = 42,
+            KeyId = 7,
+            ErrorType = "InvalidApiKey",
+            ErrorMessage = "401 invalid credential",
+            IsAutomatic = true
+        }, new TestEventContext());
+
+        _notificationRepository.Verify(x => x.CreateAsync(
+            It.Is<Notification>(notification =>
+                notification.Type == NotificationType.ProviderKeyDisabled &&
+                notification.Severity == NotificationSeverity.Error &&
+                notification.ProviderId == 42 &&
+                notification.ProviderKeyCredentialId == 7 &&
+                notification.Message.Contains("OpenAI") &&
+                notification.Message.Contains("Primary") &&
+                notification.Message.Contains("InvalidApiKey") &&
+                notification.Message.Contains("401 invalid credential") &&
+                notification.Message.Contains("automatically")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _notificationService.Verify(x => x.NotifySystemAnnouncement(
+            It.Is<string>(message => message.Contains("InvalidApiKey")),
+            NotificationSeverity.Error), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReenabledEvent_PersistsAndBroadcastsRecoveryNotification()
+    {
+        await _handler.HandleAsync(new ProviderKeyReenabledEvent
+        {
+            ProviderId = 42,
+            KeyId = 7,
+            ReenabledBy = "admin@example.com",
+            Reason = "Credential rotated"
+        }, new TestEventContext());
+
+        _notificationRepository.Verify(x => x.CreateAsync(
+            It.Is<Notification>(notification =>
+                notification.Type == NotificationType.ProviderKeyReenabled &&
+                notification.Severity == NotificationSeverity.Info &&
+                notification.ProviderId == 42 &&
+                notification.ProviderKeyCredentialId == 7 &&
+                notification.Message.Contains("admin@example.com") &&
+                notification.Message.Contains("Credential rotated")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _notificationService.Verify(x => x.NotifySystemAnnouncement(
+            It.IsAny<string>(),
+            NotificationSeverity.Info), Times.Once);
+    }
+
+    [Fact]
+    public async Task LiveBroadcastFailure_DoesNotFailAfterDurablePersistence()
+    {
+        _notificationService
+            .Setup(x => x.NotifySystemAnnouncement(It.IsAny<string>(), It.IsAny<object>()))
+            .ThrowsAsync(new InvalidOperationException("no live connections"));
+
+        await _handler.HandleAsync(new ProviderKeyDisabledEvent
+        {
+            ProviderId = 42,
+            KeyId = 7,
+            ErrorType = "AccessForbidden",
+            ErrorMessage = "forbidden"
+        }, new TestEventContext());
+
+        _notificationRepository.Verify(x => x.CreateAsync(
+            It.IsAny<Notification>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/Services/ProviderKeyReprobeServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Services/ProviderKeyReprobeServiceTests.cs
@@ -121,6 +121,58 @@ public class ProviderKeyReprobeServiceTests
             It.IsAny<DateTime>()), Times.Never);
     }
 
+    [Fact]
+    public async Task RunOnceAsync_GroupSuccessRestoresBalanceDisabledSiblings()
+    {
+        _key.ProviderAccountGroup = 2;
+        var sibling = new ProviderKeyCredential
+        {
+            Id = 8,
+            ProviderId = 42,
+            ProviderAccountGroup = 2,
+            IsEnabled = false
+        };
+        var providerKeys = new List<ProviderKeyCredential> { _key, sibling };
+        var service = CreateService();
+        _errorStore
+            .Setup(x => x.GetDisabledKeyReprobeStatesAsync())
+            .ReturnsAsync(new List<DisabledKeyReprobeState>
+            {
+                new()
+                {
+                    KeyId = 7,
+                    ErrorType = ProviderErrorType.InsufficientBalance,
+                    DisabledAt = Now.UtcDateTime.AddHours(-2)
+                },
+                new()
+                {
+                    KeyId = 8,
+                    ErrorType = ProviderErrorType.InsufficientBalance,
+                    DisabledAt = Now.UtcDateTime.AddHours(-2)
+                }
+            });
+        _keyRepository.Setup(x => x.GetByProviderIdPaginatedAsync(
+                42, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((providerKeys, providerKeys.Count));
+        _client
+            .Setup(x => x.ListModelsAsync(
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string> { "model" });
+
+        await service.RunOnceAsync();
+
+        _keyRepository.Verify(x => x.UpdateAsync(
+            It.Is<ProviderKeyCredential>(key => key.Id == 8 && key.IsEnabled),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _errorStore.Verify(x => x.ClearErrorsForKeyAsync(8, 42), Times.Once);
+        _eventBus.Verify(x => x.PublishAsync(
+            It.Is<ProviderKeyReenabledEvent>(message =>
+                message.ProviderAccountGroup == 2 &&
+                message.AffectedKeyIds.OrderBy(id => id)
+                    .SequenceEqual(new[] { 7, 8 })),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     private ProviderKeyReprobeService CreateService()
     {
         _errorStore

--- a/Tests/ConduitLLM.Tests/Gateway/Services/ProviderKeyReprobeServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Services/ProviderKeyReprobeServiceTests.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+using ConduitLLM.Gateway.Options;
+using ConduitLLM.Gateway.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace ConduitLLM.Tests.Gateway.Services;
+
+public class ProviderKeyReprobeServiceTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 7, 24, 8, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IRedisErrorStore> _errorStore = new();
+    private readonly Mock<IProviderKeyCredentialRepository> _keyRepository = new();
+    private readonly Mock<IProviderRepository> _providerRepository = new();
+    private readonly Mock<ILLMClientFactory> _clientFactory = new();
+    private readonly Mock<IEventBus> _eventBus = new();
+    private readonly Mock<ILLMClient> _client = new();
+    private readonly ProviderKeyCredential _key = new()
+    {
+        Id = 7,
+        ProviderId = 42,
+        KeyName = "Primary",
+        IsEnabled = false
+    };
+    private readonly Provider _provider = new()
+    {
+        Id = 42,
+        ProviderName = "OpenAI",
+        IsEnabled = false
+    };
+
+    [Fact]
+    public async Task RunOnceAsync_SuccessReenablesKeyAndAutoDisabledProvider()
+    {
+        var service = CreateService();
+        _client
+            .Setup(x => x.ListModelsAsync(
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string> { "model" });
+        _errorStore
+            .Setup(x => x.GetProviderSummaryAsync(42))
+            .ReturnsAsync(new ProviderSummaryData
+            {
+                ProviderDisabledAt = Now.UtcDateTime.AddHours(-2),
+                ProviderDisableReason = ProviderErrorTrackingService.AllKeysDisabledReason
+            });
+
+        await service.RunOnceAsync();
+
+        _keyRepository.Verify(x => x.UpdateAsync(
+            It.Is<ProviderKeyCredential>(key => key.Id == 7 && key.IsEnabled),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _providerRepository.Verify(x => x.UpdateAsync(
+            It.Is<Provider>(provider => provider.Id == 42 && provider.IsEnabled),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _errorStore.Verify(x => x.ClearErrorsForKeyAsync(7, 42), Times.Once);
+        _eventBus.Verify(x => x.PublishAsync(
+            It.Is<ProviderKeyReenabledEvent>(message =>
+                message.KeyId == 7 &&
+                message.ReenabledBy == "auto-reprobe"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_ContinuedBalanceFailureSchedulesExponentialBackoff()
+    {
+        var service = CreateService();
+        _client
+            .Setup(x => x.ListModelsAsync(
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new LLMCommunicationException(
+                "payment required",
+                HttpStatusCode.PaymentRequired,
+                "insufficient balance"));
+
+        await service.RunOnceAsync();
+
+        _errorStore.Verify(x => x.RecordKeyReprobeAttemptAsync(
+            7,
+            1,
+            Now.UtcDateTime,
+            Now.UtcDateTime.AddHours(2)), Times.Once);
+        _keyRepository.Verify(x => x.UpdateAsync(
+            It.IsAny<ProviderKeyCredential>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_UnauthorizedProbeRequiresManualRepair()
+    {
+        var service = CreateService();
+        _client
+            .Setup(x => x.ListModelsAsync(
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new LLMCommunicationException(
+                "unauthorized",
+                HttpStatusCode.Unauthorized,
+                "invalid key"));
+
+        await service.RunOnceAsync();
+
+        _errorStore.Verify(x => x.MarkKeyReprobeRequiresManualAsync(
+            7, ProviderErrorType.InvalidApiKey), Times.Once);
+        _errorStore.Verify(x => x.RecordKeyReprobeAttemptAsync(
+            It.IsAny<int>(),
+            It.IsAny<int>(),
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>()), Times.Never);
+    }
+
+    private ProviderKeyReprobeService CreateService()
+    {
+        _errorStore
+            .Setup(x => x.GetDisabledKeyReprobeStatesAsync())
+            .ReturnsAsync(new List<DisabledKeyReprobeState>
+            {
+                new()
+                {
+                    KeyId = 7,
+                    ErrorType = ProviderErrorType.InsufficientBalance,
+                    DisabledAt = Now.UtcDateTime.AddHours(-2)
+                }
+            });
+        _errorStore
+            .Setup(x => x.TryAcquireKeyReprobeAsync(7, It.IsAny<TimeSpan>()))
+            .ReturnsAsync(true);
+        _keyRepository.Setup(x => x.GetByIdAsync(7)).ReturnsAsync(_key);
+        _providerRepository
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_provider);
+        _clientFactory
+            .Setup(x => x.CreateTestClient(_provider, _key))
+            .Returns(_client.Object);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _keyRepository.Object);
+        services.AddScoped(_ => _providerRepository.Object);
+        services.AddScoped(_ => _clientFactory.Object);
+        services.AddScoped(_ => _eventBus.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        return new ProviderKeyReprobeService(
+            _errorStore.Object,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new ProviderKeyReprobeOptions()),
+            Mock.Of<ILogger<ProviderKeyReprobeService>>(),
+            new FixedTimeProvider(Now));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
@@ -138,6 +138,59 @@ namespace ConduitLLM.Tests.Providers
         }
 
         [Fact]
+        public async Task GetClientAsync_WithMultipleEnabledKeys_WrapsClientsForKeyFailover()
+        {
+            var mapping = new ModelProviderMapping
+            {
+                Id = 1,
+                ModelAlias = "test-model",
+                ProviderId = 1,
+                ProviderModelId = "gpt-4"
+            };
+            var provider = new Provider
+            {
+                Id = 1,
+                ProviderName = "TestProvider",
+                ProviderType = ProviderType.OpenAI,
+                IsEnabled = true
+            };
+            _mockMappingService.Setup(service => service.GetMappingByModelAliasAsync("test-model"))
+                .ReturnsAsync(mapping);
+            _mockCredentialService.Setup(service => service.GetProviderByIdAsync(1))
+                .ReturnsAsync(provider);
+            _mockCredentialService.Setup(service => service.GetKeyCredentialsByProviderIdAsync(1))
+                .ReturnsAsync(new List<ProviderKeyCredential>
+                {
+                    new()
+                    {
+                        Id = 10,
+                        ProviderId = 1,
+                        ApiKey = "fallback",
+                        IsEnabled = true
+                    },
+                    new()
+                    {
+                        Id = 20,
+                        ProviderId = 1,
+                        ApiKey = "primary",
+                        IsEnabled = true,
+                        IsPrimary = true
+                    },
+                    new()
+                    {
+                        Id = 30,
+                        ProviderId = 1,
+                        ApiKey = "disabled",
+                        IsEnabled = false
+                    }
+                });
+
+            var client = await _factory.GetClientAsync("test-model");
+
+            Assert.IsType<ProviderKeyFailoverLLMClient>(client);
+        }
+
+        [Fact]
         public async Task GetClientByProviderIdAsync_WithNonExistentProvider_ThrowsInvalidRequestException()
         {
             // Arrange

--- a/Tests/ConduitLLM.Tests/Providers/ErrorClassificationTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ErrorClassificationTests.cs
@@ -40,12 +40,14 @@ namespace ConduitLLM.Tests.Providers
         }
 
         [Fact]
-        public void ErrorThresholdConfiguration_InvalidApiKey_HasImmediateDisable()
+        public void ErrorThresholdConfiguration_InvalidApiKey_RequiresTwoDistinctRequests()
         {
-            // Verify InvalidApiKey has immediate disable policy
+            // A single provider auth incident must not permanently disable a valid key.
             var policy = ErrorThresholdConfiguration.FatalErrorPolicies[ProviderErrorType.InvalidApiKey];
             
-            policy.DisableImmediately.Should().BeTrue();
+            policy.DisableImmediately.Should().BeFalse();
+            policy.RequiredOccurrences.Should().Be(2);
+            policy.TimeWindow.Should().Be(System.TimeSpan.FromSeconds(60));
             policy.RequiresManualReenable.Should().BeTrue();
         }
 

--- a/Tests/ConduitLLM.Tests/Providers/ProviderKeyFailoverLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ProviderKeyFailoverLLMClientTests.cs
@@ -1,0 +1,338 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+
+using ConduitLLM.Core.Decorators;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Providers;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Providers;
+
+public sealed class ProviderKeyFailoverLLMClientTests
+{
+    [Fact]
+    public async Task FatalError_RetriesNextKeyAfterContextTracksFailure()
+    {
+        var fatalError = Fatal(HttpStatusCode.Unauthorized);
+        var primary = new ScriptedClient
+        {
+            ChatHandler = () => Task.FromException<ChatCompletionResponse>(fatalError)
+        };
+        var expected = Response("fallback");
+        var fallback = new ScriptedClient
+        {
+            ChatHandler = () => Task.FromResult(expected)
+        };
+        var tracker = new Mock<IProviderErrorTrackingService>();
+        tracker
+            .Setup(service => service.TrackErrorAsync(It.IsAny<ProviderErrorInfo>()))
+            .Returns(Task.CompletedTask);
+        var services = new Mock<IServiceProvider>();
+        services
+            .Setup(provider => provider.GetService(typeof(IProviderErrorTrackingService)))
+            .Returns(tracker.Object);
+        var trackedPrimary = new ContextAwareLLMClient(primary, 11, 7, services.Object);
+        var client = CreateClient((11, 0, trackedPrimary), (12, 0, fallback));
+
+        var response = await client.CreateChatCompletionAsync(Request());
+
+        Assert.Same(expected, response);
+        Assert.Equal(1, primary.ChatAttempts);
+        Assert.Equal(1, fallback.ChatAttempts);
+        tracker.Verify(service => service.TrackErrorAsync(
+            It.Is<ProviderErrorInfo>(error =>
+                error.KeyCredentialId == 11 &&
+                error.ProviderId == 7 &&
+                error.ErrorType == ProviderErrorType.InvalidApiKey)), Times.Once);
+    }
+
+    [Fact]
+    public async Task RateLimitError_DoesNotFailOver()
+    {
+        var rateLimitError = Fatal(HttpStatusCode.TooManyRequests);
+        var primary = new ScriptedClient
+        {
+            ChatHandler = () => Task.FromException<ChatCompletionResponse>(rateLimitError)
+        };
+        var fallback = SuccessfulClient("fallback");
+        var client = CreateClient((1, 0, primary), (2, 0, fallback));
+
+        var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+            () => client.CreateChatCompletionAsync(Request()));
+
+        Assert.Same(rateLimitError, thrown);
+        Assert.Equal(1, primary.ChatAttempts);
+        Assert.Equal(0, fallback.ChatAttempts);
+    }
+
+    [Fact]
+    public async Task FatalErrors_AreCappedAtTwoAdditionalAttemptsAndSurfaceOriginal()
+    {
+        var original = Fatal(HttpStatusCode.Unauthorized, "primary");
+        var first = FailingClient(original);
+        var second = FailingClient(Fatal(HttpStatusCode.Forbidden, "second"));
+        var third = FailingClient(Fatal(HttpStatusCode.PaymentRequired, "third"));
+        var fourth = SuccessfulClient("must-not-run");
+        var client = CreateClient(
+            (1, 0, first),
+            (2, 0, second),
+            (3, 0, third),
+            (4, 0, fourth));
+
+        var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(
+            () => client.CreateChatCompletionAsync(Request()));
+
+        Assert.Same(original, thrown);
+        Assert.Equal(1, first.ChatAttempts);
+        Assert.Equal(1, second.ChatAttempts);
+        Assert.Equal(1, third.ChatAttempts);
+        Assert.Equal(0, fourth.ChatAttempts);
+    }
+
+    [Fact]
+    public async Task InsufficientBalance_SkipsOtherKeysInSameAccountGroup()
+    {
+        var exhausted = FailingClient(Fatal(HttpStatusCode.PaymentRequired));
+        var sameAccount = SuccessfulClient("same-account");
+        var separateAccount = SuccessfulClient("separate-account");
+        var client = CreateClient(
+            (1, 4, exhausted),
+            (2, 4, sameAccount),
+            (3, 5, separateAccount));
+
+        var response = await client.CreateChatCompletionAsync(Request());
+
+        Assert.Equal("separate-account", response.Id);
+        Assert.Equal(0, sameAccount.ChatAttempts);
+        Assert.Equal(1, separateAccount.ChatAttempts);
+    }
+
+    [Fact]
+    public async Task QuotaClassifiedForbidden_SkipsOtherKeysInSameAccountGroup()
+    {
+        var exhausted = FailingClient(new LLMCommunicationException(
+            "quota exhausted",
+            HttpStatusCode.Forbidden,
+            """{"code":"insufficient_quota"}"""));
+        var sameAccount = SuccessfulClient("same-account");
+        var separateAccount = SuccessfulClient("separate-account");
+        var client = CreateClient(
+            (1, 4, exhausted),
+            (2, 4, sameAccount),
+            (3, 5, separateAccount));
+
+        var response = await client.CreateChatCompletionAsync(Request());
+
+        Assert.Equal("separate-account", response.Id);
+        Assert.Equal(0, sameAccount.ChatAttempts);
+    }
+
+    [Fact]
+    public async Task UngroupedBalanceFailure_AllowsNextUngroupedKey()
+    {
+        var exhausted = FailingClient(Fatal(HttpStatusCode.PaymentRequired));
+        var fallback = SuccessfulClient("ungrouped-fallback");
+        var client = CreateClient((1, 0, exhausted), (2, 0, fallback));
+
+        var response = await client.CreateChatCompletionAsync(Request());
+
+        Assert.Equal("ungrouped-fallback", response.Id);
+        Assert.Equal(1, fallback.ChatAttempts);
+    }
+
+    [Fact]
+    public async Task StreamingFatalBeforeFirstChunk_FailsOver()
+    {
+        var primary = new ScriptedClient
+        {
+            StreamHandler = () => FailBeforeFirstChunk(Fatal(HttpStatusCode.Unauthorized))
+        };
+        var fallback = new ScriptedClient
+        {
+            StreamHandler = () => CompletedStream("fallback")
+        };
+        var client = CreateClient((1, 0, primary), (2, 0, fallback));
+        var chunks = new List<ChatCompletionChunk>();
+
+        await foreach (var chunk in client.StreamChatCompletionAsync(Request()))
+        {
+            chunks.Add(chunk);
+        }
+
+        Assert.Single(chunks);
+        Assert.Equal("fallback", chunks[0].Id);
+        Assert.Equal(1, primary.StreamAttempts);
+        Assert.Equal(1, fallback.StreamAttempts);
+    }
+
+    [Fact]
+    public async Task StreamingFatalAfterFirstChunk_DoesNotFailOver()
+    {
+        var streamError = Fatal(HttpStatusCode.Forbidden);
+        var primary = new ScriptedClient
+        {
+            StreamHandler = () => FailAfterFirstChunk(streamError)
+        };
+        var fallback = new ScriptedClient
+        {
+            StreamHandler = () => CompletedStream("fallback")
+        };
+        var client = CreateClient((1, 0, primary), (2, 0, fallback));
+        var chunks = new List<ChatCompletionChunk>();
+
+        var thrown = await Assert.ThrowsAsync<LLMCommunicationException>(async () =>
+        {
+            await foreach (var chunk in client.StreamChatCompletionAsync(Request()))
+            {
+                chunks.Add(chunk);
+            }
+        });
+
+        Assert.Same(streamError, thrown);
+        Assert.Single(chunks);
+        Assert.Equal("visible", chunks[0].Id);
+        Assert.Equal(0, fallback.StreamAttempts);
+    }
+
+    private static ProviderKeyFailoverLLMClient CreateClient(
+        params (int KeyId, int Group, ILLMClient Client)[] targets)
+    {
+        return new ProviderKeyFailoverLLMClient(
+            targets
+                .Select(target => new ProviderKeyFailoverTarget(
+                    target.KeyId,
+                    target.Group,
+                    () => target.Client))
+                .ToArray());
+    }
+
+    private static ScriptedClient FailingClient(LLMCommunicationException exception)
+        => new()
+        {
+            ChatHandler = () => Task.FromException<ChatCompletionResponse>(exception)
+        };
+
+    private static ScriptedClient SuccessfulClient(string id)
+        => new()
+        {
+            ChatHandler = () => Task.FromResult(Response(id))
+        };
+
+    private static ChatCompletionRequest Request()
+        => new()
+        {
+            Model = "test-model",
+            Messages = [new Message { Role = "user", Content = "hello" }]
+        };
+
+    private static ChatCompletionResponse Response(string id = "response")
+        => new()
+        {
+            Id = id,
+            Choices = [],
+            Created = 0,
+            Model = "test-model",
+            Object = "chat.completion"
+        };
+
+    private static LLMCommunicationException Fatal(
+        HttpStatusCode statusCode,
+        string message = "provider rejected credential")
+        => new(message, statusCode, null);
+
+    private static async IAsyncEnumerable<ChatCompletionChunk> FailBeforeFirstChunk(
+        Exception exception,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (exception is not null)
+        {
+            throw exception;
+        }
+
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<ChatCompletionChunk> CompletedStream(
+        string id,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatCompletionChunk { Id = id };
+    }
+
+    private static async IAsyncEnumerable<ChatCompletionChunk> FailAfterFirstChunk(
+        Exception exception,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield return new ChatCompletionChunk { Id = "visible" };
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        throw exception;
+    }
+
+    private sealed class ScriptedClient : ILLMClient
+    {
+        public Func<Task<ChatCompletionResponse>> ChatHandler { get; init; }
+            = () => Task.FromResult(Response());
+
+        public Func<IAsyncEnumerable<ChatCompletionChunk>> StreamHandler { get; init; }
+            = () => CompletedStream("default");
+
+        public int ChatAttempts { get; private set; }
+        public int StreamAttempts { get; private set; }
+
+        public async Task<ChatCompletionResponse> CreateChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            ChatAttempts++;
+            return await ChatHandler();
+        }
+
+        public IAsyncEnumerable<ChatCompletionChunk> StreamChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            StreamAttempts++;
+            return StreamHandler();
+        }
+
+        public Task<List<string>> ListModelsAsync(
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<string>());
+
+        public Task<EmbeddingResponse> CreateEmbeddingAsync(
+            EmbeddingRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new EmbeddingResponse
+            {
+                Object = "list",
+                Data = [],
+                Model = "test-model",
+                Usage = new Usage()
+            });
+
+        public Task<ImageGenerationResponse> CreateImageAsync(
+            ImageGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ImageGenerationResponse
+            {
+                Created = 0,
+                Data = []
+            });
+
+        public Task<ProviderCapabilities> GetCapabilitiesAsync(string? modelId = null)
+            => Task.FromResult(new ProviderCapabilities());
+    }
+}

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -328,7 +328,7 @@ namespace ConduitLLM.Tests.Services
         }
 
         [Fact]
-        public async Task DisableKeyAsync_PrimaryKey_DisablesProvider()
+        public async Task DisableKeyAsync_PrimaryKey_DisablesOnlyKeyAndPromotesFallback()
         {
             // Arrange
             var keyId = 123;
@@ -343,33 +343,35 @@ namespace ConduitLLM.Tests.Services
                 IsPrimary = true
             };
             
-            var provider = new Provider
+            var fallbackKey = new ProviderKeyCredential
             {
-                Id = providerId,
-                ProviderName = "Test Provider",
-                IsEnabled = true
+                Id = 124,
+                ProviderId = providerId,
+                IsEnabled = true,
+                IsPrimary = false
             };
 
             _keyRepoMock.Setup(x => x.GetByIdAsync(keyId))
                 .ReturnsAsync(primaryKey);
-            _providerRepoMock.Setup(x => x.GetByIdAsync(providerId, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(provider);
+            var providerKeys = new List<ProviderKeyCredential> { primaryKey, fallbackKey };
+            _keyRepoMock.Setup(x => x.GetByProviderIdPaginatedAsync(
+                    providerId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((providerKeys, providerKeys.Count));
 
             // Act
             await _service.DisableKeyAsync(keyId, reason);
 
             // Assert
-            _providerRepoMock.Verify(x => x.UpdateAsync(
-                It.Is<Provider>(p => p.Id == providerId && !p.IsEnabled),
-                It.IsAny<CancellationToken>()), 
+            _keyRepoMock.Verify(x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(k =>
+                    k.Id == keyId &&
+                    !k.IsEnabled &&
+                    !k.IsPrimary)),
                 Times.Once);
-            
-            _publishEndpointMock.Verify(x => x.PublishAsync(
-                It.Is<ProviderKeyDisabledEvent>(e => 
-                    e.KeyId == keyId &&
-                    e.Reason.Contains("Provider disabled")),
-                It.IsAny<CancellationToken>()), 
-                Times.Once);
+            _keyRepoMock.Verify(x => x.SetPrimaryKeyAsync(providerId, fallbackKey.Id), Times.Once);
+            _providerRepoMock.Verify(
+                x => x.UpdateAsync(It.IsAny<Provider>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -428,7 +430,7 @@ namespace ConduitLLM.Tests.Services
                 Id = keyId,
                 ProviderId = providerId,
                 IsEnabled = true,
-                IsPrimary = false
+                IsPrimary = true
             };
             
             var key2 = new ProviderKeyCredential
@@ -436,7 +438,7 @@ namespace ConduitLLM.Tests.Services
                 Id = 124,
                 ProviderId = providerId,
                 IsEnabled = false, // Already disabled
-                IsPrimary = true
+                IsPrimary = false
             };
             
             var provider = new Provider
@@ -463,6 +465,11 @@ namespace ConduitLLM.Tests.Services
             _providerRepoMock.Verify(x => x.UpdateAsync(
                 It.Is<Provider>(p => p.Id == providerId && !p.IsEnabled),
                 It.IsAny<CancellationToken>()), 
+                Times.Once);
+            _errorStoreMock.Verify(x => x.MarkProviderDisabledAsync(
+                providerId,
+                It.IsAny<DateTime>(),
+                ProviderErrorTrackingService.AllKeysDisabledReason),
                 Times.Once);
         }
 

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -129,7 +129,10 @@ namespace ConduitLLM.Tests.Services
             _publishEndpointMock.Verify(x => x.PublishAsync(
                 It.Is<ProviderKeyDisabledEvent>(e => 
                     e.KeyId == error.KeyCredentialId &&
-                    e.ProviderId == error.ProviderId),
+                    e.ProviderId == error.ProviderId &&
+                    e.ErrorType == ProviderErrorType.InvalidApiKey.ToString() &&
+                    e.ErrorMessage == error.ErrorMessage &&
+                    e.IsAutomatic),
                 It.IsAny<CancellationToken>()), 
                 Times.Once);
         }
@@ -415,6 +418,13 @@ namespace ConduitLLM.Tests.Services
             
             // Should not disable provider (other key is still enabled)
             _providerRepoMock.Verify(x => x.UpdateAsync(It.IsAny<Provider>(), It.IsAny<CancellationToken>()), Times.Never);
+            _publishEndpointMock.Verify(x => x.PublishAsync(
+                It.Is<ProviderKeyDisabledEvent>(e =>
+                    e.KeyId == keyId &&
+                    e.ErrorType == ProviderErrorType.Unknown.ToString() &&
+                    !e.IsAutomatic),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -36,6 +36,10 @@ namespace ConduitLLM.Tests.Services
             _keyRepoMock = new Mock<IProviderKeyCredentialRepository>();
             _providerRepoMock = new Mock<IProviderRepository>();
             _publishEndpointMock = new Mock<IEventBus>();
+            _errorStoreMock
+                .Setup(x => x.TryAcquireKeyDisableAsync(
+                    It.IsAny<int>(), It.IsAny<TimeSpan>()))
+                .ReturnsAsync(true);
 
             SetupServiceScope();
 
@@ -111,6 +115,11 @@ namespace ConduitLLM.Tests.Services
 
             _keyRepoMock.Setup(x => x.GetByIdAsync(error.KeyCredentialId))
                 .ReturnsAsync(testKey);
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    error.KeyCredentialId,
+                    ProviderErrorType.InvalidApiKey,
+                    TimeSpan.FromSeconds(60)))
+                .ReturnsAsync(2);
             _keyRepoMock.Setup(x => x.UpdateAsync(It.IsAny<ProviderKeyCredential>()))
                 .ReturnsAsync(true);
             var keyList = new List<ProviderKeyCredential> { testKey };
@@ -267,13 +276,32 @@ namespace ConduitLLM.Tests.Services
         }
 
         [Fact]
-        public async Task ShouldDisableKeyAsync_InvalidApiKey_ReturnsTrue()
+        public async Task ShouldDisableKeyAsync_InvalidApiKey_FirstDistinctRequestReturnsFalse()
         {
             // Arrange
             var keyId = 123;
             var errorType = ProviderErrorType.InvalidApiKey;
-            
-            // InvalidApiKey has immediate disable policy
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    keyId, errorType, TimeSpan.FromSeconds(60)))
+                .ReturnsAsync(1);
+
+            // Act
+            var result = await _service.ShouldDisableKeyAsync(keyId, errorType);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ShouldDisableKeyAsync_InvalidApiKey_SecondDistinctRequestReturnsTrue()
+        {
+            // Arrange
+            var keyId = 123;
+            var errorType = ProviderErrorType.InvalidApiKey;
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    keyId, errorType, TimeSpan.FromSeconds(60)))
+                .ReturnsAsync(2);
+
             // Act
             var result = await _service.ShouldDisableKeyAsync(keyId, errorType);
 
@@ -287,17 +315,9 @@ namespace ConduitLLM.Tests.Services
             // Arrange
             var keyId = 123;
             var errorType = ProviderErrorType.InsufficientBalance;
-            var lastSeenTime = DateTime.UtcNow.AddMinutes(-2); // Within 5 minute window
-            
-            var fatalData = new FatalErrorData
-            {
-                ErrorType = "InsufficientBalance",
-                Count = 2, // Threshold is 2
-                LastSeen = lastSeenTime
-            };
-            
-            _errorStoreMock.Setup(x => x.GetFatalErrorDataAsync(keyId))
-                .ReturnsAsync(fatalData);
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    keyId, errorType, TimeSpan.FromMinutes(5)))
+                .ReturnsAsync(2);
 
             // Act
             var result = await _service.ShouldDisableKeyAsync(keyId, errorType);
@@ -313,15 +333,9 @@ namespace ConduitLLM.Tests.Services
             var keyId = 123;
             var errorType = ProviderErrorType.InsufficientBalance;
             
-            var fatalData = new FatalErrorData
-            {
-                ErrorType = "InsufficientBalance",
-                Count = 1, // Below threshold of 2
-                LastSeen = DateTime.UtcNow.AddMinutes(-2)
-            };
-            
-            _errorStoreMock.Setup(x => x.GetFatalErrorDataAsync(keyId))
-                .ReturnsAsync(fatalData);
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    keyId, errorType, TimeSpan.FromMinutes(5)))
+                .ReturnsAsync(1);
 
             // Act
             var result = await _service.ShouldDisableKeyAsync(keyId, errorType);
@@ -480,6 +494,53 @@ namespace ConduitLLM.Tests.Services
                 providerId,
                 It.IsAny<DateTime>(),
                 ProviderErrorTrackingService.AllKeysDisabledReason),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task TrackErrorAsync_ConcurrentThresholdFailures_PublishesOneDisableEvent()
+        {
+            // Arrange
+            const int keyId = 123;
+            const int providerId = 456;
+            var key = new ProviderKeyCredential
+            {
+                Id = keyId,
+                ProviderId = providerId,
+                IsEnabled = true
+            };
+            var guardAttempts = 0;
+
+            _errorStoreMock.Setup(x => x.GetDistinctFatalRequestCountAsync(
+                    keyId,
+                    ProviderErrorType.InvalidApiKey,
+                    TimeSpan.FromSeconds(60)))
+                .ReturnsAsync(2);
+            _errorStoreMock.Setup(x => x.TryAcquireKeyDisableAsync(
+                    keyId, It.IsAny<TimeSpan>()))
+                .ReturnsAsync(() => Interlocked.Increment(ref guardAttempts) == 1);
+            _keyRepoMock.Setup(x => x.GetByIdAsync(keyId)).ReturnsAsync(key);
+            var keys = new List<ProviderKeyCredential> { key };
+            _keyRepoMock.Setup(x => x.GetByProviderIdPaginatedAsync(
+                    providerId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((keys, keys.Count));
+
+            var errors = Enumerable.Range(0, 8).Select(index => new ProviderErrorInfo
+            {
+                KeyCredentialId = keyId,
+                ProviderId = providerId,
+                ErrorType = ProviderErrorType.InvalidApiKey,
+                ErrorMessage = "invalid",
+                RequestId = $"request-{index}"
+            });
+
+            // Act
+            await Task.WhenAll(errors.Select(_service.TrackErrorAsync));
+
+            // Assert
+            _publishEndpointMock.Verify(x => x.PublishAsync(
+                It.Is<ProviderKeyDisabledEvent>(e => e.KeyId == keyId),
+                It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -502,6 +502,117 @@ namespace ConduitLLM.Tests.Services
         }
 
         [Fact]
+        public async Task DisableKeyAsync_InsufficientBalance_DisablesNonzeroAccountGroupOnce()
+        {
+            // Arrange
+            const int providerId = 456;
+            var triggerKey = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = providerId,
+                ProviderAccountGroup = 2,
+                IsEnabled = true,
+                IsPrimary = true
+            };
+            var sharedAccountKey = new ProviderKeyCredential
+            {
+                Id = 2,
+                ProviderId = providerId,
+                ProviderAccountGroup = 2,
+                IsEnabled = true
+            };
+            var fallbackKey = new ProviderKeyCredential
+            {
+                Id = 3,
+                ProviderId = providerId,
+                ProviderAccountGroup = 3,
+                IsEnabled = true
+            };
+            var providerKeys = new List<ProviderKeyCredential>
+            {
+                triggerKey,
+                sharedAccountKey,
+                fallbackKey
+            };
+
+            _keyRepoMock.Setup(x => x.GetByIdAsync(triggerKey.Id))
+                .ReturnsAsync(triggerKey);
+            _keyRepoMock.Setup(x => x.GetByProviderIdPaginatedAsync(
+                    providerId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((providerKeys, providerKeys.Count));
+
+            // Act
+            await _service.DisableKeyAsync(
+                triggerKey.Id,
+                "balance exhausted",
+                ProviderErrorType.InsufficientBalance,
+                isAutomatic: true,
+                errorMessage: "402 payment required");
+
+            // Assert
+            _keyRepoMock.Verify(x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(key =>
+                    (key.Id == 1 || key.Id == 2) && !key.IsEnabled),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _keyRepoMock.Verify(x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(key => key.Id == 3),
+                It.IsAny<CancellationToken>()), Times.Never);
+            _keyRepoMock.Verify(x => x.SetPrimaryKeyAsync(providerId, 3), Times.Once);
+            _providerRepoMock.Verify(x => x.UpdateAsync(
+                It.IsAny<Provider>(), It.IsAny<CancellationToken>()), Times.Never);
+            _publishEndpointMock.Verify(x => x.PublishAsync(
+                It.Is<ProviderKeyDisabledEvent>(message =>
+                    message.ProviderAccountGroup == 2 &&
+                    message.AffectedKeyIds.OrderBy(id => id).SequenceEqual(new[] { 1, 2 }) &&
+                    message.Reason.Contains("Shared account group 2")),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task DisableKeyAsync_InvalidApiKey_DoesNotPropagateWithinAccountGroup()
+        {
+            // Arrange
+            const int providerId = 456;
+            var triggerKey = new ProviderKeyCredential
+            {
+                Id = 1,
+                ProviderId = providerId,
+                ProviderAccountGroup = 2,
+                IsEnabled = true
+            };
+            var siblingKey = new ProviderKeyCredential
+            {
+                Id = 2,
+                ProviderId = providerId,
+                ProviderAccountGroup = 2,
+                IsEnabled = true,
+                IsPrimary = true
+            };
+            var providerKeys = new List<ProviderKeyCredential> { triggerKey, siblingKey };
+
+            _keyRepoMock.Setup(x => x.GetByIdAsync(triggerKey.Id))
+                .ReturnsAsync(triggerKey);
+            _keyRepoMock.Setup(x => x.GetByProviderIdPaginatedAsync(
+                    providerId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((providerKeys, providerKeys.Count));
+
+            // Act
+            await _service.DisableKeyAsync(
+                triggerKey.Id,
+                "invalid",
+                ProviderErrorType.InvalidApiKey,
+                isAutomatic: true);
+
+            // Assert
+            _keyRepoMock.Verify(x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(key => key.Id == triggerKey.Id),
+                It.IsAny<CancellationToken>()), Times.Once);
+            _keyRepoMock.Verify(x => x.UpdateAsync(
+                It.Is<ProviderKeyCredential>(key => key.Id == siblingKey.Id),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task TrackErrorAsync_ConcurrentThresholdFailures_PublishesOneDisableEvent()
         {
             // Arrange

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -144,6 +144,10 @@ namespace ConduitLLM.Tests.Services
                     e.IsAutomatic),
                 It.IsAny<CancellationToken>()), 
                 Times.Once);
+            _errorStoreMock.Verify(x => x.MarkKeyDisabledAsync(
+                error.KeyCredentialId,
+                It.IsAny<DateTime>(),
+                ProviderErrorType.InvalidApiKey), Times.Once);
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Services/RedisErrorStoreTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/RedisErrorStoreTests.cs
@@ -1,0 +1,39 @@
+using ConduitLLM.Configuration.Constants;
+using ConduitLLM.Core.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace ConduitLLM.Tests.Services;
+
+public class RedisErrorStoreTests
+{
+    [Fact]
+    public async Task TryAcquireKeyDisableAsync_UsesNxGuardWithRequestedTtl()
+    {
+        var database = new Mock<IDatabase>();
+        database.Setup(x => x.StringSetAsync(
+                (RedisKey)CacheKeys.ProviderError.DisableGuard(123),
+                (RedisValue)"1",
+                TimeSpan.FromSeconds(30),
+                When.NotExists))
+            .ReturnsAsync(true);
+        var redis = new Mock<IConnectionMultiplexer>();
+        redis.Setup(x => x.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Returns(database.Object);
+        var store = new RedisErrorStore(
+            redis.Object,
+            Mock.Of<ILogger<RedisErrorStore>>());
+
+        var acquired = await store.TryAcquireKeyDisableAsync(
+            123, TimeSpan.FromSeconds(30));
+
+        Assert.True(acquired);
+        database.Verify(x => x.StringSetAsync(
+            (RedisKey)"provider:errors:key:123:disabling",
+            (RedisValue)"1",
+            TimeSpan.FromSeconds(30),
+            When.NotExists), Times.Once);
+    }
+}

--- a/WebAdmin/src/generated/admin-api.ts
+++ b/WebAdmin/src/generated/admin-api.ts
@@ -5928,6 +5928,10 @@ export interface components {
       /** Format: int32 */
       virtualKeyId?: null | number;
       virtualKeyName?: null | string;
+      /** Format: int32 */
+      providerId?: null | number;
+      /** Format: int32 */
+      providerKeyCredentialId?: null | number;
       type?: components["schemas"]["NotificationType"];
       severity?: components["schemas"]["NotificationSeverity"];
       message?: string;
@@ -5938,7 +5942,12 @@ export interface components {
     /** @enum {unknown} */
     NotificationSeverity: "info" | "warning" | "error";
     /** @enum {unknown} */
-    NotificationType: "budgetWarning" | "expirationWarning" | "system";
+    NotificationType:
+      | "budgetWarning"
+      | "expirationWarning"
+      | "system"
+      | "providerKeyDisabled"
+      | "providerKeyReenabled";
     /** @description Information about a condition operator */
     OperatorInfo: {
       /** @description The operator identifier */

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,14 @@ These four cover the system end to end:
   session affinity, and the kill switch behave.
 - **[Monitoring](./monitoring.md)** — health checks, metrics, real-time streams, and alerting.
 
-Two deeper operational runbooks stand on their own and are linked from Monitoring:
+Deeper operational runbooks stand on their own and are linked from Monitoring:
 
 - **[Billing correctness alerting](./billing-alerting.md)** — the cost canary, alert rules, and
   incident response.
 - **[SSE production validation](./sse-production-validation.md)** — deploying streaming behind a
   proxy.
+- **[Provider key auto-disable](./operations/provider-key-auto-disable.md)** — investigating fatal
+  credential/account errors and restoring keys safely.
 
 **[Versioning](./Versioning.md)** documents the release and version scheme.
 

--- a/docs/decisions/0003-provider-key-auto-disable-policy.md
+++ b/docs/decisions/0003-provider-key-auto-disable-policy.md
@@ -1,0 +1,124 @@
+# ADR 0003: Provider-key automatic disable and recovery policy
+
+- Status: Accepted
+- Date: 2026-07-23
+- Epic: #1194
+
+## Context
+
+Conduit sends requests through provider credentials that can become invalid,
+lose permission, or exhaust a shared balance. Continuing to select a known-bad
+credential creates repeated user-visible failures, but disabling too broadly or
+after one transient response can take healthy capacity out of service.
+
+Provider-key health is distinct from model-route health. Route-level circuit
+breaking responds to transient network, timeout, rate-limit, and upstream
+service failures and can move chat traffic to another provider mapping.
+Provider-key disabling responds to fatal credential or account failures and
+removes only the affected credential scope.
+
+The policy must also work under concurrency, where many requests can discover
+the same failure at once, and across Gateway replicas whose credential caches
+must converge.
+
+## Decision
+
+Conduit classifies provider errors into these numeric ranges:
+
+- `1`–`9`: fatal credential/account errors that can disable a key:
+  `InvalidApiKey`, `InsufficientBalance`, and `AccessForbidden`;
+- `10`–`19`: warnings such as `RateLimitExceeded`, `ModelNotFound`, and
+  `ServiceUnavailable`;
+- `20`–`29`: transient `NetworkError` and `Timeout`;
+- `99`: `Unknown`.
+
+HTTP `401`, `402`, and `403` map to the three fatal types. A `403` whose response
+mentions quota, billing, payment, or credit is refined to
+`InsufficientBalance`. HTTP `429`, `5xx`, network failures, and timeouts do not
+disable credentials; their retry and circuit behavior remains in the
+transient-resilience layer.
+
+### Disable thresholds
+
+Fatal thresholds count distinct request/correlation IDs, not internal retry
+attempts:
+
+| Error type | Disable threshold | Recovery |
+|---|---:|---|
+| `InvalidApiKey` | 2 distinct requests in 60 seconds | Manual credential repair and re-enable |
+| `InsufficientBalance` | 2 distinct requests in 5 minutes | Automatic balance reprobe or manual re-enable |
+| `AccessForbidden` | 3 distinct requests in 10 minutes | Manual permission repair and re-enable |
+
+The first `InvalidApiKey` response is recorded and logged without disabling the
+key. A 30-second Redis `SET NX` guard permits only one concurrent caller to
+perform a qualifying disable and publish its event.
+
+Warning and transient classifications are recorded for monitoring but never
+disable a credential.
+
+### Disable scope
+
+A fatal error disables the failing `ProviderKeyCredential`, including when it
+is the primary key. A disabled primary is demoted and an enabled sibling is
+promoted when one exists. The provider remains enabled while any eligible key
+remains.
+
+The provider entity is disabled only when the operation leaves it with no
+enabled keys. Conduit records the automatic reason
+`All provider keys disabled automatically`; this marker distinguishes an
+automatic provider disable from an operator's manual provider toggle.
+
+For `InsufficientBalance`, a nonzero `ProviderAccountGroup` means the keys share
+one billing account. Every enabled key in that provider and group is disabled
+together. Group `0` is ungrouped, so a failure never propagates between group-0
+keys. Other fatal types remain scoped to the failing key.
+
+One aggregate status event represents a group transition. Disable and re-enable
+events invalidate the provider credential cache on every Gateway replica and
+produce a durable admin notification plus a best-effort live system
+announcement.
+
+### Same-request failover
+
+After a key-specific client has attributed and tracked a fatal `401`, `402`, or
+`403`, the current request may retry another enabled key of the same provider.
+The retry layer makes at most two additional attempts and surfaces the original
+error if no eligible key succeeds.
+
+An insufficient-balance attempt excludes every remaining key in the same
+nonzero account group. Rate limits, timeouts, and `5xx` responses are not
+retried by this key layer. A streaming request can change keys only before its
+first response chunk is emitted; output is never replayed after it becomes
+visible to the caller.
+
+### Recovery
+
+Operators can clear error state and optionally re-enable a repaired key through
+the Admin provider-errors API. Re-enabling a balance-disabled key in a nonzero
+account group restores the other balance-disabled members of that group.
+
+An automatically disabled provider is restored when its key or group recovers.
+A provider disabled manually is never enabled as a side effect of key recovery.
+
+Only `InsufficientBalance` enters automatic half-open recovery. The Gateway
+waits one hour before the first real provider probe, scans every five minutes,
+and backs failed probes off exponentially up to 24 hours. A successful probe
+re-enables the key or account group. A `401` reclassifies the key as
+`InvalidApiKey`, removes it from automatic probing, and requires manual repair.
+
+## Consequences
+
+A bad primary credential no longer removes healthy sibling capacity, and a
+shared balance failure cannot churn through equivalent keys. Operators receive
+one actionable transition instead of a notification storm, while a temporary
+single `401` does not permanently disable a credential.
+
+The policy deliberately favors safety over aggressive recovery:
+authentication and permission failures require an operator, balance recovery
+waits through a cooldown, and a provider's manual disabled state always wins.
+Redis is part of the control plane for thresholds, guards, disabled membership,
+and reprobe scheduling; the database remains authoritative for whether a key or
+provider is enabled.
+
+Operational procedures and Redis key details are in
+[Provider key auto-disable operations](../operations/provider-key-auto-disable.md).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -77,12 +77,15 @@ as the source of truth rather than a list here, which would drift.
 Conduit tracks provider trouble through **error tracking**, not an up/down health probe. Errors from
 each provider and key are counted and classified, and when a key (or provider) crosses a fatal
 threshold it is **automatically disabled** so routing stops sending traffic to it. Recovery is
-**manual** — a disabled key stays disabled until an operator re-enables it; there is no automatic
-half-open retry at the provider level. This error signal is what [routing](./routing.md#how-candidates-are-scored)
-reads when it scores mappings down for an unhealthy provider.
+manual for invalid credentials and permissions. Keys disabled for insufficient balance enter a
+delayed half-open reprobe with exponential backoff and can recover automatically. This error signal
+is what [routing](./routing.md#how-candidates-are-scored) reads when it scores mappings down for an
+unhealthy provider.
 
 You review and clear provider errors from the **Provider Errors** view in WebAdmin (backed by the
-Admin API). Note this is a poll/refresh view rather than a live stream.
+Admin API). Disable and recovery events also create durable admin notifications and best-effort
+live announcements. Thresholds, recovery procedures, Redis state, and reprobe troubleshooting are
+covered in **[Provider key auto-disable operations](./operations/provider-key-auto-disable.md)**.
 
 ## Alerting: billing correctness and security
 
@@ -116,4 +119,6 @@ settles. The ingress settings, a validation matrix, and a soak test are in
 
 - **[Configuration](./configuration.md)** — the health key, observability, and security settings.
 - **[Core concepts](./concepts.md)** — the request lifecycle these signals observe.
+- **[Provider key auto-disable operations](./operations/provider-key-auto-disable.md)** — fatal
+  credential/account errors, notifications, and recovery.
 - **[Billing correctness alerting](./billing-alerting.md)** · **[SSE production validation](./sse-production-validation.md)** — the two deep operational runbooks.

--- a/docs/operations/provider-key-auto-disable.md
+++ b/docs/operations/provider-key-auto-disable.md
@@ -1,0 +1,198 @@
+# Provider key auto-disable operations
+
+*Audience: operators investigating provider credential failures, restoring
+keys, or validating automatic balance recovery. The policy rationale is in
+[ADR 0003](../decisions/0003-provider-key-auto-disable-policy.md).*
+
+## What happens when a provider key fails
+
+Conduit classifies each provider error and records it against the exact
+`ProviderKeyCredential`. Fatal `401`, `402`, and `403` classifications use
+distinct-request thresholds; `429`, `5xx`, timeouts, and network failures stay
+in the transient retry/circuit-breaker path.
+
+When a fatal threshold is crossed, Conduit:
+
+1. disables and, if necessary, demotes the affected key;
+2. disables the provider only if no enabled key remains;
+3. invalidates provider credential caches across Gateway replicas;
+4. emits a durable admin notification and a live system announcement; and
+5. makes balance-disabled keys eligible for a delayed recovery probe.
+
+For the exact thresholds and blast-radius rules, see
+[ADR 0003](../decisions/0003-provider-key-auto-disable-policy.md#disable-thresholds).
+
+## Inspecting errors
+
+Use WebAdmin's **Provider Errors** view for routine investigation. Key
+disable/re-enable transitions also appear in the admin notification feed.
+Messages include the provider, key or account group, classified error type, and
+a bounded copy of the upstream error.
+
+The backing Admin endpoints require the master key. The examples use the
+default `X-API-Key` header:
+
+```bash
+ADMIN=http://localhost:5002
+KEY_ID=123
+PROVIDER_ID=45
+
+# Most recent errors; providerId, keyId, and limit are optional.
+curl -sS -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  "$ADMIN/v1/admin/provider-errors/recent?providerId=$PROVIDER_ID&keyId=$KEY_ID&limit=100"
+
+# Fatal history, last status/message, disabled time, and recent warnings for one key.
+curl -sS -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  "$ADMIN/v1/admin/provider-errors/keys/$KEY_ID"
+
+# Provider summaries and currently disabled key IDs.
+curl -sS -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  "$ADMIN/v1/admin/provider-errors/summary"
+
+# Aggregate counts for a bounded window (1-168 hours).
+curl -sS -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  "$ADMIN/v1/admin/provider-errors/stats?hours=24"
+
+# Per-key fatal counts for one provider (1-24 hours).
+curl -sS -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  "$ADMIN/v1/admin/provider-errors/providers/$PROVIDER_ID/key-errors?hours=1"
+```
+
+The recent feed and provider summary are historical monitoring views. Clearing
+a key removes its per-key fatal/warning state and disabled membership; it does
+not rewrite the global recent feed or cumulative provider summary counters.
+
+## Repairing and re-enabling a key
+
+Fix the cause before restoring traffic: rotate an invalid secret, replenish the
+account, or correct the provider-side permission.
+
+To clear error state and re-enable the key:
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  -H "Content-Type: application/json" \
+  "$ADMIN/v1/admin/provider-errors/keys/$KEY_ID/clear" \
+  -d '{
+    "reenableKey": true,
+    "confirmReenable": true,
+    "reason": "Credential rotated and verified"
+  }'
+```
+
+To clear only the recorded error state without enabling the credential, send
+`reenableKey: false`. A re-enable request is rejected unless
+`confirmReenable` is also `true`.
+
+If the key was disabled for insufficient balance and belongs to a nonzero
+`ProviderAccountGroup`, the operation restores every member of that group whose
+recorded fatal error is `InsufficientBalance`. If all keys had automatically
+disabled the provider, the provider is restored as well. The operation never
+overrides a provider that an operator disabled manually.
+
+You can also disable a key deliberately:
+
+```bash
+curl -sS -X POST \
+  -H "X-API-Key: $CONDUIT_API_TO_API_BACKEND_AUTH_KEY" \
+  -H "Content-Type: application/json" \
+  "$ADMIN/v1/admin/provider-errors/keys/$KEY_ID/disable" \
+  -d '"Maintenance window"'
+```
+
+Manual disables do not enter automatic balance recovery.
+
+## Automatic balance reprobe
+
+The Gateway's `ProviderKeyReprobeService` handles only keys classified as
+`InsufficientBalance`. Defaults are:
+
+- enabled;
+- scan interval: 5 minutes;
+- first probe: 1 hour after disable;
+- failed-probe backoff: exponential, capped at 24 hours;
+- per-key distributed probe lock: 10 minutes;
+- maximum keys per scan: 50.
+
+The probe uses the disabled credential to make a real model-list request.
+Success clears its error state and re-enables the key. For a nonzero account
+group, the balance-disabled group recovers together. The provider is also
+restored only when it carries Conduit's automatic all-keys-disabled marker.
+
+A probe that returns `401` changes the stored classification to
+`InvalidApiKey` and stops future automatic probes. Other failures record the
+next eligible time and stay in the backoff schedule.
+
+Override the defaults through normal .NET configuration:
+
+```json
+{
+  "ProviderKeyReprobe": {
+    "Enabled": true,
+    "ScanInterval": "00:05:00",
+    "InitialCooldown": "01:00:00",
+    "MaxCooldown": "1.00:00:00",
+    "ProbeLockTtl": "00:10:00",
+    "BatchSize": 50
+  }
+}
+```
+
+Environment variables use the same section with double underscores, for
+example `ProviderKeyReprobe__Enabled=false`.
+
+## Notifications
+
+Each disable creates an unread durable notification of type
+`ProviderKeyDisabled` with error severity. Each recovery creates
+`ProviderKeyReenabled` with informational severity. Account-group operations
+name the group and affected key IDs in one notification.
+
+The Gateway also broadcasts the same text as a best-effort system announcement
+to connected admins. A live broadcast failure does not roll back the durable
+notification or cause the status event to be redelivered solely for that
+failure.
+
+## Redis state
+
+Redis stores health history and coordination state. Do not edit these keys
+directly during normal recovery; use the Admin API so database state, cache
+invalidation, events, and notifications stay consistent.
+
+| Key | Purpose |
+|---|---|
+| `provider:errors:recent` | Global sorted feed, capped at 1,000 entries |
+| `provider:errors:key:{id}:fatal` | Fatal count, classification, last error, disabled time, and reprobe schedule; 30-day TTL when tracked |
+| `provider:errors:key:{id}:fatal:{type}:requests` | Distinct request IDs used by the threshold window; 30-day TTL |
+| `provider:errors:key:{id}:warnings` | Last 100 warnings; 30-day TTL |
+| `provider:errors:key:{id}:disabling` | 30-second distributed disable guard |
+| `provider:errors:key:{id}:reprobing` | Distributed reprobe lock |
+| `provider:errors:disabled_keys` | Global set scanned by the reprobe worker |
+| `provider:errors:provider:{id}:summary` | Provider totals and automatic provider-disable marker |
+| `provider:errors:provider:{id}:disabled_keys` | Disabled credential IDs for the provider |
+
+Clearing a key deletes its fatal, warning, threshold, and guard keys and removes
+it from both disabled-key sets.
+
+## Troubleshooting
+
+If traffic still selects a disabled key, verify that `IsEnabled` is false in
+the database, the disable event was delivered, and each Gateway consumed the
+credential-cache invalidation event. The database is authoritative; Redis
+alone does not remove a credential from selection.
+
+If a key never reprobes, confirm its stored fatal type is
+`InsufficientBalance`, `ProviderKeyReprobe:Enabled` is true, the initial
+cooldown or `next_reprobe_at` has elapsed, and the Gateway worker can acquire
+the per-key lock. An `InvalidApiKey` classification intentionally requires
+manual action.
+
+If a provider stays disabled after key recovery, determine whether the provider
+was disabled manually. Automatic recovery only clears the exact
+`All provider keys disabled automatically` marker; it will not override an
+operator toggle.
+
+If WebAdmin missed a live message, check the durable notification feed first.
+The system announcement is best effort, while the notification record is the
+authoritative operator signal.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -76,6 +76,12 @@ another provider might survive, Conduit retries the next candidate:
 - **Not retried:** validation and authentication `4xx` responses — a bad request will fail the same
   way everywhere, so there is nothing to gain.
 
+There is a separate, narrower failover layer *inside* the selected provider. A fatal `401`, `402`,
+or `403` from one credential may retry up to two other enabled credentials for that same provider.
+An insufficient-balance failure skips credentials in the same shared account group. This does not
+move the request to another provider mapping; see
+[Provider key auto-disable operations](./operations/provider-key-auto-disable.md).
+
 **Streaming has one hard rule:** a streaming request can fail over only *before its first response
 chunk*. Once any output has been sent to the client, it is never replayed onto a different provider.
 
@@ -113,9 +119,10 @@ no redeploy required.
 
 Everything that is not a chat completion — embeddings, image generation, audio, rerank, and so on —
 uses **deterministic resolution**: the alias resolves to a single mapping, which is used directly.
-There is no scoring and no automatic failover for these request types. If you need redundancy for a
-non-chat model, that is a configuration choice (which mapping the alias points at), not something
-routing decides per request.
+There is no scoring or cross-provider failover for these request types. The selected provider may
+still retry another one of its enabled credentials after a fatal credential/account error. If you
+need redundancy across providers for a non-chat model, that is a configuration choice (which
+mapping the alias points at), not something routing decides per request.
 
 ## Where to go next
 


### PR DESCRIPTION
## Summary
- scope fatal provider errors to the failing key, promoting healthy sibling credentials and disabling the provider only when no enabled key remains
- invalidate credential caches and notify admins on key disable/re-enable transitions
- harden invalid-key thresholds and concurrent disable handling with Redis coordination
- add delayed balance reprobes, shared-account-group propagation, and bounded same-request key failover
- document the disable policy and operator recovery workflow

## Validation
- ConduitLLM.Tests: 3,262 passed, 6 skipped
- BillingInvariantTests: 11 passed
- FaultInjectionTests: 4 passed
- WebAdmin ESLint and TypeScript type-check passed
- EF reports no pending model changes
- full integration project: 48 passed, 1 skipped; 39 configuration-gated tests could not start because local Config/test-config.yaml is absent

## Database
- adds migration 20260724070639_AddProviderKeyNotifications

## Follow-up
- #1203 tracks exposing ProviderAccountGroup in the WebAdmin key editor

Closes #1194
Closes #1195
Closes #1196
Closes #1197
Closes #1198
Closes #1199
Closes #1200
Closes #1201
Closes #1202