### PR TITLE
test(core): pin token counts before the tokenizer library swap

### DIFF
--- a/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
+++ b/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
@@ -1,0 +1,305 @@
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Services;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Xunit.Abstractions;
+
+namespace ConduitLLM.BillingInvariantTests;
+
+/// <summary>
+/// Pins the exact token count each tiktoken encoding produces for a fixed corpus.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are <b>vocabulary</b> pins: they assert that a given encoding's BPE ranks and UTF-8
+/// handling produce a specific number. They deliberately do not exercise
+/// <see cref="TiktokenCounter"/>'s per-message arithmetic - that is pinned separately in
+/// <c>TiktokenCounterGoldenTests</c> - so that a red test here means the vocabulary moved and
+/// nothing else.
+/// </para>
+/// <para>
+/// They live in the billing-invariant suite because the counts they pin become money:
+/// <c>ChatSpendEstimator</c> turns a prompt count into a spend reservation with no safety buffer,
+/// and <c>UsageEstimationService</c> turns one into the billed usage whenever a streaming provider
+/// omits its own.
+/// </para>
+/// <para>
+/// The corpus is addressed by <i>encoding identifier</i> ("cl100k_base"), which
+/// <c>TokenizerEncodingMap.Resolve</c> accepts verbatim. That keeps this file independent of the
+/// <c>TokenizerType</c> mapping table and of whichever library is underneath, so a tokenizer
+/// migration should not need to touch it.
+/// </para>
+/// <para>
+/// <b>Provenance.</b> Captured from TiktokenSharp 1.2.1 on 2026-07-25 via the skipped
+/// <see cref="EmitBaseline"/> emitter below, then independently confirmed against Python
+/// <c>tiktoken</c>:
+/// </para>
+/// <code>
+/// enc = tiktoken.get_encoding("cl100k_base")          # and p50k_base, o200k_base
+/// len(enc.encode(text, disallowed_special=()))
+/// </code>
+/// <para>
+/// All 54 comparable entries matched exactly (18 corpus entries x 3 encodings). The four not
+/// cross-checked are <c>empty</c> (short-circuited before tokenizing), <c>prose-paragraph</c> and
+/// <c>long-mixed-100k</c> (too long to transcribe reliably into the oracle script), and
+/// <c>lone-surrogate</c> (Python cannot UTF-8 encode an unpaired surrogate at all, which is itself
+/// the interesting difference).
+/// </para>
+/// <para>
+/// <c>disallowed_special=()</c> is required to reproduce these numbers: it makes Python treat
+/// <c>&lt;|endoftext|&gt;</c> as ordinary text, which is what TiktokenSharp does by default. A
+/// tokenizer that recognises the marker instead counts the <c>special-token-text</c> entry as 4
+/// rather than 8 - a real and expected difference, not a broken pin.
+/// </para>
+/// <para>
+/// So these numbers are anchored to the tiktoken specification, not merely to whatever the current
+/// library happens to do. A failure here means the vocabulary changed - it does not mean the pin is
+/// stale. Do not re-run the emitter to make a red test green; find out what moved and why first.
+/// </para>
+/// </remarks>
+public sealed class TokenVocabularyGoldenTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public TokenVocabularyGoldenTests(ITestOutputHelper output) => _output = output;
+
+    /// <summary>Encodings addressed verbatim, bypassing the TokenizerType table.</summary>
+    private static readonly string[] Encodings = { "cl100k_base", "p50k_base", "o200k_base" };
+
+    /// <summary>
+    /// Every non-ASCII character is written as a backslash-u escape and every newline as \n, never
+    /// as a literal and never in a verbatim string. .gitattributes normalizes only *.sh, so a
+    /// literal would pick up CRLF on a Windows checkout, and a BOM or editor round-trip could
+    /// silently change the bytes - either of which moves the counts this file exists to pin.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> Corpus =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Degenerate and guard cases.
+            ["empty"] = "",
+            ["single-space"] = " ",
+            ["whitespace-run"] = "    \n\n\t\t   ",
+            ["control-chars"] = "\u0000\u0001\u001F",
+
+            // Ordinary English: the common case, and the anchor for "nothing changed".
+            ["prose-short"] = "The quick brown fox jumps over the lazy dog.",
+            ["prose-paragraph"] =
+                "Conduit is a unified gateway for large language model providers. It accepts an "
+                + "OpenAI-compatible request, resolves the requested model alias to a provider "
+                + "mapping, forwards the call, and records the resulting usage against a virtual "
+                + "key. Because providers differ in what they report, the gateway sometimes has to "
+                + "estimate token usage rather than read it from the response. Those estimates feed "
+                + "spend reservations and rate limits, so the arithmetic behind them is worth "
+                + "pinning down precisely rather than trusting to luck or to a library upgrade.",
+            ["contractions-lower"] = "don't won't it's they're I'll we've",
+            ["contractions-upper"] = "DON'T WON'T IT'S THEY'RE I'LL WE'VE",
+            ["punctuation-run"] = "...!!!???---___===+++",
+
+            // Source code: indentation runs tokenize specially in cl100k.
+            ["code-csharp"] = "public sealed class Foo\n{\n    private readonly int _x;\n}\n",
+            ["code-json"] = "{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\"}]}",
+
+            // Non-Latin scripts. Chinese for "Hello world. This is a test."
+            ["cjk-chinese"] =
+                "\u4F60\u597D\u4E16\u754C\u3002\u8FD9\u662F\u4E00\u4E2A\u6D4B\u8BD5\u3002",
+            // Japanese hiragana wrapped around an ASCII word.
+            ["cjk-japanese-mixed"] = "\u3053\u3093\u306B\u3061\u306FConduit\u3067\u3059",
+            ["cyrillic"] = "\u041F\u0440\u0438\u0432\u0435\u0442",
+            // Decomposed (e + combining acute) against precomposed. Must NOT be normalized away.
+            ["combining-marks"] = "e\u0301 vs \u00E9",
+
+            // Surrogate handling: the highest-risk divergence between UTF-8 encoders.
+            ["emoji-bmp"] = "\u2764",
+            ["emoji-astral"] = "\uD83D\uDE00",
+            ["emoji-zwj"] = "\uD83D\uDC69\u200D\uD83D\uDCBB",
+            // Unpaired high surrogate. Reachable from real traffic; encoders differ on whether
+            // they substitute U+FFFD or throw, and throwing lands in the counter's char/4 fallback.
+            ["lone-surrogate"] = "a\uD800b",
+
+            // Adversarial: a special-token marker appearing as ordinary user text. Whether this
+            // encodes as one token or as its literal characters is a library policy decision, and
+            // it is directly reachable from a caller's prompt.
+            ["special-token-text"] = "hello <|endoftext|> world",
+
+            // Scale.
+            ["repeat-10k"] = new string('a', 10_000),
+            ["long-mixed-100k"] = BuildLongMixed(),
+        };
+
+    /// <summary>Deterministic ~100 KB of mixed content. No randomness: the pins must be stable.</summary>
+    private static string BuildLongMixed()
+    {
+        const string Unit = "The gateway forwarded 1,024 tokens to provider #7. "
+            + "\u4F60\u597D\u4E16\u754C\u3002 { \"ok\": true }\n";
+        var builder = new System.Text.StringBuilder(capacity: 102_400);
+        while (builder.Length < 100_000)
+        {
+            builder.Append(Unit);
+        }
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Counts pinned from the current implementation, keyed "{encoding}|{corpusId}".
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, int> Expected =
+        new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["cl100k_base|cjk-chinese"] = 11,
+            ["cl100k_base|cjk-japanese-mixed"] = 4,
+            ["cl100k_base|code-csharp"] = 14,
+            ["cl100k_base|code-json"] = 16,
+            ["cl100k_base|combining-marks"] = 4,
+            ["cl100k_base|contractions-lower"] = 12,
+            ["cl100k_base|contractions-upper"] = 14,
+            ["cl100k_base|control-chars"] = 3,
+            ["cl100k_base|cyrillic"] = 3,
+            ["cl100k_base|emoji-astral"] = 2,
+            ["cl100k_base|emoji-bmp"] = 2,
+            ["cl100k_base|emoji-zwj"] = 7,
+            ["cl100k_base|empty"] = 0,
+            ["cl100k_base|lone-surrogate"] = 3,
+            ["cl100k_base|long-mixed-100k"] = 36114,
+            ["cl100k_base|prose-paragraph"] = 99,
+            ["cl100k_base|prose-short"] = 10,
+            ["cl100k_base|punctuation-run"] = 7,
+            ["cl100k_base|repeat-10k"] = 1250,
+            ["cl100k_base|single-space"] = 1,
+            ["cl100k_base|special-token-text"] = 8,
+            ["cl100k_base|whitespace-run"] = 2,
+            ["p50k_base|cjk-chinese"] = 20,
+            ["p50k_base|cjk-japanese-mixed"] = 10,
+            ["p50k_base|code-csharp"] = 18,
+            ["p50k_base|code-json"] = 17,
+            ["p50k_base|combining-marks"] = 5,
+            ["p50k_base|contractions-lower"] = 12,
+            ["p50k_base|contractions-upper"] = 19,
+            ["p50k_base|control-chars"] = 3,
+            ["p50k_base|cyrillic"] = 7,
+            ["p50k_base|emoji-astral"] = 2,
+            ["p50k_base|emoji-bmp"] = 2,
+            ["p50k_base|emoji-zwj"] = 7,
+            ["p50k_base|empty"] = 0,
+            ["p50k_base|lone-surrogate"] = 3,
+            ["p50k_base|long-mixed-100k"] = 40281,
+            ["p50k_base|prose-paragraph"] = 100,
+            ["p50k_base|prose-short"] = 10,
+            ["p50k_base|punctuation-run"] = 7,
+            ["p50k_base|repeat-10k"] = 2500,
+            ["p50k_base|single-space"] = 1,
+            ["p50k_base|special-token-text"] = 9,
+            ["p50k_base|whitespace-run"] = 5,
+            ["o200k_base|cjk-chinese"] = 7,
+            ["o200k_base|cjk-japanese-mixed"] = 4,
+            ["o200k_base|code-csharp"] = 14,
+            ["o200k_base|code-json"] = 17,
+            ["o200k_base|combining-marks"] = 4,
+            ["o200k_base|contractions-lower"] = 6,
+            ["o200k_base|contractions-upper"] = 14,
+            ["o200k_base|control-chars"] = 3,
+            ["o200k_base|cyrillic"] = 2,
+            ["o200k_base|emoji-astral"] = 1,
+            ["o200k_base|emoji-bmp"] = 1,
+            ["o200k_base|emoji-zwj"] = 5,
+            ["o200k_base|empty"] = 0,
+            ["o200k_base|lone-surrogate"] = 3,
+            ["o200k_base|long-mixed-100k"] = 31947,
+            ["o200k_base|prose-paragraph"] = 99,
+            ["o200k_base|prose-short"] = 10,
+            ["o200k_base|punctuation-run"] = 7,
+            ["o200k_base|repeat-10k"] = 1250,
+            ["o200k_base|single-space"] = 1,
+            ["o200k_base|special-token-text"] = 9,
+            ["o200k_base|whitespace-run"] = 2,
+        };
+
+    public static TheoryData<string, string> Cases()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var encoding in Encodings)
+        {
+            foreach (var id in Corpus.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                data.Add(encoding, id);
+            }
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task Encoding_ProducesPinnedTokenCount(string encoding, string corpusId)
+    {
+        var counter = CounterFor(encoding);
+
+        var actual = await counter.EstimateTokenCountAsync($"probe-{encoding}", Corpus[corpusId]);
+
+        Assert.Equal(Expected[$"{encoding}|{corpusId}"], actual);
+    }
+
+    /// <summary>
+    /// Fails if a corpus entry was added without a pinned count, so the corpus cannot silently
+    /// grow past its coverage.
+    /// </summary>
+    [Fact]
+    public void EveryCorpusEntry_HasAPinnedCountForEveryEncoding()
+    {
+        var missing = (from encoding in Encodings
+                       from id in Corpus.Keys
+                       let key = $"{encoding}|{id}"
+                       where !Expected.ContainsKey(key)
+                       select key)
+                      .OrderBy(k => k, StringComparer.Ordinal)
+                      .ToList();
+
+        Assert.True(missing.Count == 0, "Unpinned corpus entries: " + string.Join(", ", missing));
+    }
+
+    /// <summary>
+    /// Fails if a pin exists for a corpus entry or encoding that no longer exists, so deletions do
+    /// not leave dead expectations behind.
+    /// </summary>
+    [Fact]
+    public void EveryPin_CorrespondsToALiveCorpusEntry()
+    {
+        var live = (from encoding in Encodings from id in Corpus.Keys select $"{encoding}|{id}")
+            .ToHashSet(StringComparer.Ordinal);
+
+        var orphaned = Expected.Keys.Where(k => !live.Contains(k))
+            .OrderBy(k => k, StringComparer.Ordinal).ToList();
+
+        Assert.True(orphaned.Count == 0, "Pins with no corpus entry: " + string.Join(", ", orphaned));
+    }
+
+    [Fact(Skip = "Baseline emitter. Un-skip locally, run, paste the output into Expected, re-skip. "
+               + "Never leave un-skipped: it asserts nothing.")]
+    public async Task EmitBaseline()
+    {
+        foreach (var encoding in Encodings)
+        {
+            var counter = CounterFor(encoding);
+            foreach (var id in Corpus.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var count = await counter.EstimateTokenCountAsync($"probe-{encoding}", Corpus[id]);
+                _output.WriteLine($"            [\"{encoding}|{id}\"] = {count},");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds a counter pinned to one encoding. The capability service is the only input that
+    /// selects a tokenizer, and it accepts an encoding identifier verbatim.
+    /// </summary>
+    private static ITokenCounter CounterFor(string encodingName)
+    {
+        var capabilities = new Mock<IModelCapabilityService>();
+        capabilities
+            .Setup(c => c.GetTokenizerTypeAsync(It.IsAny<string>()))
+            .ReturnsAsync(encodingName);
+
+        return new TiktokenCounter(NullLogger<TiktokenCounter>.Instance, capabilities.Object);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
@@ -1,0 +1,343 @@
+using System.Text.Json;
+
+using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Services;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Pins what <see cref="TiktokenCounter"/> adds on top of the raw vocabulary: which tokenizer a
+    /// <c>TokenizerType</c> resolves to, the per-message overhead arithmetic, and the multimodal
+    /// content paths.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the companion to <c>TokenVocabularyGoldenTests</c> in the billing-invariant suite.
+    /// The split is deliberate: those pins are keyed on an <i>encoding name</i> and must never move,
+    /// while these are keyed on a <c>TokenizerType</c> and are expected to move whenever the
+    /// resolution table changes. A red test in one file therefore tells you which layer changed.
+    /// </para>
+    /// <para>
+    /// Every probe string here is plain ASCII. Vocabulary behaviour is the other file's job; keeping
+    /// this one ASCII means these numbers move only when the counter's arithmetic or the resolution
+    /// table moves, and it sidesteps the encoding hazards that file has to guard against.
+    /// </para>
+    /// <para>
+    /// <b>Expected to move.</b> Anything that changes which tokenizer a <c>TokenizerType</c> maps to
+    /// will change the <c>Resolution</c> pins for that type, and that is the point of pinning them:
+    /// the diff is the review artefact. Update those values deliberately, one line at a time, with
+    /// the before/after in the commit message.
+    /// </para>
+    /// <para>
+    /// Captured from TiktokenSharp 1.2.1 on 2026-07-25 via the skipped emitters below.
+    /// </para>
+    /// </remarks>
+    public class TiktokenCounterGoldenTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TiktokenCounterGoldenTests(ITestOutputHelper output) => _output = output;
+
+        /// <summary>
+        /// Single ASCII probe shared by every resolution pin, chosen so that cl100k_base,
+        /// p50k_base and o200k_base each produce a <i>different</i> count.
+        /// </summary>
+        /// <remarks>
+        /// This matters more than it looks. Ordinary English prose tokenizes identically across all
+        /// three encodings - "The quick brown fox jumps over the lazy dog." is 10 tokens in every
+        /// one of them - so a prose probe would pin 10 for all 23 TokenizerTypes and silently fail
+        /// to notice a resolution change, which is the only thing these pins exist to catch.
+        /// Contractions separate o200k from the others, and a long run of a repeated character
+        /// separates p50k (which merges 4 at a time) from cl100k and o200k (8 at a time).
+        /// <see cref="Probe_ProducesADifferentCountForEveryEncoding"/> enforces the property.
+        /// </remarks>
+        private static readonly string Probe =
+            "don't won't it's they're I'll we've " + new string('a', 64);
+
+        /// <summary>
+        /// Token count of <see cref="Probe"/> for each TokenizerType, through the full counter.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<string, int> ExpectedByTokenizer =
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["None"] = 22,
+                ["Cl100KBase"] = 22,
+                ["P50KBase"] = 29,
+                ["P50KEdit"] = 29,
+                ["R50KBase"] = 29,
+                ["O200KBase"] = 16,
+                ["Claude"] = 22,
+                ["Claude3"] = 22,
+                ["Gemini"] = 22,
+                ["PaLM"] = 22,
+                ["LLaMA"] = 22,
+                ["LLaMA2"] = 22,
+                ["LLaMA3"] = 22,
+                ["Mistral"] = 22,
+                ["Cohere"] = 22,
+                ["O200KHarmony"] = 16,
+                ["Kimi"] = 22,
+                ["Groq"] = 22,
+                ["Cerebras"] = 22,
+                ["MiniMax"] = 22,
+                ["SentencePiece"] = 22,
+                ["BPE"] = 22,
+                ["WordPiece"] = 22,
+                ["Tiktoken"] = 22,
+            };
+
+        /// <summary>
+        /// Message shapes exercising the per-message +4, the +1 for Name, and the +3 reply priming.
+        /// All content is ASCII so the deltas between rows are pure arithmetic.
+        /// </summary>
+        private static readonly IReadOnlyDictionary<string, List<Message>> MessageShapes =
+            new Dictionary<string, List<Message>>(StringComparer.Ordinal)
+            {
+                ["msgs-empty-list"] = new(),
+                ["msgs-single-user"] = new()
+                {
+                    new Message { Role = "user", Content = "Hello there." }
+                },
+                ["msgs-conversation"] = new()
+                {
+                    new Message { Role = "system", Content = "You are a helpful assistant." },
+                    new Message { Role = "user", Content = "What is the capital of France?" },
+                    new Message { Role = "assistant", Content = "Paris." },
+                    new Message { Role = "user", Content = "And of Germany?" }
+                },
+                ["msgs-named"] = new()
+                {
+                    new Message { Role = "tool", Content = "42", Name = "calculator" }
+                },
+                ["msgs-null-content"] = new()
+                {
+                    new Message { Role = "assistant", Content = null }
+                },
+                // Empty string and null take different branches in the counter.
+                ["msgs-empty-content"] = new()
+                {
+                    new Message { Role = "user", Content = "" }
+                },
+            };
+
+        private static readonly IReadOnlyDictionary<string, int> ExpectedByMessageShape =
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["msgs-conversation"] = 42,
+                ["msgs-empty-content"] = 8,
+                ["msgs-empty-list"] = 0,
+                ["msgs-named"] = 11,
+                ["msgs-null-content"] = 8,
+                ["msgs-single-user"] = 11,
+            };
+
+        /// <summary>
+        /// Multimodal content delivered as a <see cref="JsonElement"/>, which is how it arrives when
+        /// a request body is deserialized. This path is otherwise untested.
+        /// </summary>
+        /// <remarks>
+        /// Two of these rows pin known defects rather than desired behaviour, so that fixing them is
+        /// a visible decision: <c>json-unknown-part</c> shows that an audio content part contributes
+        /// zero tokens, and <c>json-text-missing-text</c> shows the same for a malformed text part.
+        /// <c>json-one-image</c> and <c>json-three-images</c> pin the hard-coded 65-tokens-per-image
+        /// constant, which does not match the real vision formula used elsewhere in the codebase.
+        /// </remarks>
+        private static readonly IReadOnlyDictionary<string, string> JsonContentShapes =
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["json-bare-string"] = "\"hello there\"",
+                ["json-text-part"] =
+                    "[{\"type\":\"text\",\"text\":\"hello there\"}]",
+                ["json-one-image"] =
+                    "[{\"type\":\"text\",\"text\":\"hello there\"},"
+                    + "{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.test/a.png\"}}]",
+                ["json-three-images"] =
+                    "[{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.test/a.png\"}},"
+                    + "{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.test/b.png\"}},"
+                    + "{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.test/c.png\"}}]",
+                ["json-image-only"] =
+                    "[{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.test/a.png\"}}]",
+                ["json-unknown-part"] =
+                    "[{\"type\":\"input_audio\",\"input_audio\":{\"data\":\"AAAA\",\"format\":\"wav\"}}]",
+                ["json-text-missing-text"] = "[{\"type\":\"text\"}]",
+            };
+
+        private static readonly IReadOnlyDictionary<string, int> ExpectedByJsonShape =
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["json-bare-string"] = 10,
+                ["json-image-only"] = 73,
+                ["json-one-image"] = 75,
+                ["json-text-missing-text"] = 8,
+                ["json-text-part"] = 10,
+                ["json-three-images"] = 203,
+                ["json-unknown-part"] = 8,
+            };
+
+        public static TheoryData<string> TokenizerTypes()
+        {
+            var data = new TheoryData<string>();
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                data.Add(tokenizerType.ToString());
+            }
+            return data;
+        }
+
+        public static TheoryData<string> MessageShapeIds() => Keys(MessageShapes.Keys);
+
+        public static TheoryData<string> JsonShapeIds() => Keys(JsonContentShapes.Keys);
+
+        private static TheoryData<string> Keys(IEnumerable<string> keys)
+        {
+            var data = new TheoryData<string>();
+            foreach (var key in keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                data.Add(key);
+            }
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(TokenizerTypes))]
+        public async Task Resolution_ProducesPinnedTokenCount(string tokenizerType)
+        {
+            var counter = CounterFor(tokenizerType);
+
+            var actual = await counter.EstimateTokenCountAsync($"probe-{tokenizerType}", Probe);
+
+            Assert.Equal(ExpectedByTokenizer[tokenizerType], actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(MessageShapeIds))]
+        public async Task MessageShape_ProducesPinnedTokenCount(string shapeId)
+        {
+            var counter = CounterFor("cl100k_base");
+
+            var actual = await counter.EstimateTokenCountAsync("probe-messages", MessageShapes[shapeId]);
+
+            Assert.Equal(ExpectedByMessageShape[shapeId], actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonShapeIds))]
+        public async Task JsonContentShape_ProducesPinnedTokenCount(string shapeId)
+        {
+            var counter = CounterFor("cl100k_base");
+
+            var actual = await counter.EstimateTokenCountAsync("probe-json", JsonMessage(shapeId));
+
+            Assert.Equal(ExpectedByJsonShape[shapeId], actual);
+        }
+
+        /// <summary>
+        /// Guards the property that makes the resolution pins meaningful: the probe must produce a
+        /// different count under each supported encoding.
+        /// </summary>
+        /// <remarks>
+        /// Without this, a probe whose count happens to coincide across encodings would make every
+        /// resolution pin identical, and a change that silently re-pointed a TokenizerType at the
+        /// wrong tokenizer would still be green. If this test fails, do not relax it - pick a probe
+        /// that separates the encodings again and re-pin.
+        /// </remarks>
+        [Fact]
+        public async Task Probe_ProducesADifferentCountForEveryEncoding()
+        {
+            var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var encoding in new[] { "cl100k_base", "p50k_base", "o200k_base" })
+            {
+                counts[encoding] = await CounterFor(encoding)
+                    .EstimateTokenCountAsync($"probe-{encoding}", Probe);
+            }
+
+            Assert.Equal(counts.Count, counts.Values.Distinct().Count());
+        }
+
+        /// <summary>
+        /// Fails if a shape was added without a pinned count, so no table can outgrow its coverage.
+        /// </summary>
+        [Fact]
+        public void EveryShape_HasAPinnedCount()
+        {
+            var missing = new List<string>();
+
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                if (!ExpectedByTokenizer.ContainsKey(tokenizerType.ToString()))
+                {
+                    missing.Add($"tokenizer:{tokenizerType}");
+                }
+            }
+
+            missing.AddRange(MessageShapes.Keys
+                .Where(k => !ExpectedByMessageShape.ContainsKey(k)).Select(k => $"messages:{k}"));
+            missing.AddRange(JsonContentShapes.Keys
+                .Where(k => !ExpectedByJsonShape.ContainsKey(k)).Select(k => $"json:{k}"));
+
+            Assert.True(missing.Count == 0, "Unpinned shapes: " + string.Join(", ", missing));
+        }
+
+        [Fact(Skip = "Baseline emitter. Un-skip locally, run, paste each block into the matching "
+                   + "table, re-skip. Never leave un-skipped: it asserts nothing.")]
+        public async Task EmitBaseline()
+        {
+            _output.WriteLine("--- RESOLUTION ---");
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                var name = tokenizerType.ToString();
+                var count = await CounterFor(name).EstimateTokenCountAsync($"probe-{name}", Probe);
+                _output.WriteLine($"                [\"{name}\"] = {count},");
+            }
+
+            _output.WriteLine("--- MESSAGES ---");
+            foreach (var id in MessageShapes.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var count = await CounterFor("cl100k_base")
+                    .EstimateTokenCountAsync("probe-messages", MessageShapes[id]);
+                _output.WriteLine($"                [\"{id}\"] = {count},");
+            }
+
+            _output.WriteLine("--- JSON ---");
+            foreach (var id in JsonContentShapes.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var count = await CounterFor("cl100k_base")
+                    .EstimateTokenCountAsync("probe-json", JsonMessage(id));
+                _output.WriteLine($"                [\"{id}\"] = {count},");
+            }
+        }
+
+        /// <summary>Wraps a JSON content payload in the single user message the counter will see.</summary>
+        private static List<Message> JsonMessage(string shapeId) => new()
+        {
+            new Message
+            {
+                Role = "user",
+                // Deserializing to JsonElement detaches it from the JsonDocument, so it stays valid.
+                Content = JsonSerializer.Deserialize<JsonElement>(JsonContentShapes[shapeId])
+            }
+        };
+
+        /// <summary>
+        /// Builds a counter pinned to one tokenizer. The capability service is the only input that
+        /// selects one, and it accepts either a TokenizerType name or an encoding identifier.
+        /// </summary>
+        private static ITokenCounter CounterFor(string tokenizerType)
+        {
+            var capabilities = new Mock<IModelCapabilityService>();
+            capabilities
+                .Setup(c => c.GetTokenizerTypeAsync(It.IsAny<string>()))
+                .ReturnsAsync(tokenizerType);
+
+            return new TiktokenCounter(NullLogger<TiktokenCounter>.Instance, capabilities.Object);
+        }
+    }
+}


