### PR TITLE
fix: map Gateway model-routing client errors to 4xx (#1191)

### DIFF
--- a/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.cs
@@ -160,11 +160,13 @@ namespace ConduitLLM.Gateway.Endpoints
             }
             catch (Exception ex)
             {
+                // Observe, then rethrow — OpenAIErrorMiddleware maps exceptions to proper HTTP responses
+                // via ExceptionToResponseMapper. Returning a 500 here instead turned model-routing client
+                // errors (unknown alias, disabled mapping/provider) into 500s and leaked ex.Message (#1191).
                 activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 activity?.SetTag("error.type", ex.GetType().Name);
-                _logger.LogError(ex, "Error processing request");
                 GatewayOpsMetrics.RecordLlmOperation("chat_completion", request.Model, "error", operationStopwatch.Elapsed.TotalSeconds);
-                return OpenAIError(500, ex.Message, "internal_error", "server_error");
+                throw;
             }
         }
 

--- a/Services/ConduitLLM.Gateway/Endpoints/GatewayApiEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/GatewayApiEndpoints.cs
@@ -101,7 +101,7 @@ public static class GatewayApiEndpoints
         app.MapPost("/v1/embeddings", ([FromServices] EmbeddingsEndpoints endpoints, EmbeddingRequest request, CancellationToken cancellationToken) => endpoints.CreateEmbedding(request, cancellationToken))
             .RequireAuthorization("VirtualKeyAuthentication").AddEndpointFilter<RequireBalanceEndpointFilter>()
             .AddEndpointFilter<OperationLoggingEndpointFilter>().WithTags("Embeddings").WithName("Embeddings_Create")
-            .Produces<EmbeddingResponse>().Produces<OpenAIErrorResponse>(400).Produces<OpenAIErrorResponse>(500);
+            .Produces<EmbeddingResponse>().Produces<OpenAIErrorResponse>(400).Produces<OpenAIErrorResponse>(404).Produces<OpenAIErrorResponse>(500);
 
         var audio = app.MapGroup("/v1/audio")
             .RequireAuthorization("VirtualKeyAuthentication")
@@ -189,6 +189,7 @@ public static class GatewayApiEndpoints
             .WithTags("Chat").WithName("Chat_CreateCompletion")
             .Produces<ChatCompletionResponse>(200, "application/json")
             .Produces<OpenAIErrorResponse>(400)
+            .Produces<OpenAIErrorResponse>(404)
             .Produces<OpenAIErrorResponse>(500);
 
         app.MapPost("/v1/responses", ([FromServices] ResponsesEndpoints endpoints, CreateResponseRequest request, CancellationToken cancellationToken) => endpoints.CreateResponse(request, cancellationToken))
@@ -202,6 +203,7 @@ public static class GatewayApiEndpoints
             .Produces<OpenAIErrorResponse>(401)
             .Produces<OpenAIErrorResponse>(402)
             .Produces<OpenAIErrorResponse>(403)
+            .Produces<OpenAIErrorResponse>(404)
             .Produces<OpenAIErrorResponse>(429)
             .Produces<OpenAIErrorResponse>(500);
 

--- a/Services/ConduitLLM.Gateway/Endpoints/RequireBalanceEndpointFilter.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/RequireBalanceEndpointFilter.cs
@@ -43,30 +43,19 @@ public sealed class RequireBalanceEndpointFilter : IEndpointFilter
                 "authentication_error");
         }
 
+        VirtualKeyValidationOutcome validation;
         try
         {
             var model = httpContext.Request.RouteValues.TryGetValue("model", out var modelValue)
                 ? modelValue?.ToString()
                 : null;
-            var validation = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKey, model);
-            if (!validation.IsValid || validation.Key is null)
-            {
-                _logger.LogWarning(
-                    "Virtual key validation failed with {FailureCode} during balance check for key prefix {KeyPrefix}",
-                    validation.FailureCode ?? "unknown",
-                    LoggingSanitizer.S(virtualKey[..Math.Min(10, virtualKey.Length)]));
-                return GatewayResults.OpenAIError(
-                    validation.HttpStatusCode,
-                    validation.Reason ?? "Virtual key validation failed.",
-                    validation.FailureCode ?? VirtualKeyValidationFailureCodes.ValidationError,
-                    GetErrorType(validation.HttpStatusCode));
-            }
-
-            httpContext.Items["ValidatedVirtualKey"] = validation.Key;
-            return await next(context);
+            validation = await _virtualKeyService.ValidateVirtualKeyAsync(virtualKey, model);
         }
         catch (Exception ex)
         {
+            // Scoped deliberately to the balance check only. Downstream exceptions must NOT be caught
+            // here — OpenAIErrorMiddleware maps them to their real status via ExceptionToResponseMapper,
+            // and swallowing them turned every client error on 9 route groups into a 500 (#1191).
             _logger.LogError(ex, "Error during balance authorization check");
             return GatewayResults.OpenAIError(
                 StatusCodes.Status500InternalServerError,
@@ -74,6 +63,22 @@ public sealed class RequireBalanceEndpointFilter : IEndpointFilter
                 "balance_check_error",
                 "server_error");
         }
+
+        if (!validation.IsValid || validation.Key is null)
+        {
+            _logger.LogWarning(
+                "Virtual key validation failed with {FailureCode} during balance check for key prefix {KeyPrefix}",
+                validation.FailureCode ?? "unknown",
+                LoggingSanitizer.S(virtualKey[..Math.Min(10, virtualKey.Length)]));
+            return GatewayResults.OpenAIError(
+                validation.HttpStatusCode,
+                validation.Reason ?? "Virtual key validation failed.",
+                validation.FailureCode ?? VirtualKeyValidationFailureCodes.ValidationError,
+                GetErrorType(validation.HttpStatusCode));
+        }
+
+        httpContext.Items["ValidatedVirtualKey"] = validation.Key;
+        return await next(context);
     }
 
     private static string GetErrorType(int statusCode) => statusCode switch

--- a/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
@@ -162,15 +162,8 @@ public sealed class ResponsesEndpoints : GatewayEndpointHandlerBase
                 mapped.Code,
                 mapped.Type);
         }
