### PR TITLE
perf(messaging): measure Postgres-transport throughput headroom (#1223)

### DIFF
--- a/Tests/ConduitLLM.Benchmarks/Messaging/HarnessSupport.cs
+++ b/Tests/ConduitLLM.Benchmarks/Messaging/HarnessSupport.cs
@@ -1,0 +1,329 @@
+using System.Diagnostics;
+using System.Globalization;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+
+namespace ConduitLLM.Benchmarks.Messaging
+{
+    /// <summary>
+    /// Synthetic handler standing in for a real <see cref="IEventHandler{TEvent}"/> on the
+    /// queue under test (#1223). It records the delivery and then awaits the configured
+    /// simulated cost.
+    /// </summary>
+    /// <remarks>
+    /// The cost is an <c>await Task.Delay</c> rather than a spin, because the real handlers
+    /// this stands in for are I/O bound, not CPU bound — <c>SpendUpdateProcessor</c> alone
+    /// makes four sequential round trips (key read, group read, idempotent balance
+    /// adjustment, follow-on publish). Modelling that as a yielding wait keeps the
+    /// measurement about the transport's scheduling rather than about the harness burning
+    /// the machine's cores.
+    /// </remarks>
+    internal sealed class BenchHandler<TEvent> : IEventHandler<TEvent>
+        where TEvent : class
+    {
+        private readonly DeliveryCollector _collector;
+
+        public BenchHandler(DeliveryCollector collector)
+        {
+            _collector = collector;
+        }
+
+        public async Task HandleAsync(TEvent @event, IEventContext context)
+        {
+            _collector.Record(@event);
+
+            if (_collector.HandlerCostMs > 0)
+            {
+                await Task.Delay(_collector.HandlerCostMs).ConfigureAwait(false);
+            }
+
+            _collector.Complete();
+        }
+    }
+
+    /// <summary>
+    /// Collects delivery counts, publish→handle latencies and observed handler concurrency
+    /// for one measurement run, and signals when the expected number of messages has drained.
+    /// </summary>
+    internal sealed class DeliveryCollector
+    {
+        private readonly List<double> _latenciesMs = new();
+        private readonly Lock _sync = new();
+
+        private TaskCompletionSource<bool> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _expected = int.MaxValue;
+        private long _firstDeliveryTimestamp;
+        private long _lastDeliveryTimestamp;
+        private int _delivered;
+        private int _inFlight;
+        private int _maxObservedConcurrency;
+
+        public DeliveryCollector(int handlerCostMs)
+        {
+            HandlerCostMs = handlerCostMs;
+        }
+
+        public int HandlerCostMs { get; }
+
+        /// <summary>
+        /// Discards everything collected so far and arms the collector for
+        /// <paramref name="expected"/> deliveries.
+        /// </summary>
+        /// <remarks>
+        /// Called after the warm-up burst has drained. Wolverine does not begin delivering on
+        /// an exclusive listener until the durability agent has assigned it to a node, which
+        /// on a cold host lands several seconds after startup. Measuring through that window
+        /// would charge one-off leader-election latency to every message in the run.
+        /// </remarks>
+        public void BeginMeasurement(int expected)
+        {
+            lock (_sync)
+            {
+                _latenciesMs.Clear();
+                _latenciesMs.Capacity = expected;
+                _delivered = 0;
+                _firstDeliveryTimestamp = 0;
+                _lastDeliveryTimestamp = 0;
+                _maxObservedConcurrency = 0;
+                _expected = expected;
+                _completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        public int Delivered => Volatile.Read(ref _delivered);
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObservedConcurrency);
+
+        /// <summary>
+        /// Delivery rate across the drain window — first delivery to last. Deliberately not
+        /// measured from the start of publishing: that would fold the producer's ramp-up into
+        /// a number meant to describe the consumer's ceiling.
+        /// </summary>
+        public double DeliveryRatePerSecond
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    if (_delivered < 2)
+                    {
+                        return 0;
+                    }
+
+                    var seconds = (_lastDeliveryTimestamp - _firstDeliveryTimestamp) / (double)Stopwatch.Frequency;
+                    return seconds <= 0 ? 0 : _delivered / seconds;
+                }
+            }
+        }
+
+        public void Record(object @event)
+        {
+            var now = Stopwatch.GetTimestamp();
+            var concurrent = Interlocked.Increment(ref _inFlight);
+
+            // Racy max is fine: it is a diagnostic for "did the endpoint actually run the
+            // parallelism its policy asks for", not a measured output.
+            if (concurrent > Volatile.Read(ref _maxObservedConcurrency))
+            {
+                Volatile.Write(ref _maxObservedConcurrency, concurrent);
+            }
+
+            lock (_sync)
+            {
+                if (_delivered == 0)
+                {
+                    _firstDeliveryTimestamp = now;
+                }
+
+                _delivered++;
+                _lastDeliveryTimestamp = now;
+
+                if (TryReadPublishTimestamp(@event, out var publishedAt))
+                {
+                    _latenciesMs.Add((now - publishedAt) * 1000.0 / Stopwatch.Frequency);
+                }
+
+                if (_delivered >= _expected)
+                {
+                    _completion.TrySetResult(true);
+                }
+            }
+        }
+
+        public void Complete() => Interlocked.Decrement(ref _inFlight);
+
+        public async Task<bool> WaitForCompletionAsync(TimeSpan timeout)
+        {
+            var finished = await Task.WhenAny(_completion.Task, Task.Delay(timeout)).ConfigureAwait(false);
+            return finished == _completion.Task;
+        }
+
+        public double Percentile(double quantile)
+        {
+            lock (_sync)
+            {
+                if (_latenciesMs.Count == 0)
+                {
+                    return 0;
+                }
+
+                var sorted = _latenciesMs.ToArray();
+                Array.Sort(sorted);
+                var index = (int)Math.Ceiling(quantile * sorted.Length) - 1;
+                return sorted[Math.Clamp(index, 0, sorted.Length - 1)];
+            }
+        }
+
+        /// <summary>
+        /// The publish-side <see cref="Stopwatch"/> tick is carried in the event's
+        /// CorrelationId. Publisher and consumer share a process here, so this is an exact
+        /// monotonic delta rather than a wall-clock subtraction across two machines.
+        /// </summary>
+        private static bool TryReadPublishTimestamp(object @event, out long timestamp)
+        {
+            timestamp = 0;
+            var correlationId = @event.GetType().GetProperty("CorrelationId")?.GetValue(@event) as string;
+            return !string.IsNullOrEmpty(correlationId)
+                && long.TryParse(correlationId, NumberStyles.Integer, CultureInfo.InvariantCulture, out timestamp);
+        }
+    }
+
+    /// <summary>Parsed command line for the throughput harness.</summary>
+    internal sealed class HarnessOptions
+    {
+        public string Queue { get; private set; } = "spend";
+
+        public int MessageCount { get; private set; } = 2000;
+
+        public IReadOnlyList<int> HandlerCostMs { get; private set; } = new[] { 0 };
+
+        public int PublishParallelism { get; private set; } = 32;
+
+        /// <summary>
+        /// Offered load in messages/second. Zero (the default) means saturation mode: publish
+        /// the whole batch as fast as possible and time the drain, which yields the ceiling.
+        /// A positive value publishes at that fixed rate instead, which is the only way to get
+        /// a meaningful latency figure — at saturation the queue grows without bound and
+        /// "latency" just measures how long the harness ran.
+        /// </summary>
+        public double OfferedRate { get; private set; }
+
+        /// <summary>
+        /// Messages published and drained before measurement starts, to get past listener
+        /// agent-assignment on a cold host.
+        /// </summary>
+        public int WarmupCount { get; private set; } = 10;
+
+        /// <summary>
+        /// Overrides the endpoint policy's <c>PrefetchCount</c>, which
+        /// <see cref="WolverineEndpointPolicy"/> translates into the per-poll receive batch.
+        /// Lets a proposed retune be measured before it is committed to
+        /// <see cref="ConduitEndpointPolicies"/>. Null leaves the production value.
+        /// </summary>
+        public int? ReceiveBatchOverride { get; private set; }
+
+        public TimeSpan Timeout { get; private set; } = TimeSpan.FromSeconds(300);
+
+        public string Database { get; private set; } = "conduit_msgbench";
+
+        public string AdminConnectionString { get; private set; } =
+            "Host=localhost;Port=5432;Username=conduit;Password=conduitpass;Database=postgres";
+
+        public static HarnessOptions? Parse(string[] args)
+        {
+            var options = new HarnessOptions();
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var key = args[i];
+                if (!key.StartsWith("--", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (i + 1 >= args.Length)
+                {
+                    Console.Error.WriteLine($"Missing value for {key}.");
+                    return null;
+                }
+
+                var value = args[++i];
+                switch (key)
+                {
+                    case "--queue":
+                        options.Queue = value;
+                        break;
+                    case "--messages":
+                        options.MessageCount = int.Parse(value, CultureInfo.InvariantCulture);
+                        break;
+                    case "--handler-cost-ms":
+                        options.HandlerCostMs = value
+                            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                            .Select(v => int.Parse(v, CultureInfo.InvariantCulture))
+                            .ToArray();
+                        break;
+                    case "--publish-parallelism":
+                        options.PublishParallelism = int.Parse(value, CultureInfo.InvariantCulture);
+                        break;
+                    case "--rate":
+                        options.OfferedRate = double.Parse(value, CultureInfo.InvariantCulture);
+                        break;
+                    case "--warmup":
+                        options.WarmupCount = int.Parse(value, CultureInfo.InvariantCulture);
+                        break;
+                    case "--receive-batch":
+                        options.ReceiveBatchOverride = int.Parse(value, CultureInfo.InvariantCulture);
+                        break;
+                    case "--timeout-seconds":
+                        options.Timeout = TimeSpan.FromSeconds(int.Parse(value, CultureInfo.InvariantCulture));
+                        break;
+                    case "--database":
+                        options.Database = value;
+                        break;
+                    case "--admin-connection":
+                        options.AdminConnectionString = value;
+                        break;
+                    default:
+                        Console.Error.WriteLine($"Unknown option {key}.");
+                        return null;
+                }
+            }
+
+            return options;
+        }
+    }
+
+    /// <summary>One measurement run: a queue at one simulated handler cost.</summary>
+    internal sealed record RunResult(
+        string Queue,
+        int HandlerCostMs,
+        double OfferedRate,
+        int Published,
+        int Delivered,
+        bool Complete,
+        double PublishRate,
+        double DeliveryRate,
+        double LatencyP50Ms,
+        double LatencyP95Ms,
+        double LatencyP99Ms,
+        int MaxObservedConcurrency)
+    {
+        public const string Header =
+            "queue            costMs   offered  delivered  deliver/s  publish/s   p50ms    p95ms    p99ms  maxConc  complete";
+
+        private string OfferedLabel => OfferedRate > 0
+            ? OfferedRate.ToString("F0", CultureInfo.InvariantCulture) + "/s"
+            : "saturate";
+
+        public string ToLine() =>
+            $"  cost={HandlerCostMs,3}ms offered={OfferedLabel,8} -> {DeliveryRate,8:F1} msg/s" +
+            $"   p50={LatencyP50Ms,7:F0}ms  p99={LatencyP99Ms,7:F0}ms" +
+            (Complete ? string.Empty : $"  [INCOMPLETE {Delivered}/{Published}]");
+
+        public string ToTableRow() =>
+            $"{Queue,-16}{HandlerCostMs,7}{OfferedLabel,10}{Delivered,11}{DeliveryRate,11:F1}{PublishRate,11:F1}" +
+            $"{LatencyP50Ms,9:F0}{LatencyP95Ms,9:F0}{LatencyP99Ms,9:F0}{MaxObservedConcurrency,9}  {(Complete ? "yes" : "NO")}";
+    }
+}