### PR DESCRIPTION
PR 1 of 4 in the tokenizer migration. **Zero production changes** — this is only the safety net,
landed first deliberately so that reverting the library swap later cannot revert the thing that
judges it.

Related: #1051 (merged, #1226), #1227 (runtime vocab download).

## Why

No test anywhere asserted an exact token count. All four `ITokenCounter` consumers mock the
interface, so nothing in the suite could detect a count change — on a path that sets money:

| Consumer | Consequence of a wrong count |
|---|---|
| `ChatSpendEstimator.cs:65` | Becomes a `decimal` spend reservation. **No safety buffer.** |
| `UsageEstimationService.cs:53-60` | Becomes the **billed** usage when a streaming provider omits its own (+10% buffer) |
| `RequestTokenEstimator.cs:89,99` | TPM rate-limit windows |

## Two layers, so a red test says *which* thing moved

**Layer A — `TokenVocabularyGoldenTests`** (billing-invariant suite, the required Release CI gate).
66 pins: 22 corpus entries x 3 encodings. Addressed by **encoding identifier**
(`"cl100k_base"`), which `TokenizerEncodingMap.Resolve` already accepts verbatim — so the file is
independent of the `TokenizerType` table and of whichever library is underneath, and a migration
should not need to touch it. **These must not move.**

