### PR TITLE
fix(core): normalize TokenizerType before resolving Tiktoken encodings (#1051)

### DIFF
--- a/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
@@ -38,8 +38,9 @@ namespace ConduitLLM.Core.Services
     /// </remarks>
     public class TiktokenCounter : ITokenCounter
     {
-        // Cache encodings for performance
-        private static readonly Dictionary<string, TikToken> _encodings = new();
+        // Cache encodings for performance, keyed by the requested tokenizer identifier.
+        // A null value is a cached failure and means "use character-based estimation".
+        private static readonly Dictionary<string, TikToken?> _encodings = new();
         private static readonly object _lock = new();
         private readonly ILogger<TiktokenCounter> _logger;
         private readonly IModelCapabilityService? _capabilityService;
@@ -201,17 +202,16 @@ namespace ConduitLLM.Core.Services
         {
             try
             {
-                string encodingName = "cl100k_base"; // Default for newer models
+                string? tokenizerType = null;
 
                 // Try to get tokenizer type from capability service first
                 if (_capabilityService != null)
                 {
                     try
                     {
-                        var tokenizerType = await _capabilityService.GetTokenizerTypeAsync(modelName);
+                        tokenizerType = await _capabilityService.GetTokenizerTypeAsync(modelName);
                         if (!string.IsNullOrEmpty(tokenizerType))
                         {
-                            encodingName = tokenizerType;
                             _logger.LogDebug("Using tokenizer {TokenizerType} from capability service for model {Model}", tokenizerType, modelName);
                         }
                     }
@@ -221,7 +221,7 @@ namespace ConduitLLM.Core.Services
                     }
                 }
 
-                return GetOrCreateEncoding(encodingName, modelName);
+                return GetOrCreateEncoding(tokenizerType, modelName);
             }
             catch (Exception ex)
             {
@@ -233,61 +233,61 @@ namespace ConduitLLM.Core.Services
         /// <summary>
         /// Gets or creates a TikToken encoding with thread-safe caching.
         /// </summary>
-        /// <param name="encodingName">The name of the encoding to get or create.</param>
+        /// <param name="tokenizerType">
+        /// The tokenizer identifier from model metadata (a <c>TokenizerType</c> name such as
+        /// <c>Cl100KBase</c> or <c>LLaMA3</c>), or null to use the default encoding.
+        /// </param>
         /// <param name="modelName">The model name (for logging purposes).</param>
         /// <returns>The TikToken encoding, or null if it cannot be created.</returns>
-        private TikToken? GetOrCreateEncoding(string encodingName, string modelName)
+        /// <remarks>
+        /// The cache is keyed on <paramref name="tokenizerType"/> rather than on the resolved
+        /// encoding name. Keying it on the resolved name meant an unresolvable tokenizer never
+        /// populated an entry under the key that was looked up, so every single token count
+        /// re-entered the failure path and re-logged (#1051).
+        /// </remarks>
+        private TikToken? GetOrCreateEncoding(string? tokenizerType, string modelName)
         {
-            // Map non-OpenAI tokenizer types to their closest OpenAI equivalent
-            // since TiktokenSharp only supports OpenAI encodings
-            if (encodingName == "claude" || encodingName == "gemini")
-            {
-                // Use cl100k_base as approximation for non-OpenAI models
-                _logger.LogDebug("Using cl100k_base approximation for {TokenizerType} tokenizer on model {Model}", encodingName, modelName);
-                encodingName = "cl100k_base";
-            }
-            else if (encodingName == "o200k_base")
-            {
-                // o200k_base is newer than cl100k_base, but if not supported, fall back
-                // Try to use it, but we'll handle the error below if it's not supported
-                _logger.LogDebug("Attempting to use o200k_base tokenizer for model {Model}", modelName);
-            }
+            var cacheKey = tokenizerType?.Trim() ?? string.Empty;
 
             lock (_lock)
             {
-                if (!_encodings.TryGetValue(encodingName, out var encoding))
+                if (_encodings.TryGetValue(cacheKey, out var cached))
                 {
-                    try
-                    {
-                        encoding = TikToken.EncodingForModel(encodingName);
-                        _encodings[encodingName] = encoding;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Failed to get encoding {EncodingName} for model {ModelName}, trying cl100k_base fallback", encodingName, modelName);
-
-                        // Try fallback to cl100k_base if the specific encoding isn't supported
-                        if (encodingName != "cl100k_base")
-                        {
-                            try
-                            {
-                                encodingName = "cl100k_base";
-                                encoding = TikToken.EncodingForModel(encodingName);
-                                _encodings[encodingName] = encoding;
-                                _logger.LogInformation("Successfully used cl100k_base fallback for model {ModelName}", modelName);
-                            }
-                            catch (Exception fallbackEx)
-                            {
-                                _logger.LogError(fallbackEx, "Failed to get fallback encoding cl100k_base");
-                                return null;
-                            }
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    }
+                    return cached;
                 }
+
+                var resolved = TokenizerEncodingMap.Resolve(tokenizerType);
+
+                if (!resolved.IsRecognized)
+                {
+                    _logger.LogWarning(
+                        "Unknown tokenizer {TokenizerType} for model {ModelName}; using {EncodingName} for estimation",
+                        tokenizerType, modelName, resolved.EncodingName);
+                }
+                else if (resolved.IsApproximation)
+                {
+                    _logger.LogDebug(
+                        "Tokenizer {TokenizerType} has no Tiktoken equivalent; approximating model {ModelName} with {EncodingName}",
+                        tokenizerType, modelName, resolved.EncodingName);
+                }
+
+                TikToken? encoding;
+                try
+                {
+                    encoding = TikToken.GetEncoding(resolved.EncodingName);
+                }
+                catch (Exception ex)
+                {
+                    // The map only ever yields encodings TiktokenSharp implements, so this is a
+                    // library or data-file problem rather than bad configuration.
+                    _logger.LogError(ex,
+                        "Failed to load encoding {EncodingName} for model {ModelName}; falling back to character-based estimation",
+                        resolved.EncodingName, modelName);
+                    encoding = null;
+                }
+
+                // Cache the failure too, so a broken encoding does not re-throw on every request.
+                _encodings[cacheKey] = encoding;
                 return encoding;
             }
         }

--- a/Shared/ConduitLLM.Core/Services/TokenizerEncodingMap.cs
+++ b/Shared/ConduitLLM.Core/Services/TokenizerEncodingMap.cs
@@ -1,0 +1,136 @@
+// TokenizerType lives in the global namespace (Shared/ConduitLLM.Configuration/Entities/TokenizerType.cs).
+
+namespace ConduitLLM.Core.Services
+{
+    /// <summary>
+    /// The outcome of resolving a <see cref="TokenizerType"/> to a Tiktoken encoding name.
+    /// </summary>
+    /// <param name="EncodingName">The Tiktoken encoding identifier to hand to TiktokenSharp.</param>
+    /// <param name="IsApproximation">
+    /// True when the requested tokenizer has no exact TiktokenSharp equivalent and
+    /// <paramref name="EncodingName"/> is a documented stand-in. Token counts are estimates in
+    /// that case, which matters for context management and fallback billing estimates.
+    /// </param>
+    /// <param name="IsRecognized">
+    /// False when the requested value did not correspond to any known <see cref="TokenizerType"/>.
+    /// </param>
+    public readonly record struct TokenizerEncoding(string EncodingName, bool IsApproximation, bool IsRecognized);
+
+    /// <summary>
+    /// Maps <see cref="TokenizerType"/> values onto the encoding identifiers TiktokenSharp accepts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Model metadata stores a <see cref="TokenizerType"/> and surfaces it as its enum name
+    /// (<c>Cl100KBase</c>, <c>LLaMA3</c>, ...), while TiktokenSharp expects lowercase encoding
+    /// identifiers (<c>cl100k_base</c>). Passing the enum name straight through made every
+    /// resolution — including the default — take an exception-driven fallback path.
+    /// </para>
+    /// <para>
+    /// TiktokenSharp 1.2.1 implements exactly three encodings: <c>cl100k_base</c>,
+    /// <c>p50k_base</c> and <c>o200k_base</c>. <c>p50k_edit</c> and <c>r50k_base</c> throw
+    /// <see cref="NotImplementedException"/>, so they are mapped to the nearest implemented
+    /// vocabulary rather than requested directly. Every non-OpenAI tokenizer is an approximation:
+    /// Conduit uses these counts for context-window checks and for estimating usage when a
+    /// provider omits it, not as an authoritative count.
+    /// </para>
+    /// </remarks>
+    public static class TokenizerEncodingMap
+    {
+        /// <summary>The encoding used whenever no closer equivalent is available.</summary>
+        public const string DefaultEncoding = "cl100k_base";
+
+        private const string P50KBase = "p50k_base";
+        private const string O200KBase = "o200k_base";
+
+        // Exact: the tokenizer is an OpenAI encoding TiktokenSharp implements.
+        // Approximate: the tokenizer is a different vocabulary (or an OpenAI encoding
+        // TiktokenSharp does not implement) and the value is the closest available stand-in.
+        private static readonly IReadOnlyDictionary<TokenizerType, TokenizerEncoding> Map =
+            new Dictionary<TokenizerType, TokenizerEncoding>
+            {
+                // OpenAI — exact
+                [TokenizerType.Cl100KBase] = Exact(DefaultEncoding),
+                [TokenizerType.P50KBase] = Exact(P50KBase),
+                [TokenizerType.O200KBase] = Exact(O200KBase),
+
+                // OpenAI — not implemented by TiktokenSharp; nearest implemented vocabulary.
+                // p50k_edit is p50k_base plus edit-specific special tokens; r50k_base is the
+                // GPT-2/Codex vocabulary that p50k_base extends.
+                [TokenizerType.P50KEdit] = Approximate(P50KBase),
+                [TokenizerType.R50KBase] = Approximate(P50KBase),
+
+                // GPT-OSS harmony is the o200k vocabulary plus harmony-format special tokens.
+                [TokenizerType.O200KHarmony] = Approximate(O200KBase),
+
+                // Generic "tiktoken" carries no encoding of its own.
+                [TokenizerType.Tiktoken] = Approximate(DefaultEncoding),
+
+                // Non-text models still get asked for a count on occasion (for example when a
+                // prompt is logged), so answer with the default rather than failing.
+                [TokenizerType.None] = Approximate(DefaultEncoding),
+
+                // Non-OpenAI vocabularies — no Tiktoken equivalent exists, so all approximate.
+                [TokenizerType.Claude] = Approximate(DefaultEncoding),
+                [TokenizerType.Claude3] = Approximate(DefaultEncoding),
+                [TokenizerType.Gemini] = Approximate(DefaultEncoding),
+                [TokenizerType.PaLM] = Approximate(DefaultEncoding),
+                [TokenizerType.LLaMA] = Approximate(DefaultEncoding),
+                [TokenizerType.LLaMA2] = Approximate(DefaultEncoding),
+                [TokenizerType.LLaMA3] = Approximate(DefaultEncoding),
+                [TokenizerType.Mistral] = Approximate(DefaultEncoding),
+                [TokenizerType.Cohere] = Approximate(DefaultEncoding),
+                [TokenizerType.Kimi] = Approximate(DefaultEncoding),
+                [TokenizerType.Groq] = Approximate(DefaultEncoding),
+                [TokenizerType.Cerebras] = Approximate(DefaultEncoding),
+                [TokenizerType.MiniMax] = Approximate(DefaultEncoding),
+                [TokenizerType.SentencePiece] = Approximate(DefaultEncoding),
+                [TokenizerType.BPE] = Approximate(DefaultEncoding),
+                [TokenizerType.WordPiece] = Approximate(DefaultEncoding),
+            };
+
+        /// <summary>
+        /// Resolves a tokenizer identifier to the encoding TiktokenSharp should be asked for.
+        /// </summary>
+        /// <param name="tokenizerType">
+        /// A <see cref="TokenizerType"/> name (<c>Cl100KBase</c>, <c>LLaMA3</c>, ...) or an
+        /// encoding identifier already in Tiktoken form (<c>cl100k_base</c>). Matching is
+        /// case-insensitive; null, empty and unrecognized values fall back to
+        /// <see cref="DefaultEncoding"/>.
+        /// </param>
+        public static TokenizerEncoding Resolve(string? tokenizerType)
+        {
+            if (string.IsNullOrWhiteSpace(tokenizerType))
+            {
+                return Approximate(DefaultEncoding);
+            }
+
+            var trimmed = tokenizerType.Trim();
+
+            if (Enum.TryParse<TokenizerType>(trimmed, ignoreCase: true, out var parsed) &&
+                Map.TryGetValue(parsed, out var mapped))
+            {
+                return mapped;
+            }
+
+            // Already an encoding identifier (configuration written by hand, or a value that
+            // has been through this map once already).
+            return trimmed.ToLowerInvariant() switch
+            {
+                DefaultEncoding => Exact(DefaultEncoding),
+                P50KBase => Exact(P50KBase),
+                O200KBase => Exact(O200KBase),
+                "p50k_edit" => Approximate(P50KBase),
+                "r50k_base" => Approximate(P50KBase),
+                "o200k_harmony" => Approximate(O200KBase),
+                _ => new TokenizerEncoding(DefaultEncoding, IsApproximation: true, IsRecognized: false)
+            };
+        }
+
+        private static TokenizerEncoding Exact(string encoding) =>
+            new(encoding, IsApproximation: false, IsRecognized: true);
+
+        private static TokenizerEncoding Approximate(string encoding) =>
+            new(encoding, IsApproximation: true, IsRecognized: true);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterEncodingTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterEncodingTests.cs
@@ -1,0 +1,93 @@
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Verifies that <see cref="TiktokenCounter"/> resolves tokenizers without exception-driven
+    /// control flow, and that a resolution is attempted at most once per tokenizer (#1051).
+    /// </summary>
+    public class TiktokenCounterEncodingTests
+    {
+        private static readonly List<Message> Messages = new()
+        {
+            new Message { Role = MessageRole.User, Content = "The quick brown fox jumps over the lazy dog." }
+        };
+
+        private static (TiktokenCounter Counter, Mock<ILogger<TiktokenCounter>> Logger) CreateCounter(string? tokenizerType)
+        {
+            var logger = new Mock<ILogger<TiktokenCounter>>();
+            var capabilities = new Mock<IModelCapabilityService>();
+            capabilities
+                .Setup(c => c.GetTokenizerTypeAsync(It.IsAny<string>()))
+                .ReturnsAsync(tokenizerType);
+
+            return (new TiktokenCounter(logger.Object, capabilities.Object), logger);
+        }
+
+        private static int CountLogs(Mock<ILogger<TiktokenCounter>> logger, LogLevel level) =>
+            logger.Invocations.Count(i =>
+                i.Method.Name == nameof(ILogger.Log) && (LogLevel)i.Arguments[0] == level);
+
+        [Theory]
+        [InlineData("Cl100KBase")]
+        [InlineData("O200KBase")]
+        [InlineData("P50KBase")]
+        [InlineData("Claude")]
+        [InlineData("Gemini")]
+        [InlineData("LLaMA3")]
+        [InlineData("O200KHarmony")]
+        [InlineData("R50KBase")]
+        public async Task EstimateTokenCountAsync_KnownTokenizer_CountsWithoutWarningOrError(string tokenizerType)
+        {
+            var (counter, logger) = CreateCounter(tokenizerType);
+
+            var count = await counter.EstimateTokenCountAsync($"model-{tokenizerType}", Messages);
+
+            Assert.True(count > 0, $"{tokenizerType} produced no tokens");
+            Assert.Equal(0, CountLogs(logger, LogLevel.Warning));
+            Assert.Equal(0, CountLogs(logger, LogLevel.Error));
+        }
+
+        [Fact]
+        public async Task EstimateTokenCountAsync_DefaultTokenizer_MatchesExplicitCl100KBase()
+        {
+            var (defaulted, _) = CreateCounter("Cl100KBase");
+            var (approximated, _) = CreateCounter("LLaMA3");
+
+            var exact = await defaulted.EstimateTokenCountAsync("model-exact", Messages);
+            var approximate = await approximated.EstimateTokenCountAsync("model-approx", Messages);
+
+            // LLaMA3 has no Tiktoken equivalent and is documented as a cl100k_base approximation,
+            // so the two must agree — a divergence would mean the approximation silently changed.
+            Assert.Equal(exact, approximate);
+        }
+
+        [Fact]
+        public async Task EstimateTokenCountAsync_UnknownTokenizer_WarnsOnceAcrossManyCalls()
+        {
+            // A tokenizer name no TokenizerType parses to, unique to this test so it gets its
+            // own slot in TiktokenCounter's process-wide encoding cache.
+            const string Unknown = "conduit-test-unknown-tokenizer-1051";
+            var (counter, logger) = CreateCounter(Unknown);
+
+            for (var i = 0; i < 25; i++)
+            {
+                var count = await counter.EstimateTokenCountAsync("model-unknown", Messages);
+                Assert.True(count > 0);
+            }
+
+            // Before #1051 the failed resolution was cached under the *resolved* name while the
+            // lookup used the *requested* name, so every call re-threw and re-logged.
+            Assert.Equal(1, CountLogs(logger, LogLevel.Warning));
+            Assert.Equal(0, CountLogs(logger, LogLevel.Error));
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Services/TokenizerEncodingMapTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TokenizerEncodingMapTests.cs
@@ -1,0 +1,127 @@
+using ConduitLLM.Core.Services;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Unit tests for <see cref="TokenizerEncodingMap"/> (#1051).
+    /// </summary>
+    /// <remarks>
+    /// Model metadata surfaces <c>TokenizerType.ToString()</c>, so these tests use the enum
+    /// names exactly as <c>DatabaseModelCapabilityService.GetTokenizerTypeAsync</c> emits them.
+    /// </remarks>
+    public class TokenizerEncodingMapTests
+    {
+        // The three encodings TiktokenSharp 1.2.1 actually implements. Any other value would
+        // send the counter back down the exception path this issue removed.
+        private static readonly string[] SupportedEncodings = { "cl100k_base", "p50k_base", "o200k_base" };
+
+        [Theory]
+        [InlineData("Cl100KBase", "cl100k_base")]
+        [InlineData("P50KBase", "p50k_base")]
+        [InlineData("O200KBase", "o200k_base")]
+        public void Resolve_OpenAiEncoding_ReturnsExactEncoding(string tokenizerType, string expected)
+        {
+            var result = TokenizerEncodingMap.Resolve(tokenizerType);
+
+            Assert.Equal(expected, result.EncodingName);
+            Assert.False(result.IsApproximation);
+            Assert.True(result.IsRecognized);
+        }
+
+        [Theory]
+        [InlineData("Claude", "cl100k_base")]
+        [InlineData("Claude3", "cl100k_base")]
+        [InlineData("Gemini", "cl100k_base")]
+        [InlineData("LLaMA3", "cl100k_base")]
+        [InlineData("Mistral", "cl100k_base")]
+        [InlineData("Kimi", "cl100k_base")]
+        [InlineData("O200KHarmony", "o200k_base")]
+        [InlineData("P50KEdit", "p50k_base")]
+        [InlineData("R50KBase", "p50k_base")]
+        public void Resolve_NonTiktokenTokenizer_ReturnsDocumentedApproximation(string tokenizerType, string expected)
+        {
+            var result = TokenizerEncodingMap.Resolve(tokenizerType);
+
+            Assert.Equal(expected, result.EncodingName);
+            Assert.True(result.IsApproximation);
+            Assert.True(result.IsRecognized);
+        }
+
+        [Fact]
+        public void Resolve_EveryTokenizerType_MapsToASupportedEncoding()
+        {
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                var result = TokenizerEncodingMap.Resolve(tokenizerType.ToString());
+
+                Assert.True(result.IsRecognized, $"{tokenizerType} is not mapped");
+                Assert.Contains(result.EncodingName, SupportedEncodings);
+            }
+        }
+
+        [Theory]
+        [InlineData("cl100k_base")]
+        [InlineData("CL100K_BASE")]
+        [InlineData("  Cl100KBase  ")]
+        [InlineData("cl100kbase")]
+        public void Resolve_IsCaseAndWhitespaceInsensitive(string tokenizerType)
+        {
+            var result = TokenizerEncodingMap.Resolve(tokenizerType);
+
+            Assert.Equal("cl100k_base", result.EncodingName);
+            Assert.True(result.IsRecognized);
+        }
+
+        [Theory]
+        [InlineData("p50k_edit", "p50k_base")]
+        [InlineData("r50k_base", "p50k_base")]
+        [InlineData("o200k_harmony", "o200k_base")]
+        public void Resolve_UnimplementedEncodingIdentifier_ReturnsNearestSupported(string encoding, string expected)
+        {
+            var result = TokenizerEncodingMap.Resolve(encoding);
+
+            Assert.Equal(expected, result.EncodingName);
+            Assert.True(result.IsApproximation);
+            Assert.True(result.IsRecognized);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Resolve_MissingTokenizer_ReturnsDefaultEncoding(string? tokenizerType)
+        {
+            var result = TokenizerEncodingMap.Resolve(tokenizerType);
+
+            Assert.Equal(TokenizerEncodingMap.DefaultEncoding, result.EncodingName);
+            Assert.True(result.IsRecognized);
+        }
+
+        [Fact]
+        public void Resolve_UnknownTokenizer_ReportsUnrecognizedAndFallsBack()
+        {
+            var result = TokenizerEncodingMap.Resolve("some-tokenizer-that-does-not-exist");
+
+            Assert.Equal(TokenizerEncodingMap.DefaultEncoding, result.EncodingName);
+            Assert.True(result.IsApproximation);
+            Assert.False(result.IsRecognized);
+        }
+
+        [Fact]
+        public void Resolve_ResultIsIdempotent()
+        {
+            // Feeding a resolved encoding name back in must not degrade it — this is what
+            // happens when configuration is written from a previous resolution.
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                var first = TokenizerEncodingMap.Resolve(tokenizerType.ToString());
+                var second = TokenizerEncodingMap.Resolve(first.EncodingName);
+
+                Assert.Equal(first.EncodingName, second.EncodingName);
+                Assert.True(second.IsRecognized);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1051.

Follow-up to #1191, whose "Related noise" section reported a
`KeyNotFoundException: Could not automatically map LLaMA3 to a tokeniser` flood
on every chat request. #1220 fixed that issue's status-code mapping; this is the
remaining half.

## What was wrong

`DatabaseModelCapabilityService.GetTokenizerTypeAsync` returns
`TokenizerType.ToString()` — `Cl100KBase`, `LLaMA3` — and `TiktokenCounter`
handed that straight to `TikToken.EncodingForModel()`, which expects
`cl100k_base`. So **every** resolution threw and fell back, including the
service's own `"Cl100KBase"` default. This was never limited to non-OpenAI
tokenizers.

Worse, the fallback cached under the *resolved* name:

```csharp
if (!_encodings.TryGetValue(encodingName, out var encoding))   // key: "LLaMA3"
    ...
    encodingName = "cl100k_base";
    _encodings[encodingName] = encoding;                        // key: "cl100k_base"
```

The lookup key stayed `"LLaMA3"`, so the cache never hit and every single token
count re-entered the throw path and re-logged. That is the "repeated dozens of
times per request" behaviour.

Two smaller defects in the same method: the only tokenizer special-cases compared
against lowercase `"claude"`/`"gemini"`, which the PascalCase enum names never
match — dead code since it was written; and the `o200k_base` branch only logged.

## What changed

- **`TokenizerEncodingMap`** — one explicit arm per `TokenizerType` (22 values),
  each marked exact or a documented approximation.

  I probed TiktokenSharp 1.2.1 rather than assuming: it implements exactly
  **three** encodings. `p50k_edit` and `r50k_base` throw
  `NotImplementedException`, and `o200k_harmony` is not mapped at all. Those now
  resolve to the nearest implemented vocabulary (`p50k_base`, `p50k_base`,
  `o200k_base`) instead of being requested and failing.

- `TikToken.GetEncoding` (encoding names) instead of `EncodingForModel`
  (model names).

- Cache keyed on the **requested** tokenizer, and failures are cached too, so a
  resolution is attempted at most once per tokenizer per process.

- Approximations log at Debug; Warning is reserved for genuinely unknown
  tokenizer values. The remaining Error path now means a library/data-file
  problem rather than configuration.

Matching is case-insensitive and also accepts encoding identifiers, so
hand-written config and previously-resolved values keep working.

## Tests

`TokenizerEncodingMapTests` + `TiktokenCounterEncodingTests` — 35 tests, all
passing. Covers #1051's required cases (`Cl100KBase`, `O200KBase`, `Claude`,
`Gemini`, `LLaMA3`) plus:

- every `TokenizerType` value maps to one of the three encodings TiktokenSharp
  actually implements — this fails if someone adds an enum value without an arm;
- the counter produces a positive count with **zero** Warning/Error logs for each
  known tokenizer, exercising real TiktokenSharp rather than a mock;
- 25 consecutive counts with an unknown tokenizer produce exactly **one**
  warning — the regression test for the cache-key bug;
- `LLaMA3` and `Cl100KBase` yield identical counts, so a silent change to the
  documented approximation is caught.

No regressions: `Core.Services` + estimator suites, 759 passed / 6 pre-existing
skips.

## Not addressed

The approximations are unchanged in accuracy — everything non-OpenAI still counts
as `cl100k_base`. This makes that explicit and cheap instead of implicit and
exception-driven. Real per-family tokenizers (Claude, LLaMA, Gemini) would need
additional dependencies and belong in their own issue.