--- a/Tests/ConduitLLM.Benchmarks/Messaging/TransportThroughputHarness.cs
+++ b/Tests/ConduitLLM.Benchmarks/Messaging/TransportThroughputHarness.cs
@@ -1,0 +1,455 @@
+using System.Diagnostics;
+using System.Globalization;
+
+using ConduitLLM.Configuration.Messaging;
+using ConduitLLM.Configuration.Messaging.Wolverine;
+using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Messaging;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Npgsql;
+
+using Wolverine;
+using Wolverine.Postgresql;
+
+namespace ConduitLLM.Benchmarks.Messaging
+{
+    /// <summary>
+    /// Measures the sustained delivery throughput the Wolverine PostgreSQL transport can
+    /// support per tuned endpoint, and the publish→handle latency at saturation (#1223).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately NOT a BenchmarkDotNet benchmark. BDN measures short, isolated,
+    /// repeatable in-process operations; what matters here is the drain rate of a durable
+    /// queue that is backed up — a stateful, multi-second, out-of-process property. The
+    /// harness therefore runs as its own console mode.
+    /// </para>
+    /// <para>
+    /// The host is configured through the <em>real</em> production entry points —
+    /// <see cref="WolverineMessagingExtensions.AddConduitWolverine"/>,
+    /// <see cref="ConduitMessagingTopology.ApplyConduitPublishRouting"/> and
+    /// <see cref="WolverineEndpointPolicy.ListenWithPolicy"/> over the actual
+    /// <see cref="ConduitEndpointPolicies"/> descriptors. Nothing about the transport tuning
+    /// is restated here, so a later change to a policy's PrefetchCount or to the listener's
+    /// polling interval is picked up by this harness automatically rather than silently
+    /// invalidating a stale measurement.
+    /// </para>
+    /// <para>
+    /// Handlers are synthetic: they count deliveries, record latency, and optionally await a
+    /// configurable delay standing in for the real handler's I/O. That separates the two
+    /// things a poll-based transport multiplies together — the receive-batch ceiling
+    /// (<c>MaximumMessagesToReceive</c> ÷ <c>PollingInterval</c>) and the handler-bound
+    /// ceiling (concurrency ÷ handler latency). Sweeping the delay traces that curve.
+    /// </para>
+    /// <para>
+    /// Runs against an isolated database (default <c>conduit_msgbench</c>), created on demand.
+    /// This is not optional: the tuned queue names are the production ones, so pointing the
+    /// harness at the application database would inject synthetic spend and webhook events
+    /// into queues a running Gateway is listening on.
+    /// </para>
+    /// </remarks>
+    internal static class TransportThroughputHarness
+    {
+        private const string DefaultAdminConnection =
+            "Host=localhost;Port=5432;Username=conduit;Password=conduitpass;Database=postgres";
+        private const string DefaultBenchDatabase = "conduit_msgbench";
+
+        /// <summary>
+        /// The queues under test. Each carries the production policy descriptor and the
+        /// representative event type used to generate load.
+        /// </summary>
+        private static readonly IReadOnlyList<QueueTarget> Targets = new[]
+        {
+            new QueueTarget(
+                "spend",
+                ConduitEndpointPolicies.SpendUpdate,
+                ConduitMessagingTopology.SpendUpdateEvents,
+                typeof(SpendUpdateRequested),
+                (i, tag) => new SpendUpdateRequested
+                {
+                    KeyId = 1,
+                    Amount = 0.01m,
+                    RequestId = $"bench-{i}",
+                    CorrelationId = tag,
+                }),
+            new QueueTarget(
+                "webhook",
+                ConduitEndpointPolicies.WebhookDelivery,
+                ConduitMessagingTopology.WebhookDeliveryEvents,
+                typeof(WebhookDeliveryRequested),
+                (i, tag) => new WebhookDeliveryRequested
+                {
+                    TaskId = $"bench-{i}",
+                    TaskType = "bench",
+                    WebhookUrl = "http://127.0.0.1:9098/sink",
+                    CorrelationId = tag,
+                }),
+            new QueueTarget(
+                "image",
+                ConduitEndpointPolicies.ImageGeneration,
+                ConduitMessagingTopology.ImageGenerationEvents,
+                typeof(ImageGenerationRequested),
+                (i, tag) => new ImageGenerationRequested
+                {
+                    TaskId = $"bench-{i}",
+                    VirtualKeyId = 1,
+                    CorrelationId = tag,
+                }),
+            new QueueTarget(
+                "video",
+                ConduitEndpointPolicies.VideoGeneration,
+                ConduitMessagingTopology.VideoGenerationEvents,
+                typeof(VideoGenerationRequested),
+                (i, tag) => new VideoGenerationRequested
+                {
+                    RequestId = $"bench-{i}",
+                    VirtualKeyId = "1",
+                    CorrelationId = tag,
+                }),
+            new QueueTarget(
+                "gateway-default",
+                Policy: null,
+                ConduitMessagingTopology.GatewayCacheInvalidationEvents.Take(1).ToArray(),
+                typeof(VirtualKeyUpdated),
+                (i, tag) => new VirtualKeyUpdated
+                {
+                    KeyId = 1,
+                    KeyHash = $"bench-{i}",
+                    CorrelationId = tag,
+                }),
+        };
+
+        public static async Task<int> RunAsync(string[] args)
+        {
+            var options = HarnessOptions.Parse(args);
+            if (options is null)
+            {
+                PrintUsage();
+                return 1;
+            }
+
+            var target = Targets.FirstOrDefault(t =>
+                string.Equals(t.Key, options.Queue, StringComparison.OrdinalIgnoreCase));
+
+            if (target is null)
+            {
+                Console.Error.WriteLine(
+                    $"Unknown queue '{options.Queue}'. Known: {string.Join(", ", Targets.Select(t => t.Key))}.");
+                return 1;
+            }
+
+            var connectionString = await EnsureBenchDatabaseAsync(options).ConfigureAwait(false);
+
+            Console.WriteLine(
+                $"# transport-throughput  queue={target.Key}  messages={options.MessageCount}  " +
+                $"handlerCostMs=[{string.Join(",", options.HandlerCostMs)}]  " +
+                $"offered={(options.OfferedRate > 0 ? options.OfferedRate.ToString("F0", CultureInfo.InvariantCulture) + "/s" : "saturate")}");
+            Console.WriteLine($"# policy: {DescribePolicy(target, options)}");
+            Console.WriteLine();
+
+            var results = new List<RunResult>();
+            foreach (var cost in options.HandlerCostMs)
+            {
+                var result = await MeasureAsync(target, connectionString, options, cost).ConfigureAwait(false);
+                results.Add(result);
+                Console.WriteLine(result.ToLine());
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(RunResult.Header);
+            foreach (var r in results)
+            {
+                Console.WriteLine(r.ToTableRow());
+            }
+
+            return 0;
+        }
+
+        private static async Task<RunResult> MeasureAsync(
+            QueueTarget target,
+            string connectionString,
+            HarnessOptions options,
+            int handlerCostMs)
+        {
+            var collector = new DeliveryCollector(handlerCostMs);
+
+            using var host = BuildHost(target, connectionString, collector, options);
+            await host.StartAsync().ConfigureAwait(false);
+
+            try
+            {
+                var bus = host.Services.GetRequiredService<IMessageBus>();
+
+                // Warm up until the listener is actually delivering. On an exclusive listener
+                // (spend, image) nothing is delivered until the durability agent assigns the
+                // queue to a node, which takes seconds on a cold host; measuring through that
+                // window would charge one-off leader election to every message in the run.
+                collector.BeginMeasurement(options.WarmupCount);
+                await PublishAllAsync(bus, target, options, options.WarmupCount).ConfigureAwait(false);
+                if (!await collector.WaitForCompletionAsync(options.Timeout).ConfigureAwait(false))
+                {
+                    Console.Error.WriteLine(
+                        $"# warm-up did not drain ({collector.Delivered}/{options.WarmupCount}) — listener may never have started");
+                }
+
+                collector.BeginMeasurement(options.MessageCount);
+
+                var publishStart = Stopwatch.GetTimestamp();
+                if (options.OfferedRate > 0)
+                {
+                    // Fixed offered load: the queue stays shallow, so publish→handle latency
+                    // reflects transport overhead rather than backlog depth.
+                    await PublishAtRateAsync(bus, target, options).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Saturation: publish the whole batch up front so the listener is never
+                    // starved and what we time is the transport's ceiling rather than the
+                    // producer's. The achieved publish rate is reported too — if it ever lands
+                    // near the delivery rate, the run was producer-bound and the delivery
+                    // number is a floor, not a ceiling.
+                    await PublishAllAsync(bus, target, options, options.MessageCount).ConfigureAwait(false);
+                }
+
+                var publishSeconds = Elapsed(publishStart);
+                var drained = await collector.WaitForCompletionAsync(options.Timeout).ConfigureAwait(false);
+
+                return new RunResult(
+                    target.Key,
+                    handlerCostMs,
+                    options.OfferedRate,
+                    Published: options.MessageCount,
+                    Delivered: collector.Delivered,
+                    Complete: drained,
+                    PublishRate: options.MessageCount / publishSeconds,
+                    DeliveryRate: collector.DeliveryRatePerSecond,
+                    LatencyP50Ms: collector.Percentile(0.50),
+                    LatencyP95Ms: collector.Percentile(0.95),
+                    LatencyP99Ms: collector.Percentile(0.99),
+                    MaxObservedConcurrency: collector.MaxObservedConcurrency);
+            }
+            finally
+            {
+                await host.StopAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Publishes <see cref="HarnessOptions.MessageCount"/> messages paced to
+        /// <see cref="HarnessOptions.OfferedRate"/>, on an absolute schedule so a slow publish
+        /// does not push the whole run late.
+        /// </summary>
+        private static async Task PublishAtRateAsync(IMessageBus bus, QueueTarget target, HarnessOptions options)
+        {
+            var interval = 1.0 / options.OfferedRate;
+            var start = Stopwatch.GetTimestamp();
+            var pending = new List<Task>(options.MessageCount);
+
+            for (var i = 0; i < options.MessageCount; i++)
+            {
+                var dueSeconds = interval * i;
+                var behind = dueSeconds - (Stopwatch.GetTimestamp() - start) / (double)Stopwatch.Frequency;
+                if (behind > 0)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(behind)).ConfigureAwait(false);
+                }
+
+                var index = i;
+                var tag = Stopwatch.GetTimestamp().ToString(CultureInfo.InvariantCulture);
+                pending.Add(bus.PublishAsync(target.Factory(index, tag)).AsTask());
+            }
+
+            await Task.WhenAll(pending).ConfigureAwait(false);
+        }
+
+        private static async Task PublishAllAsync(IMessageBus bus, QueueTarget target, HarnessOptions options, int count)
+        {
+            // Bounded fan-out: each publish is an outbox INSERT, so a little parallelism is
+            // needed to get ahead of the listener without opening an unbounded connection storm.
+            using var gate = new SemaphoreSlim(options.PublishParallelism);
+            var tasks = new List<Task>(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                var index = i;
+                await gate.WaitAsync().ConfigureAwait(false);
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        var tag = Stopwatch.GetTimestamp().ToString(CultureInfo.InvariantCulture);
+                        await bus.PublishAsync(target.Factory(index, tag)).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        gate.Release();
+                    }
+                }));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        private static IHost BuildHost(
+            QueueTarget target,
+            string connectionString,
+            DeliveryCollector collector,
+            HarnessOptions options)
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["ConduitLLM:Messaging:Wolverine:Transport"] = "Postgresql",
+                ["ConduitLLM:Messaging:Wolverine:AutoProvision"] = "true",
+            };
+
+            return Host.CreateDefaultBuilder()
+                .ConfigureAppConfiguration(cfg => cfg.AddInMemoryCollection(settings))
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    // Wolverine logs an Information line per delivery; at saturation that
+                    // console I/O would itself become the bottleneck being measured.
+                    logging.SetMinimumLevel(LogLevel.Warning);
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton(collector);
+                    services.AddWolverineEventBus();
+
+                    foreach (var eventType in target.EventTypes)
+                    {
+                        services.AddScoped(
+                            typeof(IEventHandler<>).MakeGenericType(eventType),
+                            typeof(BenchHandler<>).MakeGenericType(eventType));
+                    }
+                })
+                .AddConduitWolverine(
+                    new ConfigurationBuilder().AddInMemoryCollection(settings).Build(),
+                    connectionString,
+                    "conduit-bench",
+                    opts =>
+                    {
+                        foreach (var eventType in target.EventTypes)
+                        {
+                            opts.AddEventBridge(eventType);
+                        }
+
+                        // Production routing, verbatim.
+                        opts.ApplyConduitPublishRouting();
+
+                        if (target.Policy is { } policy)
+                        {
+                            // A retune is expressed by amending the descriptor, so the
+                            // measurement still goes through the production translation in
+                            // WolverineEndpointPolicy rather than a parallel copy of it.
+                            if (options.ReceiveBatchOverride is { } batch)
+                            {
+                                policy = policy with { PrefetchCount = batch };
+                            }
+
+                            opts.ListenWithPolicy(policy, target.EventTypes);
+                        }
+                        else
+                        {
+                            // Mirrors ListenAsConduitGateway's default-queue listener.
+                            opts.ListenToPostgresqlQueue(ConduitMessagingTopology.GatewayEventsQueue)
+                                .PollingInterval(TimeSpan.FromMilliseconds(250))
+                                .MaximumMessagesToReceive(50);
+                        }
+                    })
+                .Build();
+        }
+
+        /// <summary>
+        /// Creates the isolated benchmark database if it does not exist and returns its
+        /// connection string.
+        /// </summary>
+        private static async Task<string> EnsureBenchDatabaseAsync(HarnessOptions options)
+        {
+            var adminBuilder = new NpgsqlConnectionStringBuilder(options.AdminConnectionString);
+            var database = options.Database;
+
+            await using (var admin = new NpgsqlConnection(adminBuilder.ConnectionString))
+            {
+                await admin.OpenAsync().ConfigureAwait(false);
+
+                await using var exists = new NpgsqlCommand(
+                    "SELECT 1 FROM pg_database WHERE datname = @name", admin);
+                exists.Parameters.AddWithValue("name", database);
+                var found = await exists.ExecuteScalarAsync().ConfigureAwait(false) is not null;
+
+                if (!found)
+                {
+                    // Identifier cannot be parameterized; quote it instead.
+                    await using var create = new NpgsqlCommand(
+                        $"CREATE DATABASE \"{database.Replace("\"", "\"\"")}\"", admin);
+                    await create.ExecuteNonQueryAsync().ConfigureAwait(false);
+                    Console.WriteLine($"# created isolated benchmark database '{database}'");
+                }
+            }
+
+            var target = new NpgsqlConnectionStringBuilder(adminBuilder.ConnectionString)
+            {
+                Database = database,
+            };
+            return target.ConnectionString;
+        }
+
+        private static string DescribePolicy(QueueTarget target, HarnessOptions options)
+        {
+            if (target.Policy is not { } p)
+            {
+                return $"{ConduitMessagingTopology.GatewayEventsQueue} (untuned default: 250ms poll, batch 50)";
+            }
+
+            if (options.ReceiveBatchOverride is { } overrideBatch)
+            {
+                p = p with { PrefetchCount = overrideBatch };
+            }
+
+            var ordering = p.ConcurrentMessageLimit == 1
+                ? "strict ordering (1 node, sequential)"
+                : p.SingleActiveConsumer
+                    ? $"exclusive node, parallelism {p.ConcurrentMessageLimit?.ToString(CultureInfo.InvariantCulture) ?? "50 (default)"}"
+                    : $"parallelism {p.ConcurrentMessageLimit?.ToString(CultureInfo.InvariantCulture) ?? "Wolverine default"}";
+
+            var batch = p.PrefetchCount?.ToString(CultureInfo.InvariantCulture) ?? "50 (default)";
+            return $"{p.Name} — {ordering}; receive batch {batch} per 250ms poll";
+        }
+
+        private static double Elapsed(long startTimestamp) =>
+            Math.Max((Stopwatch.GetTimestamp() - startTimestamp) / (double)Stopwatch.Frequency, 1e-6);
+
+        private static void PrintUsage()
+        {
+            Console.Error.WriteLine("""
+                Usage:
+                  dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- transport-throughput \
+                      --queue <spend|webhook|image|video|gateway-default> \
+                      [--messages 2000] [--handler-cost-ms 0,5,10,25] [--rate 0] \
+                      [--warmup 10] [--publish-parallelism 32] [--timeout-seconds 300] \
+                      [--database conduit_msgbench] [--admin-connection "<npgsql connstring to 'postgres' db>"]
+
+                Measures sustained delivery throughput and publish->handle latency for one
+                tuned queue, using the production endpoint policies. Runs against an isolated
+                database so synthetic events never reach a live service's queues (#1223).
+
+                --rate 0 (default) saturates the queue and reports the delivery ceiling.
+                --rate N offers a fixed N msg/s and reports latency at that load; use this for
+                latency, since at saturation the backlog — not the transport — sets latency.
+                """);
+        }
+
+        private sealed record QueueTarget(
+            string Key,
+            EndpointPolicy? Policy,
+            IReadOnlyList<Type> EventTypes,
+            Type PrimaryEventType,
+            Func<int, string, object> Factory);
+    }
+}

