### PR TITLE
fix(webadmin): make provider structured settings editable after creat…

### DIFF
--- a/WebAdmin/src/components/providers/ProviderForm.tsx
+++ b/WebAdmin/src/components/providers/ProviderForm.tsx
@@ -187,65 +187,63 @@ export function ProviderForm({ mode, providerId }: ProviderFormProps) {
                     />
                   )}
 
-                  {config && mode === 'add' && (
-                    <>
-                      {config.requiresOrganizationId && (
-                        <TextInput
-                          label="Organization ID"
-                          placeholder={providerTypeNum === ProviderType.OpenAI ? "Optional OpenAI organization ID" : "Enter organization ID"}
-                          required={config.requiresOrganizationId}
-                          autoComplete="off"
-                          aria-autocomplete="none"
-                          list="autocompleteOff"
-                          data-form-type="other"
-                          {...form.getInputProps('organizationId')}
-                          size="md"
-                        />
-                      )}
+                  {config && mode === 'add' && config.requiresOrganizationId && (
+                    <TextInput
+                      label="Organization ID"
+                      placeholder={providerTypeNum === ProviderType.OpenAI ? "Optional OpenAI organization ID" : "Enter organization ID"}
+                      required={config.requiresOrganizationId}
+                      autoComplete="off"
+                      aria-autocomplete="none"
+                      list="autocompleteOff"
+                      data-form-type="other"
+                      {...form.getInputProps('organizationId')}
+                      size="md"
+                    />
+                  )}
 
-                      {config.settings?.map((field) => (
-                        field.secret ? (
-                          <PasswordInput
-                            key={field.key}
-                            label={field.label}
-                            placeholder={field.placeholder ?? ''}
-                            description={field.helpText}
-                            required={field.required}
-                            autoComplete="off"
-                            {...form.getInputProps(`settings.${field.key}`)}
-                            size="md"
-                          />
-                        ) : (
-                          <TextInput
-                            key={field.key}
-                            label={field.label}
-                            placeholder={field.placeholder ?? ''}
-                            description={field.helpText}
-                            required={field.required}
-                            autoComplete="off"
-                            aria-autocomplete="none"
-                            list="autocompleteOff"
-                            data-form-type="other"
-                            {...form.getInputProps(`settings.${field.key}`)}
-                            size="md"
-                          />
-                        )
-                      ))}
+                  {/* Structured settings render in both modes: these identify the provider account
+                      (for example a Cloudflare Account ID) and must stay editable after creation. */}
+                  {config?.settings?.map((field) => (
+                    field.secret ? (
+                      <PasswordInput
+                        key={field.key}
+                        label={field.label}
+                        placeholder={field.placeholder ?? ''}
+                        description={field.helpText}
+                        required={field.required}
+                        autoComplete="off"
+                        {...form.getInputProps(`settings.${field.key}`)}
+                        size="md"
+                      />
+                    ) : (
+                      <TextInput
+                        key={field.key}
+                        label={field.label}
+                        placeholder={field.placeholder ?? ''}
+                        description={field.helpText}
+                        required={field.required}
+                        autoComplete="off"
+                        aria-autocomplete="none"
+                        list="autocompleteOff"
+                        data-form-type="other"
+                        {...form.getInputProps(`settings.${field.key}`)}
+                        size="md"
+                      />
+                    )
+                  ))}
 
-                      {(config.requiresEndpoint || config.supportsCustomEndpoint) && (
-                        <TextInput
-                          label={config.requiresEndpoint ? "API Endpoint" : "Custom API Endpoint"}
-                          placeholder={config.requiresEndpoint ? "https://api.example.com" : "https://api.example.com (optional)"}
-                          required={config.requiresEndpoint}
-                          autoComplete="off"
-                          aria-autocomplete="none"
-                          list="autocompleteOff"
-                          data-form-type="other"
-                          {...form.getInputProps('apiEndpoint')}
-                          size="md"
-                        />
-                      )}
-                    </>
+                  {config && mode === 'add' && (config.requiresEndpoint || config.supportsCustomEndpoint) && (
+                    <TextInput
+                      label={config.requiresEndpoint ? "API Endpoint" : "Custom API Endpoint"}
+                      placeholder={config.requiresEndpoint ? "https://api.example.com" : "https://api.example.com (optional)"}
+                      required={config.requiresEndpoint}
+                      autoComplete="off"
+                      aria-autocomplete="none"
+                      list="autocompleteOff"
+                      data-form-type="other"
+                      {...form.getInputProps('apiEndpoint')}
+                      size="md"
+                    />
                   )}
 
                   <Switch

--- a/WebAdmin/src/components/providers/ProviderFormHandlers.ts
+++ b/WebAdmin/src/components/providers/ProviderFormHandlers.ts
@@ -15,28 +15,60 @@ function getSettingFields(providerType: string) {
   return PROVIDER_CONFIG_REQUIREMENTS[providerType as unknown as ProviderType]?.settings ?? [];
 }
 
-/** Collects non-empty declared settings into the map sent to the backend, or undefined when none. */
-function collectSettings(values: ProviderFormData): Record<string, string> | undefined {
-  const result: Record<string, string> = {};
-  for (const field of getSettingFields(values.providerType)) {
+/**
+ * Collects the structured settings map sent to the backend, or undefined to leave the stored value
+ * untouched (the update endpoint treats null as "no change" and any supplied map as a wholesale
+ * replace).
+ *
+ * Edit mode seeds the map from the values loaded off the provider rather than building it from
+ * scratch, so keys this TypeScript mirror does not yet declare survive that wholesale replace.
+ * Clearing a declared field removes its key, which is how a value gets unset.
+ */
+function collectSettings(
+  values: ProviderFormData,
+  mode: 'add' | 'edit'
+): Record<string, string> | undefined {
+  const fields = getSettingFields(values.providerType);
+  const result: Record<string, string> = mode === 'edit' ? { ...(values.settings ?? {}) } : {};
+
+  for (const field of fields) {
     const raw = values.settings?.[field.key]?.trim() ?? '';
     if (raw) {
       result[field.key] = raw;
+    } else {
+      delete result[field.key];
     }
+  }
+
+  if (mode === 'edit') {
+    // Only manage settings for provider types that declare them; otherwise send nothing so an
+    // unrecognized type's stored settings are left alone.
+    return fields.length > 0 ? result : undefined;
   }
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-/** Validates required/format for declared settings; returns a map of form-path -> error message. */
-function validateSettings(values: ProviderFormData): Record<string, string> {
+/**
+ * Validates declared settings; returns a map of form-path -> error message.
+ *
+ * Required-ness is only enforced on create. An existing provider may legitimately carry no settings
+ * because its identifier is embedded in a raw base URL (the dual-read path), so blocking an edit on
+ * a missing value would be stricter than the backend, which decides by re-resolving the base URL.
+ */
+function validateSettings(
+  values: ProviderFormData,
+  mode: 'add' | 'edit'
+): Record<string, string> {
   const errors: Record<string, string> = {};
   for (const field of getSettingFields(values.providerType)) {
     const raw = values.settings?.[field.key]?.trim() ?? '';
-    if (field.required && !raw) {
-      errors[`settings.${field.key}`] = `${field.label} is required`;
+    if (!raw) {
+      if (field.required && mode === 'add') {
+        errors[`settings.${field.key}`] = `${field.label} is required`;
+      }
       continue;
     }
-    if (raw && field.validationRegexSource) {
+    if (field.validationRegexSource) {
       try {
         if (!new RegExp(field.validationRegexSource).test(raw)) {
           errors[`settings.${field.key}`] = `${field.label} is not in the expected format`;
@@ -62,14 +94,14 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
   const handleSubmit = async (values: ProviderFormData) => {
     setIsSubmitting(true);
     try {
-      if (mode === 'add') {
-        // Validate declared structured settings (for example a required Cloudflare account ID).
-        const settingsErrors = validateSettings(values);
-        if (Object.keys(settingsErrors).length > 0) {
-          Object.entries(settingsErrors).forEach(([path, message]) => form.setFieldError(path, message));
-          return;
-        }
+      // Validate declared structured settings (for example a required Cloudflare account ID).
+      const settingsErrors = validateSettings(values, mode);
+      if (Object.keys(settingsErrors).length > 0) {
+        Object.entries(settingsErrors).forEach(([path, message]) => form.setFieldError(path, message));
+        return;
+      }
 
+      if (mode === 'add') {
         let providerName = values.providerName.trim();
         if (!providerName) {
           const selectedProvider = availableProviders.find(p => p.value === values.providerType);
@@ -81,7 +113,7 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
           providerType: values.providerType as ProviderType,
           providerName: providerName,
           baseUrl: values.apiEndpoint ?? undefined,
-          settings: collectSettings(values),
+          settings: collectSettings(values, 'add'),
           isEnabled: values.isEnabled,
           trustProviderReportedCosts: values.trustProviderReportedCosts,
           providerCostMarkupMultiplier: values.providerCostMarkupMultiplier,
@@ -119,6 +151,7 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
           providerName: values.providerName ?? undefined,
           baseUrl: values.apiEndpoint ?? undefined,
           organization: values.organizationId ?? undefined,
+          settings: collectSettings(values, 'edit'),
           isEnabled: values.isEnabled,
           trustProviderReportedCosts: values.trustProviderReportedCosts,
           providerCostMarkupMultiplier: values.providerCostMarkupMultiplier,
@@ -152,7 +185,7 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
     }
 
     // Validate declared structured settings before hitting the provider.
-    const settingsErrors = validateSettings(form.values);
+    const settingsErrors = validateSettings(form.values, mode);
     if (Object.keys(settingsErrors).length > 0) {
       Object.entries(settingsErrors).forEach(([path, message]) => form.setFieldError(path, message));
       return;
@@ -171,7 +204,7 @@ export function useProviderFormHandlers({ mode, providerId, logic }: UseProvider
             apiKey: form.values.apiKey,
             baseUrl: form.values.apiEndpoint ?? undefined,
             organizationId: form.values.organizationId ?? undefined,
-            settings: collectSettings(form.values),
+            settings: collectSettings(form.values, 'add'),
           })
         );
       } else {

--- a/WebAdmin/src/components/providers/ProviderFormLogic.ts
+++ b/WebAdmin/src/components/providers/ProviderFormLogic.ts
@@ -153,8 +153,11 @@ export function useProviderFormLogic(
             providerCostMarkupMultiplier: provider.providerCostMarkupMultiplier ?? 1,
           };
           
-          // Update initial values - form will reinitialize via key prop
+          // Hydrate the form with the loaded provider. useForm captures initialValues on its first
+          // render, so updating the state alone would never reach the inputs; initialize() sets both
+          // the values and the dirty baseline, and is a no-op if it somehow runs twice.
           setInitialFormValues(newFormValues);
+          form.initialize(newFormValues);
         } catch (error) {
           console.error('Error fetching provider:', error);
           notify.error('Failed to load provider');
@@ -166,6 +169,9 @@ export function useProviderFormLogic(
       
       void loadProvider();
     }
+    // 'form' is intentionally omitted: useForm returns a new object every render, so including it
+    // would refetch the provider on each render. The initialize() call inside is self-guarding.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, providerId, router]);
 
   let providerDisplayName = 'Unknown Provider';


### PR DESCRIPTION
…ion (#1182)

Structured settings (for example a Cloudflare Account ID) could be set when adding a provider and never changed afterwards: the settings fields were rendered inside a `mode === "add"` gate, and the edit payload omitted `settings` entirely, so any change was silently dropped on save.

- Render the declared settings fields in both modes. Organization ID and API Endpoint stay add-only, as before.
- Send `settings` in the update payload. Edit seeds the map from the values loaded off the provider instead of rebuilding it from the declared fields, so keys the TypeScript mirror does not yet declare survive the wholesale replace the backend performs. Clearing a field removes its key, which is how a value gets unset.
- Enforce required-ness only on create. An existing provider may legitimately carry no settings because its identifier is embedded in a raw base URL (the dual-read path), so blocking an edit on a missing value would be stricter than the backend, which decides by re-resolving the base URL and returns an actionable 400.

Also fixes the hydration bug underneath, without which the above is inert: the edit form never populated any field. `useForm` captures `initialValues` on its first render and `ProviderForm` has no `key` to remount it, so the `setInitialFormValues` call after the fetch never reached the inputs (the "form will reinitialize via key prop" comment described a mechanism that does not exist). Left as-is, the Account ID field would render empty and wipe the stored value on save. Hydrate with Mantine's one-shot `form.initialize()` instead. This restores editing of provider name, enable state, and cost markup too, which were broken the same way.

Verified: `npm run type-check` and `npm run lint` clean; provider contract tests pass (13/13).

Advances #1182 - serving the settings schema from the backend to retire the hand-mirrored PROVIDER_CONFIG_REQUIREMENTS remains open.