### PR TITLE
ci: close dev-merged issues that GitHub leaves open

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,30 @@ The Git tag drives the GitHub release and Docker image versions.
 - Results appear in Security tab
 - Non-blocking, informational only
 
+### 4. Close dev issues (`close-dev-issues.yml`)
+**Triggers:** Push to `dev`, Manual dispatch
+
+GitHub only honours `Closes #N` for PRs merged into the **default** branch (`master`).
+Every PR here targets `dev`, so those references never fire and completed issues sit
+open until someone closes them by hand. This workflow closes them.
+
+**What it does:**
+- Finds every merged PR in the pushed commit range
+- Reads closing keywords (`close[sd]`, `fix(e[sd])`, `resolve[sd]`) from each PR's title
+  and body, including the comma/`and`-separated list form used here
+  (`Closes #1205, #1206, #1207.`) that GitHub only ever honours for the first number
+- Closes each referenced open issue with a comment pointing at the PR and merge commit
+
+**What it deliberately does not close:**
+- References without a closing keyword — `Advances #1182`, `Completes epic #1204`,
+  `part of #800`. Partial progress stays open; write a closing keyword only when the
+  issue is actually done.
+- Issues already closed, PR numbers, and numbers inside words (`prefixes #99`)
+
+**Backfilling:** run it manually with a PR number to process an older merged PR.
+`dry_run` defaults to **true** on manual runs — it lists what it would close without
+closing anything. Set it to false to act.
+
 ## Release Process
 
 Releases are cut from `master` by pushing a version tag.