--- a/Tests/ConduitLLM.Benchmarks/Program.cs
+++ b/Tests/ConduitLLM.Benchmarks/Program.cs
@@ -1,5 +1,7 @@
 using BenchmarkDotNet.Running;
 
+using ConduitLLM.Benchmarks.Messaging;
+
 namespace ConduitLLM.Benchmarks;
 
 /// <summary>
@@ -10,11 +12,22 @@ namespace ConduitLLM.Benchmarks;
 /// for .NET 10 modernization efforts, particularly Span&lt;T&gt; optimizations.
 ///
 /// Run with: dotnet run -c Release --project ConduitLLM.Benchmarks
+///
+/// The <c>transport-throughput</c> mode is not a BenchmarkDotNet benchmark — it drives a
+/// live Wolverine host against a real PostgreSQL queue to measure sustained delivery
+/// throughput and headroom (#1223):
+///   dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- transport-throughput --queue spend
 /// </remarks>
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
-        var summary = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        if (args.Length > 0 && args[0].Equals("transport-throughput", StringComparison.OrdinalIgnoreCase))
+        {
+            return await TransportThroughputHarness.RunAsync(args[1..]).ConfigureAwait(false);
+        }
+
+        _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        return 0;
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Deeper operational runbooks stand on their own and are linked from Monitoring:
   credential/account errors and restoring keys safely.
 - **[Rate limiting](./operations/rate-limiting.md)** — what can be limited and at which scope, what
   a throttled client sees, and what happens when the limit store is unreachable.