Corpus covers: empty / whitespace runs / C0 control chars; prose short and long; contractions
(a known p50k↔cl100k divergence); C# and JSON source; CJK, Japanese, Cyrillic, combining marks;
BMP, astral and ZWJ emoji; an unpaired surrogate; `<|endoftext|>` as user text; 10 KB and 100 KB
inputs.

**Layer B — `TiktokenCounterGoldenTests`** (unit suite). Pins what the counter adds on top: which
tokenizer each of the 23 `TokenizerType`s resolves to, the `+4` / `+1` for `Name` / `+3` priming
arithmetic, and the `JsonElement` multimodal path — which had **no coverage at all**. These are
*expected* to move when the resolution table changes; that diff is the review artefact.

## Verified against an independent oracle

All **54 of 54** comparable Layer A entries match Python `tiktoken` exactly:

```python
enc.encode(text, disallowed_special=())   # cl100k_base, p50k_base, o200k_base
```

So these numbers are anchored to the tiktoken specification, not merely to what TiktokenSharp
happens to do. The four not cross-checked are documented in the file with reasons (two too long to
transcribe reliably, one short-circuits before tokenizing, one Python cannot encode at all — an
unpaired surrogate).

`disallowed_special=()` is load-bearing and pins down a real policy difference: a tokenizer that
*recognises* `<|endoftext|>` counts that entry as **4** rather than **8**. Worth knowing before a
library swap, not after.