--- a/.github/workflows/close-dev-issues.yml
+++ b/.github/workflows/close-dev-issues.yml
@@ -1,0 +1,142 @@
+name: Close dev issues
+
+# GitHub only honours "Closes #N" for PRs merged into the *default* branch (master).
+# Every PR here targets `dev`, so those references never fire and issues stay open
+# until someone closes them by hand. This workflow does that closing.
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Merged PR number to process (backfill a single PR)'
+        required: true
+        type: string
+      dry_run:
+        description: 'List what would be closed without closing anything'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  close-referenced-issues:
+    name: Close issues referenced by merged PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      EVENT: ${{ github.event_name }}
+      BEFORE: ${{ github.event.before }}
+      AFTER: ${{ github.sha }}
+      BRANCH: ${{ github.ref_name }}
+      # Untrusted-ish inputs are passed through env, never interpolated into the script body.
+      INPUT_PR: ${{ inputs.pr }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/close-dev-issues.yml
+    steps:
+      - name: Find merged PRs in this push
+        run: |
+          set -euo pipefail
+          : > prs.txt
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            printf '%s\n' "$INPUT_PR" | grep -oE '[0-9]+' > prs.txt || true
+          elif [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "Branch was just created — no commit range to scan."
+          else
+            # compare/ returns every commit in the range (capped at 250 by the API,
+            # which no realistic push to dev exceeds).
+            gh api "repos/$REPO/compare/$BEFORE...$AFTER" --paginate \
+              --jq '.commits[].sha' > shas.txt
+            while read -r sha; do
+              [ -n "$sha" ] || continue
+              gh api "repos/$REPO/commits/$sha/pulls" \
+                --jq '.[] | select(.merged_at != null) | .number' >> prs.txt || true
+            done < shas.txt
+          fi
+
+          sort -u -o prs.txt prs.txt
+          echo "Merged PRs in range: $(tr '\n' ' ' < prs.txt)"
+
+      - name: Collect closing references
+        run: |
+          set -euo pipefail
+          : > refs.txt
+
+          # GitHub's closing-keyword set, plus the comma/and-separated list form this
+          # repo actually writes ("Closes #1205, #1206, #1207."), which GitHub itself
+          # only ever honours for the first number. \b stops `prefixes #99` matching.
+          keywords='\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]*:?[[:space:]]*#[0-9]+([[:space:]]*(,|and|, and)[[:space:]]*#[0-9]+)*'
+
+          while read -r pr; do
+            [ -n "$pr" ] || continue
+            gh api "repos/$REPO/pulls/$pr" --jq '.title, (.body // "")' \
+              | grep -oiE "$keywords" \
+              | grep -oE '#[0-9]+' | tr -d '#' \
+              | sed "s/\$/ $pr/" >> refs.txt || true
+          done < prs.txt
+
+          sort -u -o refs.txt refs.txt
+          echo "Closing references found: $(wc -l < refs.txt)"
+
+      - name: Close the referenced issues
+        run: |
+          set -euo pipefail
+          closed=0
+          skipped=0
+          {
+            echo "### Close dev issues"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while read -r issue pr; do
+            [ -n "$issue" ] || continue
+
+            # A PR referencing another PR in this same push is not an issue to close.
+            if grep -qx "$issue" prs.txt; then
+              echo "#$issue — skipped (it is a PR in this push)"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            state=$(gh api "repos/$REPO/issues/$issue" \
+              --jq 'if .pull_request then "is-a-pr" else .state end' 2>/dev/null || echo "not-found")
+
+            if [ "$state" != "open" ]; then
+              echo "#$issue — skipped ($state)"
+              echo "- \`#$issue\` skipped — $state" >> "$GITHUB_STEP_SUMMARY"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            if [ "${DRY_RUN:-false}" = "true" ]; then
+              echo "#$issue — would close (referenced by #$pr)"
+              echo "- \`#$issue\` **would close** — referenced by #$pr (dry run)" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            gh issue close "$issue" --repo "$REPO" --comment \
+          "Completed in #$pr, merged to \`$BRANCH\` (\`$(echo "$AFTER" | cut -c1-8)\`).
+
+          Closed automatically by [\`close-dev-issues\`]($WORKFLOW_URL): pull requests in this repository target \`dev\` rather than the default branch, so GitHub's built-in \`Closes #N\` handling never fires."
+
+            echo "#$issue — closed (referenced by #$pr)"
+            echo "- \`#$issue\` closed — referenced by #$pr" >> "$GITHUB_STEP_SUMMARY"
+            closed=$((closed + 1))
+          done < refs.txt
+
+          if [ "$closed" = "0" ] && [ "$skipped" = "0" ]; then
+            echo "_No closing references in this push._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "Closed $closed issue(s), skipped $skipped."


### PR DESCRIPTION
## Summary

GitHub only honours `Closes #N` for PRs merged into the **default** branch (`master`). Every PR in this repo targets `dev`, so those references never fire — completed issues sit open until someone closes them by hand. Epics #1194 and #1204 both needed a manual sweep this week.

Adds a workflow that runs on push to `dev`: it resolves each commit in the pushed range to its merged PR, reads closing keywords from the PR title and body, and closes the referenced open issues with a comment naming the PR and merge commit.

## Parser behaviour

Handles the comma/`and`-separated list form this repo actually writes — `Closes #1205, #1206, #1207.` — which GitHub itself only ever honours for the first number. A word-boundary anchor keeps `prefixes #99` from matching.

Deliberately conservative: **no closing keyword, no close.** References like `Advances #1182`, `Completes epic #1204`, and `part of #800` are left alone, so partial progress stays open. The trade-off is that epics closed with prose still need a manual close, or a `Closes` keyword going forward.

Also skipped: issues already closed, PR numbers, and self-references within the same push.

## Validation

Step scripts were extracted from the YAML and run in dry-run mode against real merged history:

| Range | Result |
|---|---|
| PR #1217 (epic #1194) | 9 refs — `#1194`–`#1202` |
| PR #1219 (rate limiting) | 12 refs — `#1205`–`#1216` |
| PRs #1220 + #1221 | `#1191` only; `#1182` correctly untouched (`Advances #1182 … remains open`) |

The regex was also checked against ten hand-written cases covering the traps above, including `Closes #1205, and see #1300 for context` (correctly stops at 1205).

## Notes for review

- `permissions:` is scoped to `issues: write`, `pull-requests: read`, `contents: read`. No checkout — the job only calls the API.
- Workflow-dispatch inputs are passed through `env:` rather than interpolated into the script body.
- The compare API caps at 250 commits per range, which no realistic push to `dev` exceeds.
- Manual dispatch takes a PR number for backfilling older merges and **defaults to a dry run**.

## Backfill

#1191 is currently open but complete (PR #1220 merged with a closing keyword). A manual dispatch on PR #1220 with `dry_run: false` will clean it up once this lands.