-        catch (Exception exception)
-        {
-            Logger.LogError(exception, "Responses request failed for model {Model}", chatRequest.Model);
-            return GatewayResults.OpenAIError(
-                StatusCodes.Status500InternalServerError,
-                "The Responses request could not be completed.",
-                "internal_error",
-                "server_error");
-        }
+        // No blanket catch: OpenAIErrorMiddleware maps exceptions to proper HTTP responses via
+        // ExceptionToResponseMapper. A catch-all 500 here masked model-routing client errors (#1191).
     }
 
     internal static ResponseTranslation Translate(CreateResponseRequest request)

--- a/Services/ConduitLLM.Gateway/Program.Configuration.cs
+++ b/Services/ConduitLLM.Gateway/Program.Configuration.cs
@@ -12,6 +12,11 @@ public partial class Program
 
         builder.Services.ConfigureHttpJsonOptions(options =>
             GatewayJsonOptions.Configure(options.SerializerOptions));
+
+        // Surface request-binding failures as BadHttpRequestException so OpenAIErrorMiddleware can
+        // answer with the OpenAI error envelope. Without this, a malformed or incomplete body returns
+        // a bare 400 with an empty body, which is not a valid OpenAI-compatible error response (#1191).
+        builder.Services.Configure<RouteHandlerOptions>(options => options.ThrowOnBadRequest = true);
         builder.Services.AddSingleton(services =>
             services
                 .GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>()

--- a/Services/ConduitLLM.Gateway/openapi-gateway.json
+++ b/Services/ConduitLLM.Gateway/openapi-gateway.json
@@ -637,6 +637,24 @@
               }
             }
           },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "x-request-id": {
+                "description": "Request identifier for support and distributed tracing.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAIErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "headers": {
@@ -825,6 +843,24 @@
           },
           "400": {
             "description": "Bad Request",
+            "headers": {
+              "x-request-id": {
+                "description": "Request identifier for support and distributed tracing.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "headers": {
               "x-request-id": {
                 "description": "Request identifier for support and distributed tracing.",
@@ -1084,6 +1120,24 @@
           },
           "403": {
             "description": "Forbidden",
+            "headers": {
+              "x-request-id": {
+                "description": "Request identifier for support and distributed tracing.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "headers": {
               "x-request-id": {
                 "description": "Request identifier for support and distributed tracing.",

--- a/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
+++ b/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace ConduitLLM.Core.Exceptions;
@@ -55,6 +56,18 @@ public static class ExceptionToResponseMapper
             InvalidRequestException invalidReq
                 => new(400, invalidReq.Message, invalidReq.ErrorCode ?? "invalid_request", LogLevel.Warning,
                     "Invalid request", true, "invalid_request_error", invalidReq.Param),
+
+            // Thrown by ValidationHelper / ToolValidation with user-facing parameter messages.
+            // Note: derives from Exception, not ConduitException.
+            ValidationException validationEx
+                => new(400, validationEx.Message, "validation_error", LogLevel.Warning,
+                    "Validation error", true, "invalid_request_error"),
+
+            // The provider reported the model as missing (e.g. an upstream 404).
+            // Note: derives from Exception, not ConduitException.
+            ModelUnavailableException modelUnavailableEx
+                => new(404, modelUnavailableEx.Message, "model_not_found", LogLevel.Warning,
+                    "Model unavailable", true, "invalid_request_error", "model"),
 
             RequestTimeoutException timeoutEx
                 => new(408, timeoutEx.Message, "request_timeout", LogLevel.Warning,
@@ -115,6 +128,13 @@ public static class ExceptionToResponseMapper
             NotImplementedException
                 => new(501, "Feature not implemented", "not_implemented", LogLevel.Warning,
                     "Not implemented", false, "server_error"),
+
+            // Raised by minimal-API model binding when the request body is malformed or missing a
+            // required member (400), or exceeds the body size limit (413). The framework message names
+            // internal types, so it is redacted. Keep ahead of the catch-all.
+            BadHttpRequestException badRequestEx
+                => new(badRequestEx.StatusCode, "The request body could not be read", "invalid_request_body",
+                    LogLevel.Warning, "Malformed request", false, "invalid_request_error"),
 
             // Catch-all for unexpected exceptions
             _ => new(500, "An unexpected error occurred", "internal_error", LogLevel.Error,

--- a/Shared/ConduitLLM.Core/Middleware/ExceptionHandlingMiddlewareBase.cs
+++ b/Shared/ConduitLLM.Core/Middleware/ExceptionHandlingMiddlewareBase.cs
@@ -74,27 +74,29 @@ public abstract class ExceptionHandlingMiddlewareBase
             // Body capture should never prevent error handling
         }
 
+        // Map exception using the shared mapper. Mapped first so the log severity matches the
+        // response: client errors (404 model_not_found, 400 invalid_request) must not be logged as
+        // errors, or every unknown-model request pages an operator.
+        var mapping = ExceptionToResponseMapper.Map(exception);
+
         // Log with or without body
         if (requestBody != null)
         {
-            Logger.LogError(exception,
-                "Unhandled exception caught by {MiddlewareName}. TraceId: {TraceId}, Method: {Method}, Path: {Path}, RequestBody: {RequestBody}",
-                MiddlewareName, traceId,
+            Logger.Log(mapping.LogLevel, exception,
+                "{LogPrefix} caught by {MiddlewareName}. TraceId: {TraceId}, Method: {Method}, Path: {Path}, RequestBody: {RequestBody}",
+                mapping.LogPrefix, MiddlewareName, traceId,
                 LoggingSanitizer.S(context.Request.Method),
                 LoggingSanitizer.S(context.Request.Path.ToString()),
                 requestBody);
         }
         else
         {
-            Logger.LogError(exception,
-                "Unhandled exception caught by {MiddlewareName}. TraceId: {TraceId}, Method: {Method}, Path: {Path}",
-                MiddlewareName, traceId,
+            Logger.Log(mapping.LogLevel, exception,
+                "{LogPrefix} caught by {MiddlewareName}. TraceId: {TraceId}, Method: {Method}, Path: {Path}",
+                mapping.LogPrefix, MiddlewareName, traceId,
                 LoggingSanitizer.S(context.Request.Method),
                 LoggingSanitizer.S(context.Request.Path.ToString()));
         }
-
-        // Map exception using the shared mapper
-        var mapping = ExceptionToResponseMapper.Map(exception);
 
         // In development, show actual exception messages for redacted responses
         var message = mapping.IncludeExceptionMessageInLog

--- a/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
+++ b/Shared/ConduitLLM.Providers/DatabaseAwareLLMClientFactory.cs
@@ -74,7 +74,16 @@ namespace ConduitLLM.Providers
         {
             var mappings = await _mappingService.GetMappingsByModelAliasAsync(request.Model);
             if (mappings.Count == 0)
-                throw new ModelNotFoundException(request.Model, $"Model '{request.Model}' not found. Please check your model configuration.");
+                throw new ModelNotFoundException(request.Model, ModelUnavailableMessage(request.Model));
+
+            // Administratively disabled routes make the alias unavailable to the client — that is a 404,
+            // not a retryable 503. Only route *health* exhaustion (open circuit below, or no usable
+            // credential further down) is 503. Collapsing both into one 503 was part of #1191.
+            var configured = mappings.Where(mapping => mapping.IsEnabled
+                && mapping.Provider?.IsEnabled == true
+                && mapping.ModelProviderTypeAssociation?.IsEnabled == true).ToList();
+            if (configured.Count == 0)
+                throw new ModelNotFoundException(request.Model, ModelUnavailableMessage(request.Model));
 
             var settings = _serviceProvider.GetService<IGlobalSettingsCacheService>();
             var switchValue = settings is null ? null : await settings.GetSettingValueAsync("Routing.Chat.Enabled");
@@ -82,8 +91,7 @@ namespace ConduitLLM.Providers
             var policy = await GetRoutePolicyAsync(request.Model, cancellationToken);
             if (routingEnabled && _logger.IsEnabled(LogLevel.Debug))
             {
-                foreach (var mapping in mappings.Where(mapping => mapping.IsEnabled && mapping.Provider?.IsEnabled == true &&
-                    mapping.ModelProviderTypeAssociation?.IsEnabled == true && !RouteCircuitRegistry.IsAvailable(mapping.Id)))
+                foreach (var mapping in configured.Where(mapping => !RouteCircuitRegistry.IsAvailable(mapping.Id)))
                 {
                     _logger.LogDebug(
                         "Excluding provider mapping {MappingId} for model {ModelAlias} because its route circuit is open or a recovery probe is already in progress",
@@ -91,8 +99,10 @@ namespace ConduitLLM.Providers
                         request.Model);
                 }
             }
-            var scored = routingEnabled ? BalancedRouteScorer.Score(mappings, policy) :
-                mappings.OrderBy(mapping => mapping.Id).Take(1).Select(mapping => new ScoredRoute(mapping, 0.5m)).ToArray();
+            // Both branches route over `configured` so that turning routing off never selects a
+            // mapping an operator has disabled.
+            var scored = routingEnabled ? BalancedRouteScorer.Score(configured, policy) :
+                configured.OrderBy(mapping => mapping.Id).Take(1).Select(mapping => new ScoredRoute(mapping, 0.5m)).ToArray();
             if (scored.Count == 0)
                 throw new ServiceUnavailableException($"No healthy provider route for model '{request.Model}'.", "Routing");
 
@@ -129,6 +139,14 @@ namespace ConduitLLM.Providers
             request.SelectedMappingId = routes[0].Item1.Id;
             return new RoutedChatClient(routes, request, _distributedCache, policy, _logger);
         }
+
+        /// <summary>
+        /// Client-facing message for an alias that has no route: either it does not exist or every
+        /// route for it is administratively disabled. Deliberately does not distinguish the two, and
+        /// deliberately avoids hinting at server configuration.
+        /// </summary>
+        private static string ModelUnavailableMessage(string modelAlias) =>
+            $"The model '{modelAlias}' does not exist or is not available.";
 
         private async Task<ModelRoutePolicy> GetRoutePolicyAsync(string alias, CancellationToken cancellationToken)
         {
@@ -173,7 +191,7 @@ namespace ConduitLLM.Providers
             if (mapping == null)
             {
                 _logger.LogWarning("No model mapping found in database for alias: {ModelAlias}", modelName);
-                throw new ModelNotFoundException(modelName, $"Model '{modelName}' not found. Please check your model configuration.");
+                throw new ModelNotFoundException(modelName, ModelUnavailableMessage(modelName));
             }
 
             _logger.LogDebug("Found mapping in database: {ModelAlias} -> ProviderId:{ProviderId}/{ProviderModelId}",

--- a/Tests/ConduitLLM.IntegrationTests/Core/TestConfiguration.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/TestConfiguration.cs
@@ -100,7 +100,13 @@ public class ValidationConfig
 // Test context for sharing state between test steps
 public class TestContext
 {
-    public string TestRunId { get; set; } = $"TEST_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
+    // Second resolution alone is not unique: xUnit constructs a TestContext per test, and two tests
+    // starting within the same second produced the *same* model alias. Because an alias may legitimately
+    // carry several mappings (multi-provider routing), one test's disabled mapping and another's enabled
+    // mapping then collided under one alias and the tests interfered. Milliseconds plus a random suffix
+    // keep every test's provider/key/alias/group names distinct.
+    public string TestRunId { get; set; } =
+        $"TEST_{DateTime.UtcNow:yyyyMMdd_HHmmssfff}_{Guid.NewGuid():N}"[..34];
     public int? ProviderId { get; set; }
     public string? ProviderKeyId { get; set; }
     public int? ModelMappingId { get; set; }

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/ProviderFailoverIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/ProviderFailoverIntegrationTests.cs
@@ -81,8 +81,11 @@ public class ProviderFailoverIntegrationTests : CriticalPathTestBase
 
         // Assert
         response.Success.Should().BeFalse("Request to provider with invalid key should fail");
-        response.StatusCode.Should().BeOneOf(new[] { 401, 403, 500, 502 },
-            "Should return auth error or server error from provider");
+        // 500 is deliberately not accepted: tolerating it is what let #1191 hide, since the Gateway
+        // returned 500 for every routing failure. A rejected provider credential is a provider
+        // communication error, which maps to 502 (see ChatEndpoints.MapProviderCommunicationError).
+        response.StatusCode.Should().BeOneOf(new[] { 401, 403, 502 },
+            "Should surface the provider's auth failure, not a generic server error");
 
         _output.WriteLine($"Invalid key correctly handled: {response.StatusCode}");
 

--- a/Tests/ConduitLLM.Tests/Admin/Middleware/AdminExceptionMiddlewareTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Middleware/AdminExceptionMiddlewareTests.cs
@@ -302,10 +302,10 @@ namespace ConduitLLM.Tests.Admin.Middleware
         }
 
         [Fact]
-        public async Task LogsError_WithExceptionAndRequestDetails()
+        public async Task LogsServerError_AtErrorLevel_WithExceptionAndRequestDetails()
         {
-            // Arrange
-            var exception = new InvalidOperationException("something broke");
+            // Arrange — ConfigurationException maps to 500, so it is a genuine operator concern.
+            var exception = new ConfigurationException("something broke");
             _mockNext.Setup(x => x(It.IsAny<HttpContext>()))
                 .ThrowsAsync(exception);
 
@@ -315,7 +315,7 @@ namespace ConduitLLM.Tests.Admin.Middleware
             // Act
             await _middleware.InvokeAsync(_httpContext);
 
-            // Assert — LogError was called with the exception
+            // Assert — logged at Error with the exception and the trace id
             _mockLogger.Verify(
                 x => x.Log(
                     LogLevel.Error,
@@ -324,6 +324,41 @@ namespace ConduitLLM.Tests.Admin.Middleware
                     exception,
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
+        }
+
+        [Fact]
+        public async Task LogsClientError_AtWarningLevel_NotErrorLevel()
+        {
+            // The log severity must track the mapped status: a 4xx is the caller's problem, not the
+            // operator's. Logging every unknown model or malformed body at Error buries real faults.
+            var exception = new InvalidOperationException("something the caller did");
+            _mockNext.Setup(x => x(It.IsAny<HttpContext>()))
+                .ThrowsAsync(exception);
+
+            _httpContext.Request.Method = "POST";
+            _httpContext.Request.Path = "/api/providers";
+
+            await _middleware.InvokeAsync(_httpContext);
+
+            Assert.Equal(400, _httpContext.Response.StatusCode);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("test-trace-id")),
+                    exception,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
@@ -4,6 +4,7 @@ using ConduitLLM.Core.Exceptions;
 
 using FluentAssertions;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace ConduitLLM.Tests.Core.Exceptions;
@@ -435,6 +436,82 @@ public class ExceptionToResponseMapperTests
         result.LogPrefix.Should().Be("Configuration error");
         result.IncludeExceptionMessageInLog.Should().BeFalse();
         result.OpenAIErrorType.Should().Be("server_error");
+    }
+
+    [Fact]
+    public void Map_ValidationException_Returns400WithValidationError()
+    {
+        // Arrange
+        var exception = new ValidationException("messages collection cannot be null or empty");
+
+        // Act
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        // Assert
+        result.StatusCode.Should().Be(400);
+        result.ErrorCode.Should().Be("validation_error");
+        result.ResponseMessage.Should().Be("messages collection cannot be null or empty");
+        result.LogLevel.Should().Be(LogLevel.Warning);
+        result.LogPrefix.Should().Be("Validation error");
+        result.IncludeExceptionMessageInLog.Should().BeTrue();
+        result.OpenAIErrorType.Should().Be("invalid_request_error");
+    }
+
+    [Fact]
+    public void Map_ModelUnavailableException_Returns404WithModelNotFound()
+    {
+        // Arrange
+        var exception = new ModelUnavailableException("Model 'llama-4' not found for provider Groq");
+
+        // Act
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        // Assert
+        result.StatusCode.Should().Be(404);
+        result.ErrorCode.Should().Be("model_not_found");
+        result.ResponseMessage.Should().Contain("llama-4");
+        result.LogLevel.Should().Be(LogLevel.Warning);
+        result.LogPrefix.Should().Be("Model unavailable");
+        result.IncludeExceptionMessageInLog.Should().BeTrue();
+        result.OpenAIErrorType.Should().Be("invalid_request_error");
+        result.Param.Should().Be("model");
+    }
+
+    #endregion
+
+    #region Framework Binding Exception Tests
+
+    [Fact]
+    public void Map_BadHttpRequestException_Returns400WithRedactedMessage()
+    {
+        // Minimal-API model binding raises this when the body is malformed or missing a
+        // required member. The framework message names internal types, so it is not echoed.
+        var exception = new BadHttpRequestException(
+            "JSON deserialization for type 'ConduitLLM.Core.Models.ChatCompletionRequest' was missing required properties, including: messages.");
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(400);
+        result.ErrorCode.Should().Be("invalid_request_body");
+        result.ResponseMessage.Should().Be("The request body could not be read");
+        result.ResponseMessage.Should().NotContain("ConduitLLM.Core.Models");
+        result.LogLevel.Should().Be(LogLevel.Warning);
+        result.LogPrefix.Should().Be("Malformed request");
+        result.IncludeExceptionMessageInLog.Should().BeFalse();
+        result.OpenAIErrorType.Should().Be("invalid_request_error");
+    }
+
+    [Fact]
+    public void Map_BadHttpRequestException_PreservesNon400StatusCode()
+    {
+        // A request body over the configured size limit surfaces as 413, not 400.
+        var exception = new BadHttpRequestException("Request body too large.", StatusCodes.Status413PayloadTooLarge);
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(413);
+        result.ErrorCode.Should().Be("invalid_request_body");
+        result.OpenAIErrorType.Should().Be("invalid_request_error");
     }
 
     #endregion

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ChatEndpointErrorStatusTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ChatEndpointErrorStatusTests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Core;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Gateway.Options;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+namespace ConduitLLM.Tests.Gateway.Endpoints;
+
+/// <summary>
+/// End-to-end status-code contract for <c>POST /v1/chat/completions</c> (#1191).
+///
+/// These run over the real minimal-API pipeline — endpoint filters, the endpoint handler and
+/// OpenAIErrorMiddleware — because the bug lived in the seams between them, not in any one unit.
+/// <see cref="ExceptionToResponseMapper"/> already mapped ModelNotFoundException to 404 and had a
+/// passing unit test, yet the live endpoint answered 500: two blanket catch handlers
+/// (ChatEndpoints and RequireBalanceEndpointFilter) converted the exception first.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "GatewayErrorContract")]
+public sealed class ChatEndpointErrorStatusTests
+{
+    [Fact]
+    public async Task ModelNotFoundException_Returns404ModelNotFound()
+    {
+        var response = await PostChatAsync(
+            new ModelNotFoundException("ghost-model", "The model 'ghost-model' does not exist or is not available."));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await ReadErrorAsync(response);
+        error.Code.Should().Be("model_not_found");
+        error.Type.Should().Be("invalid_request_error");
+        error.Param.Should().Be("model");
+        error.Message.Should().Contain("ghost-model");
+    }
+
+    [Fact]
+    public async Task ServiceUnavailableException_Returns503()
+    {
+        // Route health exhaustion (open circuit / no usable credential) stays retryable.
+        var response = await PostChatAsync(
+            new ServiceUnavailableException("No healthy provider route for model 'test-model'.", "Routing"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        var error = await ReadErrorAsync(response);
+        error.Code.Should().Be("service_unavailable");
+    }
+
+    [Fact]
+    public async Task ValidationException_Returns400()
+    {
+        var response = await PostChatAsync(new ValidationException("messages collection cannot be null or empty"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var error = await ReadErrorAsync(response);
+        error.Code.Should().Be("validation_error");
+        error.Type.Should().Be("invalid_request_error");
+    }
+
+    [Fact]
+    public async Task RateLimitExceededException_Returns429WithRetryAfter()
+    {
+        var response = await PostChatAsync(
+            new RateLimitExceededException("Provider rate limit reached.", retryAfterSeconds: 30));
+
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter?.Delta.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Theory]
+    [InlineData(typeof(ModelNotFoundException))]
+    [InlineData(typeof(ServiceUnavailableException))]
+    [InlineData(typeof(ValidationException))]
+    public async Task ClientErrors_AreNeverReportedAsBalanceCheckFailures(Type exceptionType)
+    {
+        // Guards the RequireBalanceEndpointFilter regression: it used to wrap next(context) in its
+        // own try/catch, so every downstream exception came back as 500 balance_check_error.
+        Exception exception = exceptionType == typeof(ModelNotFoundException)
+            ? new ModelNotFoundException("test-model")
+            : exceptionType == typeof(ServiceUnavailableException)
+                ? new ServiceUnavailableException("No healthy provider route.", "Routing")
+                : new ValidationException("bad input");
+
+        var response = await PostChatAsync(exception);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.InternalServerError);
+
+        var error = await ReadErrorAsync(response);
+        error.Code.Should().NotBe("balance_check_error");
+        error.Code.Should().NotBe("internal_error");
+    }
+
+    [Fact]
+    public async Task UnexpectedException_Returns500WithRedactedMessage()
+    {
+        // The catch-all still yields 500 — but must not echo internals back to the caller,
+        // which the removed blanket catch did via OpenAIError(500, ex.Message, ...).
+        var response = await PostChatAsync(
+            new InvalidCastException("Unable to cast Npgsql.Internal.SecretConnectionString"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+
+        var error = await ReadErrorAsync(response);
+        error.Code.Should().Be("internal_error");
+        error.Type.Should().Be("server_error");
+        error.Message.Should().Be("An unexpected error occurred");
+        error.Message.Should().NotContain("Npgsql");
+    }
+
+    [Fact]
+    public async Task BodyMissingRequiredMessages_Returns400WithOpenAIEnvelope()
+    {
+        // Minimal-API binding failure. Before ThrowOnBadRequest this was a bare 400 with an
+        // empty body — not a valid OpenAI-compatible error response.
+        await using var host = await StartHostAsync(new ModelNotFoundException("unused"));
+
+        using var content = new StringContent(
+            """{"model":"test-model"}""", Encoding.UTF8, "application/json");
+        var response = await host.Client.PostAsync("/v1/chat/completions", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var error = await ReadErrorAsync(response);
+        error.Should().NotBeNull();
+        error.Code.Should().Be("invalid_request_body");
+        error.Type.Should().Be("invalid_request_error");
+        error.Message.Should().NotContain("ConduitLLM.Core.Models");
+    }
+
+    // -----------------------------------------------------------------------------------------
+
+    private static async Task<HttpResponseMessage> PostChatAsync(Exception routingFailure)
+    {
+        await using var host = await StartHostAsync(routingFailure);
+
+        return await host.Client.PostAsJsonAsync("/v1/chat/completions", new
+        {
+            model = "test-model",
+            messages = new[] { new { role = "user", content = "Hello" } }
+        });
+    }
+
+    /// <summary>
+    /// Boots the Gateway endpoint pipeline with a client factory that fails model resolution,
+    /// which is where every condition in #1191 originates.
+    /// </summary>
+    private static Task<GatewayEndpointTestHost> StartHostAsync(Exception routingFailure)
+    {
+        var clientFactory = new Mock<ILLMClientFactory>();
+        clientFactory
+            .Setup(factory => factory.GetClientForChatAsync(
+                It.IsAny<ChatCompletionRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(routingFailure);
+        clientFactory
+            .Setup(factory => factory.GetClientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(routingFailure);
+
+        var mappingService = new Mock<IModelProviderMappingService>();
+        mappingService
+            .Setup(service => service.GetMappingByModelAliasAsync(It.IsAny<string>()))
+            .ReturnsAsync((ModelProviderMapping?)null);
+
+        // The balance filter must pass through so the request actually reaches the handler.
+        var virtualKeyService = new Mock<IVirtualKeyService>();
+        virtualKeyService
+            .Setup(service => service.ValidateVirtualKeyAsync(It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(VirtualKeyValidationOutcome.Success(new VirtualKey
+            {
+                Id = 1,
+                KeyName = "test-key",
+                KeyHash = "hash"
+            }));
+
+        return GatewayEndpointTestHost.StartAsync(services =>
+        {
+            services.AddSingleton(clientFactory.Object);
+            services.AddSingleton(mappingService.Object);
+            services.AddSingleton(GatewayJsonOptions.Create());
+            services.AddSingleton(Mock.Of<IEventBus>());
+            services.AddSingleton(Mock.Of<IGlobalSettingsCacheService>());
+            services.AddSingleton(Mock.Of<IUsageEstimationService>());
+            services.AddSingleton(virtualKeyService.Object);
+            services.AddScoped<Conduit>();
+        });
+    }
+
+    private static async Task<OpenAIError> ReadErrorAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        payload.Should().NotBeEmpty("every Gateway error must carry an OpenAI error envelope");
+
+        var envelope = JsonSerializer.Deserialize<OpenAIErrorResponse>(
+            payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        envelope.Should().NotBeNull();
+        return envelope!.Error;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayEndpointTestHost.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayEndpointTestHost.cs
@@ -2,10 +2,12 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Middleware;
 using ConduitLLM.Gateway.Endpoints;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -36,6 +38,9 @@ internal sealed class GatewayEndpointTestHost : IAsyncDisposable
                 {
                     services.AddLogging();
                     services.AddRouting();
+                    // Mirrors Program.Configuration.cs so binding failures surface as
+                    // BadHttpRequestException and get the OpenAI error envelope.
+                    services.Configure<RouteHandlerOptions>(options => options.ThrowOnBadRequest = true);
                     services.AddGatewayEndpointHandlers();
                     services.AddSingleton(Mock.Of<IMediaStorageService>());
                     services.AddSingleton(Mock.Of<IMediaRecordRepository>());
@@ -61,6 +66,9 @@ internal sealed class GatewayEndpointTestHost : IAsyncDisposable
                     app.UseRouting();
                     app.UseAuthentication();
                     app.UseAuthorization();
+                    // Mirrors Program.Middleware.cs: the error middleware sits below auth and above
+                    // the endpoints, so endpoint exceptions map to OpenAI-shaped error responses.
+                    app.UseOpenAIErrorHandling();
                     app.UseEndpoints(endpoints => endpoints.MapGatewayApiEndpoints());
                 });
             })

--- a/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/DatabaseAwareLLMClientFactoryTests.cs
@@ -56,9 +56,113 @@ namespace ConduitLLM.Tests.Providers
                 async () => await _factory.GetClientAsync(modelName)
             );
 
-            Assert.Equal($"Model '{modelName}' not found. Please check your model configuration.", exception.Message);
+            Assert.Equal($"The model '{modelName}' does not exist or is not available.", exception.Message);
             Assert.Equal(modelName, exception.ModelName);
         }
+
+        // ---------------------------------------------------------------------
+        // GetClientForChatAsync route eligibility (#1191).
+        // Administratively disabled routes make the alias unavailable to the client: 404
+        // (ModelNotFoundException). Only route *health* exhaustion is a retryable 503.
+        // ---------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetClientForChatAsync_WithNoMappings_ThrowsModelNotFoundException()
+        {
+            var request = new ConduitLLM.Core.Models.ChatCompletionRequest
+            {
+                Model = "unmapped-model",
+                Messages = []
+            };
+            _mockMappingService.Setup(x => x.GetMappingsByModelAliasAsync(request.Model))
+                .ReturnsAsync(new List<ModelProviderMapping>());
+
+            var exception = await Assert.ThrowsAsync<ModelNotFoundException>(
+                () => _factory.GetClientForChatAsync(request));
+
+            Assert.Equal($"The model '{request.Model}' does not exist or is not available.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GetClientForChatAsync_WithDisabledMapping_ThrowsModelNotFoundException()
+        {
+            var request = NewChatRequest();
+            _mockMappingService.Setup(x => x.GetMappingsByModelAliasAsync(request.Model))
+                .ReturnsAsync([NewRoutableMapping(1, mappingEnabled: false)]);
+
+            var exception = await Assert.ThrowsAsync<ModelNotFoundException>(
+                () => _factory.GetClientForChatAsync(request));
+
+            Assert.Equal($"The model '{request.Model}' does not exist or is not available.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GetClientForChatAsync_WithDisabledProvider_ThrowsModelNotFoundException()
+        {
+            var request = NewChatRequest();
+            _mockMappingService.Setup(x => x.GetMappingsByModelAliasAsync(request.Model))
+                .ReturnsAsync([NewRoutableMapping(1, providerEnabled: false)]);
+
+            await Assert.ThrowsAsync<ModelNotFoundException>(
+                () => _factory.GetClientForChatAsync(request));
+        }
+
+        [Fact]
+        public async Task GetClientForChatAsync_WithDisabledTypeAssociation_ThrowsModelNotFoundException()
+        {
+            var request = NewChatRequest();
+            _mockMappingService.Setup(x => x.GetMappingsByModelAliasAsync(request.Model))
+                .ReturnsAsync([NewRoutableMapping(1, associationEnabled: false)]);
+
+            await Assert.ThrowsAsync<ModelNotFoundException>(
+                () => _factory.GetClientForChatAsync(request));
+        }
+
+        [Fact]
+        public async Task GetClientForChatAsync_WithEnabledMappingButNoCredential_ThrowsServiceUnavailableException()
+        {
+            // The route is configured, so this is genuine health exhaustion — 503, not 404.
+            var request = NewChatRequest();
+            _mockMappingService.Setup(x => x.GetMappingsByModelAliasAsync(request.Model))
+                .ReturnsAsync([NewRoutableMapping(1)]);
+            _mockCredentialService.Setup(x => x.GetProviderByIdAsync(1))
+                .ReturnsAsync((Provider?)null);
+
+            await Assert.ThrowsAsync<ServiceUnavailableException>(
+                () => _factory.GetClientForChatAsync(request));
+        }
+
+        private static ConduitLLM.Core.Models.ChatCompletionRequest NewChatRequest() => new()
+        {
+            Model = "test-model",
+            Messages = []
+        };
+
+        private static ModelProviderMapping NewRoutableMapping(
+            int id,
+            bool mappingEnabled = true,
+            bool providerEnabled = true,
+            bool associationEnabled = true) => new()
+            {
+                Id = id,
+                ModelAlias = "test-model",
+                ProviderId = id,
+                ProviderModelId = "gpt-4",
+                IsEnabled = mappingEnabled,
+                ModelProviderTypeAssociationId = id,
+                Provider = new Provider
+                {
+                    Id = id,
+                    ProviderName = "TestProvider",
+                    ProviderType = ProviderType.OpenAI,
+                    IsEnabled = providerEnabled
+                },
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation
+                {
+                    Id = id,
+                    IsEnabled = associationEnabled
+                }
+            };
 
         [Fact]
         public async Task GetClientAsync_WithDisabledProvider_ThrowsServiceUnavailableException()

--- a/WebAdmin/src/generated/gateway-api.ts
+++ b/WebAdmin/src/generated/gateway-api.ts
@@ -1849,6 +1849,17 @@ export interface operations {
           "application/json": components["schemas"]["OpenAIErrorResponse"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          /** @description Request identifier for support and distributed tracing. */
+          "x-request-id"?: string;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OpenAIErrorResponse"];
+        };
+      };
       /** @description The request timed out. */
       408: {
         headers: {
@@ -1959,6 +1970,17 @@ export interface operations {
       };
       /** @description The authenticated key is not authorized for this operation. */
       403: {
+        headers: {
+          /** @description Request identifier for support and distributed tracing. */
+          "x-request-id"?: string;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OpenAIErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
         headers: {
           /** @description Request identifier for support and distributed tracing. */
           "x-request-id"?: string;
@@ -2089,6 +2111,17 @@ export interface operations {
       };
       /** @description Forbidden */
       403: {
+        headers: {
+          /** @description Request identifier for support and distributed tracing. */
+          "x-request-id"?: string;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["OpenAIErrorResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
         headers: {
           /** @description Request identifier for support and distributed tracing. */
           "x-request-id"?: string;

--- a/docs/api-guides/gateway-route-namespaces.md
+++ b/docs/api-guides/gateway-route-namespaces.md
@@ -33,3 +33,40 @@ OpenAI API contract. Conduit-specific extensions live below `/v1/conduit/...`.
 The old extension routes are intentionally not retained as aliases. This keeps
 the generated contract unambiguous and prevents new non-OpenAI resources from
 leaking into the reserved namespace.
+
+## Error contract
+
+Every Gateway error — on `/v1/...` and `/v1/conduit/...` alike — is the OpenAI error
+envelope, and carries the request's `x-request-id` header:
+
+```json
+{ "error": { "message": "...", "type": "invalid_request_error", "code": "model_not_found", "param": "model" } }
+```
+
+Status selection is centralized in `ExceptionToResponseMapper`
+(`Shared/ConduitLLM.Core/Exceptions/`), applied by `OpenAIErrorMiddleware`. Endpoint
+handlers must **not** translate exceptions to status codes themselves: observe (activity
+tags, metrics) and rethrow. A blanket `catch (Exception) → 500` in a handler or an endpoint
+filter silently downgrades every client error to a server error.
+
+| Status | `code` | `type` | Raised by |
+|---|---|---|---|
+| 400 | `invalid_request_body` | `invalid_request_error` | Malformed JSON, or a body missing a required member |
+| 400 | `validation_error` | `invalid_request_error` | `ValidationException` (parameter and tool validation) |
+| 400 | `invalid_request` | `invalid_request_error` | `InvalidRequestException` (`code` overridable) |
+| 401 | `missing_key`, `invalid_key`, `key_disabled`, `key_expired` | `authentication_error` | Virtual-key validation |
+| 402 | `insufficient_balance` | `billing_error` | Balance check, or billing admission in Enforce mode |
+| 403 | `model_not_allowed` | `permission_error` | Key is not permitted to use the requested model |
+| 403 | `forbidden` | `invalid_request_error` | `AuthorizationException` |
+| 404 | `model_not_found` | `invalid_request_error` | Unknown model alias, **or** every route for it administratively disabled |
+| 408 | `request_timeout` | `timeout_error` | `RequestTimeoutException` |
+| 413 | `payload_too_large` | `invalid_request_error` | Body over the endpoint's size limit |
+| 429 | `rate_limit_exceeded` | `rate_limit_error` | Virtual-key or provider rate limit (sends `Retry-After`) |
+| 500 | `internal_error` | `server_error` | Unexpected failure; the message is redacted outside Development |
+| 503 | `service_unavailable` | `service_unavailable` | No **healthy** route: open circuit or no usable provider credential |
+
+`404` versus `503` is the distinction worth remembering: a disabled mapping, provider or
+model/provider-type association means the alias is not available to the caller at all, so it
+is a `404` — the same answer OpenAI gives for a model you cannot access. `503` is reserved
+for routes that are configured and expected to come back, and is therefore the only one of
+the two worth retrying.


### PR DESCRIPTION
Fixes #1191.

## Problem

`/v1/chat/completions` answered **500 `internal_error`** for four client-error conditions: unknown model alias, disabled model mapping, disabled provider, and a malformed request body.

The mapping was never missing. `ExceptionToResponseMapper` already mapped `ModelNotFoundException → 404 model_not_found`, and `OpenAIErrorMiddleware` already emitted the envelope from it — there is even a passing unit test for exactly that (`OpenAIErrorMiddlewareTests.cs:46`). **Two nested blanket `catch (Exception)` handlers converted the exception before the middleware could see it:**

| Where | What it did |
|---|---|
| `ChatEndpoints.cs:161` | `return OpenAIError(500, ex.Message, "internal_error", "server_error")` — also leaked the raw exception message to clients in production |
| `RequireBalanceEndpointFilter.cs:66` | `await next(context)` sat **inside** the filter's `try`; its catch returned 500 `balance_check_error` |

The filter is attached to **nine route groups** (chat, responses, embeddings, audio, images, conduit/images, videos, rerank, functions), so it also defeated `ImagesEndpoints`, which already rethrew on purpose with the comment *"OpenAIErrorMiddleware maps exceptions to proper HTTP responses"*. Fixing the chat handler alone would not have made the tests pass.

## Changes

- **Stop the swallowing.** The balance filter's catch now covers only `ValidateVirtualKeyAsync`; the chat and responses handlers observe (activity tags, metrics) and `throw;`. Status selection lives solely in `ExceptionToResponseMapper`.
- **Unavailable vs unhealthy.** In `DatabaseAwareLLMClientFactory`, a disabled mapping / provider / model-provider-type association means the alias is not available to the caller → `404 model_not_found`, matching OpenAI's answer for a model you cannot access. An open circuit or no usable credential stays `503` — the only genuinely retryable case. Both routing branches now read the filtered list, which also fixes a latent bug: with `Routing.Chat.Enabled=false` the fallback bypassed the enabled filter and would route to a mapping an operator had disabled.
- **Mapper gaps**: `ValidationException` → 400 (38 throw sites in `ValidationHelper`/`ToolValidation`), `ModelUnavailableException` → 404, `BadHttpRequestException` → its own status (400/413) with the framework message redacted. All three previously fell through to the 500 catch-all.
- **`RouteHandlerOptions.ThrowOnBadRequest`** so minimal-API binding failures carry the OpenAI envelope instead of a bare, empty 400.
- **Log severity now tracks the mapped status.** `mapping.LogLevel`/`LogPrefix` already existed on the mapping result and were unused, so every unknown-model request logged at Error.
- **Contract**: 404 declared on `Chat_CreateCompletion`, `Responses_Create`, `Embeddings_Create`; `openapi-gateway.json` and `WebAdmin/src/generated/gateway-api.ts` regenerated. Error contract documented in `docs/api-guides/gateway-route-namespaces.md`.

## A test that was passing *because* of the bug

`ProviderWithInvalidKey_FailsGracefully` flipped to 404 on the first verification run. Not a regression — it was rubber-stamping the defect.

`TestContext.TestRunId` used `yyyyMMdd_HHmmss`, **second resolution**, so two tests starting in the same second built the same model alias. Since an alias may legitimately carry several mappings (multi-provider routing), `ModelMappingDisabled_Returns404`'s deliberately-disabled mapping collided with this test's enabled mapping under one alias. Pre-fix that resolved to `ServiceUnavailableException` → swallowed → 500, and this test's `BeOneOf(401, 403, 500, 502)` accepted it. Confirmed from the DB (two mappings, one alias, one `IsEnabled=f`) and from the logs (a uniquely-named run of the same scenario returned the expected 502).

`TestRunId` now carries milliseconds plus a random suffix, and the assertion no longer accepts 500. The previously "flaky (passes in isolation)" recovery test now passes too — same root cause.

## Test plan

New `ChatEndpointErrorStatusTests` drives the real pipeline — filters, handler and middleware — because the defect lived in the seams between them, where per-unit tests were already green. Restoring the filter's blanket catch turns **8 of its 9 cases red** with `balance_check_error`, so they are genuine regression guards. Also extends `ExceptionToResponseMapperTests` and `DatabaseAwareLLMClientFactoryTests`.

`AdminExceptionMiddlewareTests.LogsError_*` asserted `LogLevel.Error` for an `InvalidOperationException`, which maps to 400; split into a server-error case (Error) and a client-error case (Warning, asserting Error is never used).

Verified live against the dev stack (`./scripts/dev.ps1 -Build`):

| Probe | Result |
|---|---|
| Unknown alias | 404 `model_not_found`, `param: "model"`, `x-request-id` present |
| Unknown alias, `stream: true` | 404 |
| Body missing `messages` | 400 `invalid_request_body` |
| Malformed JSON | 400 `invalid_request_body` |
| `/v1/embeddings`, unknown alias | 404 — **not** 500 `balance_check_error` |
| Group balance after all probes | unchanged |

- Unit suite: 3240 pass / 0 fail / 6 skip
- `CriticalPath=true`: **30/30 pass**, including all four tests named in the issue
- Full integration suite: **83 pass / 1 skip / 4 fail**, up from the #1193 baseline of 78/1/9. The four remaining are the credential rows #1193 documented — 2× Cerebras (placeholder key) and 2× SambaNova (exhausted credits), both surfacing as provider 502s
- `npm run verify:offline` + `validate:openapi` clean, no contract drift; WebAdmin `lint` and `type-check` clean

## Notes

- **Billing is unaffected.** `BillingPolicyHandler` skips billing for any status ≥ 400, so 404 behaves as 500 did. Reservations live only in Redis (`BatchSpendUpdateService.TryReserveSpendAsync` writes a reserved total, a reservations hash and an expiry ZSET); `VirtualKeyGroup.Balance` is only read there, so a routing failure does not move the persisted balance — confirmed by the unchanged probe balance. The indeterminate-reservation hold on this path is byte-identical before and after: the same `UsageTrackingMiddleware` `finally` ran with `InvocationStarted == true` when the endpoint returned a 500 result.
- Streaming is unchanged where it must be: once SSE has started the middleware cannot rewrite the response, so the in-band SSE error event still applies. Before the first chunk, the exception now maps correctly.
- The tokenizer log flood mentioned in the issue's "related noise" section is a different root cause and belongs to #1051, where I added the finding: `TiktokenCounter` caches the successful fallback under a *different* key than it looks up, so every token count re-throws — which is why one request emits dozens of lines. It affects every model, not only Llama.
- Out of scope, noted for follow-up: `UnsupportedProviderException` has no production throw sites; there is still no chat-capability check on the resolved model; and `MapProviderCommunicationError` maps provider 401/403 to 502 rather than passing them through, which diverges from the central mapper but is existing intentional behavior with test coverage.