## Two things worth a reviewer's eye

**The obvious probe was useless.** I first used `"The quick brown fox jumps over the lazy dog."` for
the Layer B resolution pins. It's 10 tokens in cl100k, p50k *and* o200k, so every one of the 23
`TokenizerType`s pinned `10` — the pins could not have detected a resolution change, which is the
only thing they exist to catch. The probe is now a contraction run plus a repeated-character run
(22 / 29 / 16 across the three encodings), and `Probe_ProducesADifferentCountForEveryEncoding`
enforces the property so it cannot regress silently.

**Three Layer B rows pin defects, not desired behaviour**, so that fixing them is a visible
decision rather than an invisible drift:
- `json-unknown-part` — an `input_audio` content part contributes **0** tokens.
- `json-text-missing-text` — a malformed text part contributes **0**.
- `json-one-image` / `json-three-images` — images contribute a hard-coded **65**, which does not
  match the real vision formula `IImageTokenCalculator` implements and uses elsewhere.

Follow-up issues for these will be filed; they are deliberately not fixed here.

## Conventions

Both files are pure ASCII: every non-ASCII character is a `\uXXXX` escape, no verbatim strings,
newlines written `\n`. `.gitattributes` normalizes only `*.sh`, so a literal would pick up CRLF on
a Windows checkout and move the very counts being pinned. Plain `Assert` + Moq + `[Theory]`,
matching the neighbouring tokenizer tests.

Baselines come from a committed, permanently-**skipped** emitter. Regeneration should be manual and
slightly annoying on a money path, so a human reads each changed number in the diff. Both files also
carry completeness guards that fail if a corpus entry is added without a pin, or a pin outlives its
entry.

## Verification

- `Tests/ConduitLLM.BillingInvariantTests` **Release** (as CI runs it): **79 passed, 1 skipped**
- `Core.Services` + tokenizer + estimator suites: **807 passed, 7 skipped** (up from a 759/6
  baseline; the extra skip is the new emitter)
- Both new files confirmed byte-level ASCII