+- **[Messaging throughput](./operations/messaging-throughput.md)** — what caps the event bus, which
+  queue binds first, why latency is the wrong alarm, and what to tune before anything drastic.
 
 **[Versioning](./Versioning.md)** documents the release and version scheme.
 

--- a/docs/operations/messaging-throughput.md
+++ b/docs/operations/messaging-throughput.md
@@ -1,0 +1,162 @@
+# Messaging throughput and headroom
+
+Conduit's event bus runs on Wolverine over the PostgreSQL transport. Queues are tables and
+listeners **poll** them; there is no broker pushing work. That one fact determines the
+system's throughput ceiling, how it degrades, and which alarm actually gives warning — all of
+which behave differently from a push-based broker, and none of which are obvious from the
+event rates alone.
+
+This page explains where the ceiling comes from, which queue binds first, and what to do
+about it. It does not restate the tuning values — those live in
+`ConduitEndpointPolicies` and are the source of truth.
+
+## What sets the ceiling
+
+Two independent limits apply to every listener, and the lower one wins:
+
+```
+ceiling  =  min(  receive batch ÷ poll interval  ,  handler concurrency ÷ handler latency  )
+             \_______ transport-bound _______/     \_______ handler-bound _______/
+```
+
+**The transport-bound term is the one people miss.** A listener claims at most *receive batch*
+rows per poll and polls on a fixed interval, so a queue with a small batch has a hard rate cap
+no matter how fast its handler is or how many nodes are running. The batch comes from each
+endpoint's `PrefetchCount` in
+[`ConduitEndpointPolicies`](../../Shared/ConduitLLM.Configuration/Messaging/ConduitEndpointPolicies.cs);
+the interval is set alongside it in
+[`WolverineEndpointPolicy.ListenWithPolicy`](../../Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs).
+
+Measurement matches the model closely — a queue delivers about 95% of `batch ÷ interval` when
+its handler is not the constraint. Reproduce with the harness (see [below](#reproducing-the-measurements)).
+
+> **`PrefetchCount` does not mean on this transport what it meant on the previous one.** On
+> RabbitMQ it bounded *unacknowledged messages held locally* — back-pressure, with no effect on
+> sustained rate. Translated to the Postgres transport it became the per-poll batch, which is a
+> direct throughput divisor. An endpoint whose prefetch was deliberately set *low* for safety
+> therefore inherited a low rate cap that was never intended.
+
+## Which queue binds first
+
+`spend-update-events` — by a wide margin, and it is also the least able to grow.
+
+Its policy is `ConcurrentMessageLimit = 1`, which
+[translates](../../Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineEndpointPolicy.cs)
+to `ListenWithStrictOrdering`: exactly **one node** listens, handling messages **sequentially**.
+That is the correct semantics for ordered financial processing, but it has a consequence worth
+stating plainly:
+
+**Adding Gateway instances does not add spend throughput.** Every other queue absorbs load by
+scaling out or by running its handlers in parallel; this one cannot do either. Whatever ceiling
+it has is the ceiling, fleet-wide.
+
+Compounding that, it carries the smallest receive batch of any tuned endpoint, so it is
+transport-bound long before its handler becomes the limit. Measured on a single node against a
+local database, it sustains roughly **39 msg/s** — an order of magnitude below every other
+queue, and *unchanged* whether the handler takes 0 ms or 15 ms, because the handler is not what
+is limiting it.
+
+The crossover to handler-bound sits near **25 ms** of handler latency. `SpendUpdateProcessor`
+makes four sequential round trips per message (key read, group read, idempotent balance
+adjustment, follow-on publish), so a deployment whose database round trips are slower than
+about 6 ms each — plausible with a networked or cross-AZ database, unlike the local one these
+figures come from — will be handler-bound instead, at a *lower* rate than 39/s. **Re-measure
+against production-like database latency before trusting any specific number here.**
+
+## Latency will not warn you
+
+The natural alarm — "page when publish→handle latency crosses a threshold" — does not work on a
+poll-based transport. Latency is dominated by the poll interval (a message waits half an
+interval on average) and stays essentially **flat right up to the ceiling**, then goes vertical
+once arrivals exceed drain rate and the backlog grows without bound.
+
+Measured on `spend-update-events`: p99 held between roughly 265 and 275 ms across offered loads
+from 10/s to 35/s — that is, from 25% to 90% of capacity, with no meaningful upward drift. A
+latency alarm on this queue moves from "quiet" to "unbounded backlog" with almost no warning
+band in between.
+
+**Alarm on utilization and queue depth instead**, both of which move early and proportionally:
+
+| Signal | Where it comes from | Threshold |
+|---|---|---|
+| Sustained delivery rate ÷ measured ceiling | Wolverine metrics ([observability](../monitoring.md)) | **warn 60%**, **page 80%** |
+| Queue depth | Row count in `wolverine_queues.wolverine_queue_<name>` | **page** if above 10 s of drain (`ceiling × 10`) for 5 min |
+
+Use queue depth as the authoritative signal. Rate tells you how close you are; depth tells you
+whether you have already lost.
+
+## What to do before changing transports
+
+In increasing order of cost and risk. **Exhaust these before treating the transport as the
+problem** — a transport swap is a bootstrap change plus a full re-validation of ordering and
+financial parity, and none of the levers below require either.
+
+1. **Raise the endpoint's `PrefetchCount`.** One line in `ConduitEndpointPolicies`. The ceiling
+   moves linearly and — critically — **strict ordering is unaffected**, because the batch only
+   controls how many rows a poll claims, not how they are handed to the handler; sequential
+   dispatch on a single node is preserved. Measured on `spend-update-events`: batch 10 → ~39/s,
+   25 → ~99/s, 50 → ~200/s, 100 → ~406/s, with handler concurrency pinned at 1 throughout.
+   This is by far the cheapest lever and it is the right first response to spend-queue pressure.
+2. **Shorten the poll interval.** Also linear, but it multiplies the standing database load
+   described below, and it helps every queue whether or not they need it. Prefer lever 1.
+3. **Partition the ordered queue.** `SpendUpdateRequested` exposes a `PartitionKey` (the virtual
+   key), so the domain only requires ordering *per key* — global serialization across all keys
+   is stricter than necessary and is what caps the queue. Splitting into partition-ordered
+   listeners lifts the cap without weakening the guarantee the domain actually depends on.
+   This needs a correctness review first: balance is held per *group*, not per key, so
+   per-key partitioning must be shown safe against the group-level balance adjustment and the
+   depletion-crossing check in `SpendUpdateProcessor`.
+4. **Change transports.** Only once the above are exhausted — realistically when a queue needs
+   sustained throughput in the thousands per second, or when poll load itself has become the
+   binding constraint on the database.
+
+## Standing cost of polling
+
+Listeners poll whether or not there is traffic, so the transport has a **non-zero floor that
+scales with hosts × queues, not with load**. On an idle two-host development environment (one
+Gateway, one Admin; six queues plus their scheduled-message tables) this measures at roughly
+**216 table scans/s** and **175 transactions/s**, entirely served from Postgres's buffer cache.
+
+That is negligible at this size, and it is not negligible in shape: a Gateway scaled to ten
+instances pays roughly ten times the Gateway share of it while completely idle. Include this
+floor when sizing the database, and treat a rising idle transaction rate after a scale-out as
+expected rather than as a leak.
+
+Sample it directly:
+
+```sql
+SELECT schemaname || '.' || relname AS table, seq_scan + idx_scan AS scans
+FROM pg_stat_all_tables
+WHERE schemaname LIKE 'wolverine%'
+ORDER BY scans DESC;
+```
+
+Take the difference between two samples over a known interval; the absolute counters are since
+statistics reset.
+
+## Reproducing the measurements
+
+The harness lives in `Tests/ConduitLLM.Benchmarks` and drives a real Wolverine host through the
+**production** configuration path — the same `ConduitEndpointPolicies` descriptors and the same
+`WolverineEndpointPolicy` translation the services use — so retuning an endpoint changes what
+the harness reports, and no figure here can silently drift from the code that produces it.
+
+```bash
+# Ceiling for one queue, sweeping simulated handler cost
+dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- transport-throughput \
+    --queue spend --messages 600 --handler-cost-ms 0,5,15,30,60
+
+# Latency at a fixed offered load (the only way to get a meaningful latency figure)
+dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- transport-throughput \
+    --queue spend --messages 400 --handler-cost-ms 15 --rate 20
+
+# Effect of a proposed retune, before committing it to ConduitEndpointPolicies
+dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- transport-throughput \
+    --queue spend --messages 800 --receive-batch 50
+```
+
+Queues: `spend`, `webhook`, `image`, `video`, `gateway-default`.
+
+The harness creates and uses its own database (`conduit_msgbench`). This is deliberate — the
+queue names are the production ones, so pointing it at the application database would inject
+synthetic spend and webhook events into queues a running Gateway is listening on.


### PR DESCRIPTION
Closes #1223.

Adds a throughput harness for the Wolverine PostgreSQL transport and records the resulting capacity reference. Full measurement report is on [the issue](https://github.com/nickna/Conduit/issues/1223#issuecomment-5076694042); this is the summary.

## What's here

- `Tests/ConduitLLM.Benchmarks` gains a `transport-throughput` mode (not a BenchmarkDotNet benchmark — the property of interest is the drain rate of a backed-up durable queue, which is stateful and multi-second).
- `docs/operations/messaging-throughput.md` — the durable reference: what caps the bus, which queue binds first, why latency is the wrong alarm, and what to tune before anything drastic.

The harness builds its host through the **production** path — the same `ConduitEndpointPolicies` descriptors and `WolverineEndpointPolicy` translation the services use — so retuning an endpoint changes what it reports, and the documented figures can't silently drift from the code. A proposed retune is measured by amending the descriptor (`policy with { PrefetchCount = n }`), not by a parallel copy of the listener setup.

It runs against its own database (`conduit_msgbench`, auto-created). That's deliberate, not tidiness: the tuned queue names are the production ones, so pointing it at the app database would inject synthetic spend and webhook events into queues a running Gateway is listening on.

## Findings

**Ceiling = `min(receive batch ÷ poll interval, concurrency ÷ handler latency)`.** Every queue delivers ~95% of `batch ÷ 250ms` when not handler-bound. Observed concurrency confirms the #926 translation is doing what it intended (75 webhook / 50 image / 1 spend).

**`spend-update-events` binds first, at ~39 msg/s, and cannot scale out** — strict ordering means one node, sequential, so adding Gateway instances adds nothing. It's transport-bound rather than handler-bound: identical at 0 ms and 15 ms handler cost, crossover near 25 ms. `SpendUpdateProcessor` makes four sequential round trips per message, so a production database slower than ~6 ms per round trip is handler-bound *below* 39/s. These numbers come from a local database — re-measure before treating 39 as the number.

**Latency is a useless alarm on a poll-based transport.** p99 held at ~270 ms from 25% to 90% of capacity, then goes vertical once arrivals exceed drain rate. There's effectively no warning band. The doc specifies utilization (warn 60% / page 80%) and queue depth instead. This corrects the "or p99 latency > Y" framing in the issue's original scope.

**The cheapest lever doesn't cost ordering.** Raising `PrefetchCount` lifts the ceiling linearly — 10 → 39/s, 25 → 99/s, 50 → 200/s, 100 → 406/s — with sequential dispatch preserved at every step, since the batch governs how many rows a poll claims, not how they're handed to the handler.

**Idle polling costs ~216 scans/s and ~175 xact/s** for two hosts and six queues, all buffer-cache hits. Negligible in magnitude; the shape matters more — it scales with hosts × queues, not with traffic, so a ten-instance Gateway pays ~10× its share while completely idle.

## Not covered

No access to production/staging telemetry from here, so the utilization half of "observed peak ÷ ceiling" is unfilled. The thresholds are expressed as percentages of measured ceiling and are usable without it, but nobody yet knows where real traffic sits on that scale. The nearest data point — #929's 17/s synthetic spend load — is 44% of ceiling, already past warn. Queries to close the gap are in the issue comment.

## Verification

`dotnet build Tests/ConduitLLM.Benchmarks -c Release` clean, 0 warnings. All figures reproduced from the committed harness; commands are in the doc. No production code paths changed — this adds a benchmark mode and documentation only.

## Follow-up

`PrefetchCount` changed meaning across the migration: on RabbitMQ it bounded unacknowledged messages held locally (back-pressure, no rate effect); on the Postgres transport it's the per-poll batch, a direct throughput divisor. `spend-update-events` had it set low (10) on purpose for in-flight safety under ordered processing and thereby inherited a 40/s cap that was never intended — on the one queue that can't scale out. Worth its own issue; happy to file.
