### PR TITLE
test(gateway): fix the 8 endpoint tests failing on dev since #1220

### DIFF
--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayEndpointTestHost.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayEndpointTestHost.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using ConduitLLM.Configuration.Interfaces;
+using ConduitLLM.Configuration.Options;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Middleware;
 using ConduitLLM.Gateway.Endpoints;
+using ConduitLLM.Gateway.RateLimiting;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -44,6 +46,7 @@ internal sealed class GatewayEndpointTestHost : IAsyncDisposable
                     services.AddGatewayEndpointHandlers();
                     services.AddSingleton(Mock.Of<IMediaStorageService>());
                     services.AddSingleton(Mock.Of<IMediaRecordRepository>());
+                    AddRateLimitingFilterDependencies(services);
                     services.AddAuthentication("VirtualKey")
                         .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>("VirtualKey", null);
                     services.AddAuthorization(options =>
@@ -75,6 +78,23 @@ internal sealed class GatewayEndpointTestHost : IAsyncDisposable
             .StartAsync();
 
         return new GatewayEndpointTestHost(host);
+    }
+
+    /// <summary>
+    /// Mirrors the no-Redis branch of <c>AddConduitRateLimiting</c>. The chat, embeddings and
+    /// responses routes carry <see cref="TokenRateLimitFilter"/>; without its dependencies every
+    /// request to them fails DI inside the filter chain and answers 500 dependency_resolution_error
+    /// before the handler ever runs. <see cref="UnlimitedTokenRateLimitService"/> admits everything,
+    /// so the filter stays a pass-through and tests observe the handler's own behaviour.
+    /// </summary>
+    private static void AddRateLimitingFilterDependencies(IServiceCollection services)
+    {
+        services.AddSingleton(new RateLimitOptions());
+        services.AddSingleton<IRateLimitFailurePolicy, RateLimitFailurePolicy>();
+        services.AddSingleton<ITokenRateLimitService, UnlimitedTokenRateLimitService>();
+        services.AddSingleton(Mock.Of<ITokenCounter>());
+        services.AddSingleton<RequestTokenEstimator>();
+        services.AddSingleton<TokenRateLimitFilter>();
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## What's broken

`ChatEndpointErrorStatusTests` has been red on `dev` since PR #1220 merged (8 of 9 tests). Every request returns 500 `dependency_resolution_error` instead of the mapped status:

```
System.InvalidOperationException: Unable to resolve service for type
'ConduitLLM.Gateway.RateLimiting.ITokenRateLimitService' while attempting to
activate 'ConduitLLM.Gateway.RateLimiting.TokenRateLimitFilter'.
  at ConduitLLM.Gateway.Endpoints.RequireBalanceEndpointFilter.InvokeAsync(...)
```

The request dies in the endpoint-filter chain and never reaches the handler under test, so 404/400/503/429 all come back as 500.

## Why

A semantic conflict between two PRs that landed 29 minutes apart:

- **#1219** (rate-limiting epic #1204) attached `TokenRateLimitFilter` to `/v1/chat/completions`, `/v1/embeddings` and `/v1/responses` — merged 01:02, green.
- **#1220** branched before that and added `GatewayEndpointTestHost`, which registers only what the *handler* needs — merged 01:31, with **no status checks at all** (`statusCheckRollup: []`), so CI never reported the break.

**Production is unaffected.** `AddConduitRateLimiting` registers the whole filter graph, and its no-Redis branch deliberately binds `UnlimitedTokenRateLimitService` so the filter always resolves. This is a test-host gap only.

## Fix

`GatewayEndpointTestHost` now mirrors that no-Redis branch: `RateLimitOptions`, `RateLimitFailurePolicy`, `UnlimitedTokenRateLimitService`, a mocked `ITokenCounter`, `RequestTokenEstimator`, `TokenRateLimitFilter`. The filter becomes a pass-through, so tests observe the handler's own behaviour.

Registered in the shared host rather than the one failing class, since the responses and embeddings tests sit behind the same filter and would hit this next.

## Verification

- `Gateway.Endpoints`: **84/84** pass (was 76/84)
- Full CI filter (`FullyQualifiedName!~IntegrationTests&Category!=TimingSensitive`): **3334 passed, 0 failed**

## Follow-up worth considering

`dev` branch protection doesn't require CI — #1220 merged with zero checks. That's what let a red suite reach `dev` in the first place.
