### PR TITLE
fix(core): bundle tokenizer vocabularies — swap TiktokenSharp for Microsoft.ML.Tokenizers (#1227)

### DIFF
--- a/.github/SETUP_DOTNET_VERSIONING.md
+++ b/.github/SETUP_DOTNET_VERSIONING.md
@@ -138,7 +138,7 @@ Or trigger GitHub Actions manually:
 
 ### ConduitLLM.Core  
 - **Purpose**: Core interfaces, models, business logic
-- **Dependencies**: AWS S3, Polly, TiktokenSharp, ConduitLLM.Configuration
+- **Dependencies**: AWS S3, Polly, Microsoft.ML.Tokenizers, ConduitLLM.Configuration
 - **Use Case**: When building applications that use Conduit's core functionality
 
 ### ConduitLLM.Providers
@@ -231,7 +231,7 @@ ConduitLLM.Core
 ├── ConduitLLM.Configuration
 ├── AWS S3 SDK
 ├── Polly (resilience)
-└── TiktokenSharp (tokenization)
+└── Microsoft.ML.Tokenizers (tokenization, bundled vocabularies)
 
 ConduitLLM.Providers  
 ├── ConduitLLM.Core

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Common" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.10" />
+    <!-- Security override for Microsoft.ML.Tokenizers transitives (GHSA-73j8-2gch-69rq / CVE-2026-26127, high; fixed in 9.0.14). -->
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />
     <!-- Security override for EF Core Design transitives (CVE-2025-55247). -->
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.6.3" />
     <!-- Security override for EF Core Design transitives (CVE-2025-55247). -->
@@ -57,6 +59,13 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <!-- Tokenizer engine plus its offline vocabulary data. The .Data.* packages embed the tiktoken
+         BPE files, replacing TiktokenSharp's runtime download from Azure Blob Storage (#1227). -->
+    <PackageVersion Include="Microsoft.ML.Tokenizers" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.P50kBase" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.R50kBase" Version="2.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <!-- Security override for Microsoft.AspNetCore.OpenApi transitives (GHSA-v5pm-xwqc-g5wc, high; fixed in 2.7.5). -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
@@ -94,7 +103,6 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.0.0" />
-    <PackageVersion Include="TiktokenSharp" Version="1.2.1" />
     <PackageVersion Include="WolverineFx" Version="6.14.0" />
     <PackageVersion Include="WolverineFx.Postgresql" Version="6.14.0" />
     <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />

--- a/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
+++ b/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
@@ -12,11 +12,19 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="MessagePack" />
+    <!-- Direct reference lifts the vulnerable 9.0.4 that Microsoft.ML.Tokenizers pulls transitively
+         (GHSA-73j8-2gch-69rq); transitive pinning is not enabled centrally. -->
+    <PackageReference Include="Microsoft.Bcl.Memory" />
+    <PackageReference Include="Microsoft.ML.Tokenizers" />
+    <!-- Offline tiktoken vocabularies for every encoding TokenizerEncodingMap can resolve to. -->
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.P50kBase" />
+    <PackageReference Include="Microsoft.ML.Tokenizers.Data.R50kBase" />
     <PackageReference Include="Polly" />
     <PackageReference Include="prometheus-net" />
     <PackageReference Include="prometheus-net.AspNetCore" />
     <PackageReference Include="StackExchange.Redis" />
-    <PackageReference Include="TiktokenSharp" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Shared/ConduitLLM.Core/README.md
+++ b/Shared/ConduitLLM.Core/README.md
@@ -279,7 +279,8 @@ All configuration supports environment variable substitution and validation.
 - **Polly** (8.6.2) - Resilience patterns and circuit breakers
 - **prometheus-net** (8.2.1) - Metrics collection and monitoring
 - **MassTransit** (8.5.6) - Message queuing and async processing
-- **TiktokenSharp** (1.1.7) - Token counting and optimization
+- **Microsoft.ML.Tokenizers** (2.0.0) - Token counting; vocabulary data is bundled via
+  Microsoft.ML.Tokenizers.Data.* packages, so tokenization needs no network access
 
 ### Project Dependencies
 - **ConduitLLM.Configuration** - Shared configuration models and validation

--- a/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
@@ -5,18 +5,19 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 
 using Microsoft.Extensions.Logging;
-
-using TiktokenSharp;
+using Microsoft.ML.Tokenizers;
 
 namespace ConduitLLM.Core.Services
 {
     /// <summary>
-    /// Token counter implementation using TiktokenSharp for OpenAI-compatible tokenization.
+    /// Token counter implementation using Microsoft.ML.Tokenizers for OpenAI-compatible (tiktoken)
+    /// tokenization.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The TiktokenCounter provides token counting functionality using the TiktokenSharp library,
-    /// which implements OpenAI's tokenization algorithm. This service is essential for:
+    /// The TiktokenCounter provides token counting functionality using Microsoft.ML.Tokenizers,
+    /// which implements OpenAI's tiktoken algorithm with vocabulary data bundled as NuGet
+    /// packages — no runtime download (#1227). This service is essential for:
     /// </para>
     /// <list type="bullet">
     ///   <item><description>Accurately estimating token usage for cost calculation</description></item>
@@ -40,7 +41,7 @@ namespace ConduitLLM.Core.Services
     {
         // Cache encodings for performance, keyed by the requested tokenizer identifier.
         // A null value is a cached failure and means "use character-based estimation".
-        private static readonly Dictionary<string, TikToken?> _encodings = new();
+        private static readonly Dictionary<string, Tokenizer?> _encodings = new();
         private static readonly object _lock = new();
         private readonly ILogger<TiktokenCounter> _logger;
         private readonly IModelCapabilityService? _capabilityService;
@@ -92,7 +93,7 @@ namespace ConduitLLM.Core.Services
                     {
                         try
                         {
-                            tokenCount += encoding.Encode(message.Role).Count;
+                            tokenCount += encoding.CountTokens(message.Role);
                         }
                         catch (Exception ex)
                         {
@@ -108,7 +109,7 @@ namespace ConduitLLM.Core.Services
                             if (message.Content is string contentStr)
                             {
                                 // Simple string content
-                                tokenCount += encoding.Encode(contentStr).Count;
+                                tokenCount += encoding.CountTokens(contentStr);
                             }
                             else if (message.Content is JsonElement jsonElement)
                             {
@@ -119,7 +120,7 @@ namespace ConduitLLM.Core.Services
                             {
                                 // Try to handle content parts or other objects
                                 string textContent = ExtractTextFromContentObject(message.Content);
-                                tokenCount += encoding.Encode(textContent).Count;
+                                tokenCount += encoding.CountTokens(textContent);
                             }
                         }
                         catch (Exception ex)
@@ -136,7 +137,7 @@ namespace ConduitLLM.Core.Services
                     {
                         try
                         {
-                            tokenCount += encoding.Encode(message.Name).Count;
+                            tokenCount += encoding.CountTokens(message.Name);
                         }
                         catch (Exception ex)
                         {
@@ -178,7 +179,7 @@ namespace ConduitLLM.Core.Services
 
                 try
                 {
-                    return encoding.Encode(text).Count;
+                    return encoding.CountTokens(text);
                 }
                 catch (Exception ex)
                 {
@@ -194,11 +195,11 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <summary>
-        /// Gets the appropriate TikToken encoding for a given model asynchronously.
+        /// Gets the appropriate tiktoken tokenizer for a given model asynchronously.
         /// </summary>
         /// <param name="modelName">The name of the model to get encoding for.</param>
-        /// <returns>The appropriate TikToken encoding, or null if it cannot be determined.</returns>
-        private async Task<TikToken?> GetEncodingForModelAsync(string modelName)
+        /// <returns>The appropriate tokenizer, or null if it cannot be determined.</returns>
+        private async Task<Tokenizer?> GetEncodingForModelAsync(string modelName)
         {
             try
             {
@@ -231,21 +232,21 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <summary>
-        /// Gets or creates a TikToken encoding with thread-safe caching.
+        /// Gets or creates a tiktoken tokenizer with thread-safe caching.
         /// </summary>
         /// <param name="tokenizerType">
         /// The tokenizer identifier from model metadata (a <c>TokenizerType</c> name such as
         /// <c>Cl100KBase</c> or <c>LLaMA3</c>), or null to use the default encoding.
         /// </param>
         /// <param name="modelName">The model name (for logging purposes).</param>
-        /// <returns>The TikToken encoding, or null if it cannot be created.</returns>
+        /// <returns>The tokenizer, or null if it cannot be created.</returns>
         /// <remarks>
         /// The cache is keyed on <paramref name="tokenizerType"/> rather than on the resolved
         /// encoding name. Keying it on the resolved name meant an unresolvable tokenizer never
         /// populated an entry under the key that was looked up, so every single token count
         /// re-entered the failure path and re-logged (#1051).
         /// </remarks>
-        private TikToken? GetOrCreateEncoding(string? tokenizerType, string modelName)
+        private Tokenizer? GetOrCreateEncoding(string? tokenizerType, string modelName)
         {
             var cacheKey = tokenizerType?.Trim() ?? string.Empty;
 
@@ -271,15 +272,16 @@ namespace ConduitLLM.Core.Services
                         tokenizerType, modelName, resolved.EncodingName);
                 }
 
-                TikToken? encoding;
+                Tokenizer? encoding;
                 try
                 {
-                    encoding = TikToken.GetEncoding(resolved.EncodingName);
+                    encoding = TiktokenTokenizer.CreateForEncoding(resolved.EncodingName);
                 }
                 catch (Exception ex)
                 {
-                    // The map only ever yields encodings TiktokenSharp implements, so this is a
-                    // library or data-file problem rather than bad configuration.
+                    // The map only ever yields encodings whose vocabulary ships in a referenced
+                    // Microsoft.ML.Tokenizers.Data.* package, so this indicates a missing package
+                    // reference rather than bad configuration or a network failure.
                     _logger.LogError(ex,
                         "Failed to load encoding {EncodingName} for model {ModelName}; falling back to character-based estimation",
                         resolved.EncodingName, modelName);
@@ -313,7 +315,7 @@ namespace ConduitLLM.Core.Services
         /// usage depends on resolution which isn't always available at counting time.
         /// </para>
         /// </remarks>
-        private int EstimateJsonElementTokens(JsonElement element, TikToken encoding)
+        private int EstimateJsonElementTokens(JsonElement element, Tokenizer encoding)
         {
             int tokenCount = 0;
 
@@ -322,7 +324,7 @@ namespace ConduitLLM.Core.Services
                 string? stringValue = element.GetString();
                 if (stringValue != null)
                 {
-                    tokenCount += encoding.Encode(stringValue).Count;
+                    tokenCount += encoding.CountTokens(stringValue);
                 }
             }
             else if (element.ValueKind == JsonValueKind.Array)
@@ -341,7 +343,7 @@ namespace ConduitLLM.Core.Services
                         string? text = textElement.GetString();
                         if (text != null)
                         {
-                            tokenCount += encoding.Encode(text).Count;
+                            tokenCount += encoding.CountTokens(text);
                         }
                     }
                     else if (item.TryGetProperty("type", out var imgTypeElement) &&

--- a/Shared/ConduitLLM.Core/Services/TokenizerEncodingMap.cs
+++ b/Shared/ConduitLLM.Core/Services/TokenizerEncodingMap.cs
@@ -5,9 +5,9 @@ namespace ConduitLLM.Core.Services
     /// <summary>
     /// The outcome of resolving a <see cref="TokenizerType"/> to a Tiktoken encoding name.
     /// </summary>
-    /// <param name="EncodingName">The Tiktoken encoding identifier to hand to TiktokenSharp.</param>
+    /// <param name="EncodingName">The tiktoken encoding identifier to hand to Microsoft.ML.Tokenizers.</param>
     /// <param name="IsApproximation">
-    /// True when the requested tokenizer has no exact TiktokenSharp equivalent and
+    /// True when the requested tokenizer has no exact tiktoken equivalent and
     /// <paramref name="EncodingName"/> is a documented stand-in. Token counts are estimates in
     /// that case, which matters for context management and fallback billing estimates.
     /// </param>
@@ -17,22 +17,24 @@ namespace ConduitLLM.Core.Services
     public readonly record struct TokenizerEncoding(string EncodingName, bool IsApproximation, bool IsRecognized);
 
     /// <summary>
-    /// Maps <see cref="TokenizerType"/> values onto the encoding identifiers TiktokenSharp accepts.
+    /// Maps <see cref="TokenizerType"/> values onto the encoding identifiers
+    /// Microsoft.ML.Tokenizers accepts.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Model metadata stores a <see cref="TokenizerType"/> and surfaces it as its enum name
-    /// (<c>Cl100KBase</c>, <c>LLaMA3</c>, ...), while TiktokenSharp expects lowercase encoding
-    /// identifiers (<c>cl100k_base</c>). Passing the enum name straight through made every
-    /// resolution — including the default — take an exception-driven fallback path.
+    /// (<c>Cl100KBase</c>, <c>LLaMA3</c>, ...), while the tokenizer library expects lowercase
+    /// encoding identifiers (<c>cl100k_base</c>). Passing the enum name straight through made
+    /// every resolution — including the default — take an exception-driven fallback path.
     /// </para>
     /// <para>
-    /// TiktokenSharp 1.2.1 implements exactly three encodings: <c>cl100k_base</c>,
-    /// <c>p50k_base</c> and <c>o200k_base</c>. <c>p50k_edit</c> and <c>r50k_base</c> throw
-    /// <see cref="NotImplementedException"/>, so they are mapped to the nearest implemented
-    /// vocabulary rather than requested directly. Every non-OpenAI tokenizer is an approximation:
-    /// Conduit uses these counts for context-window checks and for estimating usage when a
-    /// provider omits it, not as an authoritative count.
+    /// Microsoft.ML.Tokenizers implements five tiktoken encodings — <c>cl100k_base</c>,
+    /// <c>p50k_base</c>, <c>p50k_edit</c>, <c>r50k_base</c> and <c>o200k_base</c> — with the
+    /// vocabulary for each shipped in a <c>Microsoft.ML.Tokenizers.Data.*</c> package referenced
+    /// by ConduitLLM.Core. An encoding may only be added here alongside its data package, or
+    /// resolution fails at runtime. Every non-OpenAI tokenizer is an approximation: Conduit uses
+    /// these counts for context-window checks and for estimating usage when a provider omits it,
+    /// not as an authoritative count.
     /// </para>
     /// </remarks>
     public static class TokenizerEncodingMap
@@ -41,24 +43,22 @@ namespace ConduitLLM.Core.Services
         public const string DefaultEncoding = "cl100k_base";
 
         private const string P50KBase = "p50k_base";
+        private const string P50KEdit = "p50k_edit";
+        private const string R50KBase = "r50k_base";
         private const string O200KBase = "o200k_base";
 
-        // Exact: the tokenizer is an OpenAI encoding TiktokenSharp implements.
-        // Approximate: the tokenizer is a different vocabulary (or an OpenAI encoding
-        // TiktokenSharp does not implement) and the value is the closest available stand-in.
+        // Exact: the tokenizer is an OpenAI encoding with a bundled vocabulary.
+        // Approximate: the tokenizer is a different vocabulary and the value is the closest
+        // available stand-in.
         private static readonly IReadOnlyDictionary<TokenizerType, TokenizerEncoding> Map =
             new Dictionary<TokenizerType, TokenizerEncoding>
             {
                 // OpenAI — exact
                 [TokenizerType.Cl100KBase] = Exact(DefaultEncoding),
                 [TokenizerType.P50KBase] = Exact(P50KBase),
+                [TokenizerType.P50KEdit] = Exact(P50KEdit),
+                [TokenizerType.R50KBase] = Exact(R50KBase),
                 [TokenizerType.O200KBase] = Exact(O200KBase),
-
-                // OpenAI — not implemented by TiktokenSharp; nearest implemented vocabulary.
-                // p50k_edit is p50k_base plus edit-specific special tokens; r50k_base is the
-                // GPT-2/Codex vocabulary that p50k_base extends.
-                [TokenizerType.P50KEdit] = Approximate(P50KBase),
-                [TokenizerType.R50KBase] = Approximate(P50KBase),
 
                 // GPT-OSS harmony is the o200k vocabulary plus harmony-format special tokens.
                 [TokenizerType.O200KHarmony] = Approximate(O200KBase),
@@ -90,7 +90,7 @@ namespace ConduitLLM.Core.Services
             };
 
         /// <summary>
-        /// Resolves a tokenizer identifier to the encoding TiktokenSharp should be asked for.
+        /// Resolves a tokenizer identifier to the encoding the tokenizer library should be asked for.
         /// </summary>
         /// <param name="tokenizerType">
         /// A <see cref="TokenizerType"/> name (<c>Cl100KBase</c>, <c>LLaMA3</c>, ...) or an
@@ -119,9 +119,9 @@ namespace ConduitLLM.Core.Services
             {
                 DefaultEncoding => Exact(DefaultEncoding),
                 P50KBase => Exact(P50KBase),
+                P50KEdit => Exact(P50KEdit),
+                R50KBase => Exact(R50KBase),
                 O200KBase => Exact(O200KBase),
-                "p50k_edit" => Approximate(P50KBase),
-                "r50k_base" => Approximate(P50KBase),
                 "o200k_harmony" => Approximate(O200KBase),
                 _ => new TokenizerEncoding(DefaultEncoding, IsApproximation: true, IsRecognized: false)
             };

--- a/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
+++ b/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
@@ -33,26 +33,35 @@ namespace ConduitLLM.BillingInvariantTests;
 /// migration should not need to touch it.
 /// </para>
 /// <para>
-/// <b>Provenance.</b> Captured from TiktokenSharp 1.2.1 on 2026-07-25 via the skipped
+/// <b>Provenance.</b> Originally captured from TiktokenSharp 1.2.1 on 2026-07-25 via the skipped
 /// <see cref="EmitBaseline"/> emitter below, then independently confirmed against Python
 /// <c>tiktoken</c>:
 /// </para>
 /// <code>
-/// enc = tiktoken.get_encoding("cl100k_base")          # and p50k_base, o200k_base
-/// len(enc.encode(text, disallowed_special=()))
+/// enc = tiktoken.get_encoding("cl100k_base")          # and the other encodings
+/// len(enc.encode(text, allowed_special="all"))
 /// </code>
 /// <para>
-/// All 54 comparable entries matched exactly (18 corpus entries x 3 encodings). The four not
-/// cross-checked are <c>empty</c> (short-circuited before tokenizing), <c>prose-paragraph</c> and
-/// <c>long-mixed-100k</c> (too long to transcribe reliably into the oracle script), and
-/// <c>lone-surrogate</c> (Python cannot UTF-8 encode an unpaired surrogate at all, which is itself
-/// the interesting difference).
+/// Re-captured from Microsoft.ML.Tokenizers 2.0.0 during the TiktokenSharp replacement (#1227).
+/// Of the 66 original pins, 60 reproduced exactly; the six that moved are the two entries the
+/// paragraphs below always flagged as library policy decisions, and they moved in the documented
+/// direction. The <c>p50k_edit</c> and <c>r50k_base</c> groups were added at the same time (those
+/// encodings were previously unavailable): <c>p50k_edit</c> shares every pin with
+/// <c>p50k_base</c> because they differ only in special tokens this corpus does not contain,
+/// while <c>r50k_base</c> diverges on <c>code-csharp</c> and <c>whitespace-run</c>, the entries
+/// exercising the whitespace-run merges p50k added on top of the GPT-2 vocabulary.
 /// </para>
 /// <para>
-/// <c>disallowed_special=()</c> is required to reproduce these numbers: it makes Python treat
-/// <c>&lt;|endoftext|&gt;</c> as ordinary text, which is what TiktokenSharp does by default. A
-/// tokenizer that recognises the marker instead counts the <c>special-token-text</c> entry as 4
-/// rather than 8 - a real and expected difference, not a broken pin.
+/// <c>special-token-text</c>: Microsoft.ML.Tokenizers recognises each encoding's registered
+/// special tokens in input, so <c>&lt;|endoftext|&gt;</c> counts as one token (the entry pins 4).
+/// TiktokenSharp treated the marker as ordinary text (8-9). Python reproduces the current pins
+/// with <c>allowed_special="all"</c> and the old ones with <c>disallowed_special=()</c>.
+/// </para>
+/// <para>
+/// <c>lone-surrogate</c>: Microsoft.ML.Tokenizers substitutes U+FFFD for the unpaired surrogate
+/// and never throws (TiktokenSharp pinned 3; the replacement char tokenizes to 4-5). Python
+/// cannot UTF-8 encode an unpaired surrogate at all, so this entry has no Python oracle - the
+/// pin records observed, deterministic library behaviour.
 /// </para>
 /// <para>
 /// So these numbers are anchored to the tiktoken specification, not merely to whatever the current
@@ -67,7 +76,8 @@ public sealed class TokenVocabularyGoldenTests
     public TokenVocabularyGoldenTests(ITestOutputHelper output) => _output = output;
 
     /// <summary>Encodings addressed verbatim, bypassing the TokenizerType table.</summary>
-    private static readonly string[] Encodings = { "cl100k_base", "p50k_base", "o200k_base" };
+    private static readonly string[] Encodings =
+        { "cl100k_base", "p50k_base", "o200k_base", "p50k_edit", "r50k_base" };
 
     /// <summary>
     /// Every non-ASCII character is written as a backslash-u escape and every newline as \n, never
@@ -161,14 +171,14 @@ public sealed class TokenVocabularyGoldenTests
             ["cl100k_base|emoji-bmp"] = 2,
             ["cl100k_base|emoji-zwj"] = 7,
             ["cl100k_base|empty"] = 0,
-            ["cl100k_base|lone-surrogate"] = 3,
+            ["cl100k_base|lone-surrogate"] = 4,
             ["cl100k_base|long-mixed-100k"] = 36114,
             ["cl100k_base|prose-paragraph"] = 99,
             ["cl100k_base|prose-short"] = 10,
             ["cl100k_base|punctuation-run"] = 7,
             ["cl100k_base|repeat-10k"] = 1250,
             ["cl100k_base|single-space"] = 1,
-            ["cl100k_base|special-token-text"] = 8,
+            ["cl100k_base|special-token-text"] = 4,
             ["cl100k_base|whitespace-run"] = 2,
             ["p50k_base|cjk-chinese"] = 20,
             ["p50k_base|cjk-japanese-mixed"] = 10,
@@ -183,14 +193,14 @@ public sealed class TokenVocabularyGoldenTests
             ["p50k_base|emoji-bmp"] = 2,
             ["p50k_base|emoji-zwj"] = 7,
             ["p50k_base|empty"] = 0,
-            ["p50k_base|lone-surrogate"] = 3,
+            ["p50k_base|lone-surrogate"] = 5,
             ["p50k_base|long-mixed-100k"] = 40281,
             ["p50k_base|prose-paragraph"] = 100,
             ["p50k_base|prose-short"] = 10,
             ["p50k_base|punctuation-run"] = 7,
             ["p50k_base|repeat-10k"] = 2500,
             ["p50k_base|single-space"] = 1,
-            ["p50k_base|special-token-text"] = 9,
+            ["p50k_base|special-token-text"] = 4,
             ["p50k_base|whitespace-run"] = 5,
             ["o200k_base|cjk-chinese"] = 7,
             ["o200k_base|cjk-japanese-mixed"] = 4,
@@ -205,15 +215,59 @@ public sealed class TokenVocabularyGoldenTests
             ["o200k_base|emoji-bmp"] = 1,
             ["o200k_base|emoji-zwj"] = 5,
             ["o200k_base|empty"] = 0,
-            ["o200k_base|lone-surrogate"] = 3,
+            ["o200k_base|lone-surrogate"] = 4,
             ["o200k_base|long-mixed-100k"] = 31947,
             ["o200k_base|prose-paragraph"] = 99,
             ["o200k_base|prose-short"] = 10,
             ["o200k_base|punctuation-run"] = 7,
             ["o200k_base|repeat-10k"] = 1250,
             ["o200k_base|single-space"] = 1,
-            ["o200k_base|special-token-text"] = 9,
+            ["o200k_base|special-token-text"] = 4,
             ["o200k_base|whitespace-run"] = 2,
+            ["p50k_edit|cjk-chinese"] = 20,
+            ["p50k_edit|cjk-japanese-mixed"] = 10,
+            ["p50k_edit|code-csharp"] = 18,
+            ["p50k_edit|code-json"] = 17,
+            ["p50k_edit|combining-marks"] = 5,
+            ["p50k_edit|contractions-lower"] = 12,
+            ["p50k_edit|contractions-upper"] = 19,
+            ["p50k_edit|control-chars"] = 3,
+            ["p50k_edit|cyrillic"] = 7,
+            ["p50k_edit|emoji-astral"] = 2,
+            ["p50k_edit|emoji-bmp"] = 2,
+            ["p50k_edit|emoji-zwj"] = 7,
+            ["p50k_edit|empty"] = 0,
+            ["p50k_edit|lone-surrogate"] = 5,
+            ["p50k_edit|long-mixed-100k"] = 40281,
+            ["p50k_edit|prose-paragraph"] = 100,
+            ["p50k_edit|prose-short"] = 10,
+            ["p50k_edit|punctuation-run"] = 7,
+            ["p50k_edit|repeat-10k"] = 2500,
+            ["p50k_edit|single-space"] = 1,
+            ["p50k_edit|special-token-text"] = 4,
+            ["p50k_edit|whitespace-run"] = 5,
+            ["r50k_base|cjk-chinese"] = 20,
+            ["r50k_base|cjk-japanese-mixed"] = 10,
+            ["r50k_base|code-csharp"] = 20,
+            ["r50k_base|code-json"] = 17,
+            ["r50k_base|combining-marks"] = 5,
+            ["r50k_base|contractions-lower"] = 12,
+            ["r50k_base|contractions-upper"] = 19,
+            ["r50k_base|control-chars"] = 3,
+            ["r50k_base|cyrillic"] = 7,
+            ["r50k_base|emoji-astral"] = 2,
+            ["r50k_base|emoji-bmp"] = 2,
+            ["r50k_base|emoji-zwj"] = 7,
+            ["r50k_base|empty"] = 0,
+            ["r50k_base|lone-surrogate"] = 5,
+            ["r50k_base|long-mixed-100k"] = 40281,
+            ["r50k_base|prose-paragraph"] = 100,
+            ["r50k_base|prose-short"] = 10,
+            ["r50k_base|punctuation-run"] = 7,
+            ["r50k_base|repeat-10k"] = 2500,
+            ["r50k_base|single-space"] = 1,
+            ["r50k_base|special-token-text"] = 4,
+            ["r50k_base|whitespace-run"] = 10,
         };
 
     public static TheoryData<string, string> Cases()

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
@@ -37,7 +37,10 @@ namespace ConduitLLM.Tests.Core.Services
     /// the before/after in the commit message.
     /// </para>
     /// <para>
-    /// Captured from TiktokenSharp 1.2.1 on 2026-07-25 via the skipped emitters below.
+    /// Captured from Microsoft.ML.Tokenizers 2.0.0 on 2026-07-25 via the skipped emitters below.
+    /// (Originally captured from TiktokenSharp 1.2.1; the resolution pins moved when the
+    /// TiktokenSharp replacement promoted <c>P50KEdit</c> and <c>R50KBase</c> to exact encodings
+    /// and the probe was extended to distinguish all five - see the <see cref="Probe"/> remarks.)
     /// </para>
     /// </remarks>
     public class TiktokenCounterGoldenTests
@@ -47,20 +50,23 @@ namespace ConduitLLM.Tests.Core.Services
         public TiktokenCounterGoldenTests(ITestOutputHelper output) => _output = output;
 
         /// <summary>
-        /// Single ASCII probe shared by every resolution pin, chosen so that cl100k_base,
-        /// p50k_base and o200k_base each produce a <i>different</i> count.
+        /// Single ASCII probe shared by every resolution pin, chosen so that each of the five
+        /// supported encodings produces a <i>different</i> count.
         /// </summary>
         /// <remarks>
-        /// This matters more than it looks. Ordinary English prose tokenizes identically across all
-        /// three encodings - "The quick brown fox jumps over the lazy dog." is 10 tokens in every
+        /// This matters more than it looks. Ordinary English prose tokenizes identically across
+        /// the encodings - "The quick brown fox jumps over the lazy dog." is 10 tokens in every
         /// one of them - so a prose probe would pin 10 for all 23 TokenizerTypes and silently fail
         /// to notice a resolution change, which is the only thing these pins exist to catch.
-        /// Contractions separate o200k from the others, and a long run of a repeated character
-        /// separates p50k (which merges 4 at a time) from cl100k and o200k (8 at a time).
+        /// Each ingredient separates a specific pair: contractions separate o200k from cl100k; the
+        /// long run of a repeated character separates the p50k/r50k family (which merges 4 at a
+        /// time) from cl100k and o200k (8 at a time); the whitespace run separates r50k from p50k
+        /// (whose vocabulary added whitespace-run merges); and the fim marker separates p50k_edit
+        /// from p50k_base, because edit-specific special tokens are their only difference.
         /// <see cref="Probe_ProducesADifferentCountForEveryEncoding"/> enforces the property.
         /// </remarks>
         private static readonly string Probe =
-            "don't won't it's they're I'll we've " + new string('a', 64);
+            "don't won't it's they're I'll we've " + new string('a', 64) + "\n\n\t\t   <|fim_middle|>";
 
         /// <summary>
         /// Token count of <see cref="Probe"/> for each TokenizerType, through the full counter.
@@ -68,30 +74,30 @@ namespace ConduitLLM.Tests.Core.Services
         private static readonly IReadOnlyDictionary<string, int> ExpectedByTokenizer =
             new Dictionary<string, int>(StringComparer.Ordinal)
             {
-                ["None"] = 22,
-                ["Cl100KBase"] = 22,
-                ["P50KBase"] = 29,
-                ["P50KEdit"] = 29,
-                ["R50KBase"] = 29,
-                ["O200KBase"] = 16,
-                ["Claude"] = 22,
-                ["Claude3"] = 22,
-                ["Gemini"] = 22,
-                ["PaLM"] = 22,
-                ["LLaMA"] = 22,
-                ["LLaMA2"] = 22,
-                ["LLaMA3"] = 22,
-                ["Mistral"] = 22,
-                ["Cohere"] = 22,
-                ["O200KHarmony"] = 16,
-                ["Kimi"] = 22,
-                ["Groq"] = 22,
-                ["Cerebras"] = 22,
-                ["MiniMax"] = 22,
-                ["SentencePiece"] = 22,
-                ["BPE"] = 22,
-                ["WordPiece"] = 22,
-                ["Tiktoken"] = 22,
+                ["None"] = 25,
+                ["Cl100KBase"] = 25,
+                ["P50KBase"] = 41,
+                ["P50KEdit"] = 34,
+                ["R50KBase"] = 42,
+                ["O200KBase"] = 24,
+                ["Claude"] = 25,
+                ["Claude3"] = 25,
+                ["Gemini"] = 25,
+                ["PaLM"] = 25,
+                ["LLaMA"] = 25,
+                ["LLaMA2"] = 25,
+                ["LLaMA3"] = 25,
+                ["Mistral"] = 25,
+                ["Cohere"] = 25,
+                ["O200KHarmony"] = 24,
+                ["Kimi"] = 25,
+                ["Groq"] = 25,
+                ["Cerebras"] = 25,
+                ["MiniMax"] = 25,
+                ["SentencePiece"] = 25,
+                ["BPE"] = 25,
+                ["WordPiece"] = 25,
+                ["Tiktoken"] = 25,
             };
 
         /// <summary>
@@ -253,7 +259,7 @@ namespace ConduitLLM.Tests.Core.Services
         public async Task Probe_ProducesADifferentCountForEveryEncoding()
         {
             var counts = new Dictionary<string, int>(StringComparer.Ordinal);
-            foreach (var encoding in new[] { "cl100k_base", "p50k_base", "o200k_base" })
+            foreach (var encoding in new[] { "cl100k_base", "p50k_base", "p50k_edit", "r50k_base", "o200k_base" })
             {
                 counts[encoding] = await CounterFor(encoding)
                     .EstimateTokenCountAsync($"probe-{encoding}", Probe);

--- a/Tests/ConduitLLM.Tests/Core/Services/TokenizerEncodingMapTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TokenizerEncodingMapTests.cs
@@ -13,13 +13,17 @@ namespace ConduitLLM.Tests.Core.Services
     /// </remarks>
     public class TokenizerEncodingMapTests
     {
-        // The three encodings TiktokenSharp 1.2.1 actually implements. Any other value would
-        // send the counter back down the exception path this issue removed.
-        private static readonly string[] SupportedEncodings = { "cl100k_base", "p50k_base", "o200k_base" };
+        // The five encodings whose vocabulary ships in a referenced
+        // Microsoft.ML.Tokenizers.Data.* package. Any other value would send the counter back
+        // down the exception path this issue removed.
+        private static readonly string[] SupportedEncodings =
+            { "cl100k_base", "p50k_base", "p50k_edit", "r50k_base", "o200k_base" };
 
         [Theory]
         [InlineData("Cl100KBase", "cl100k_base")]
         [InlineData("P50KBase", "p50k_base")]
+        [InlineData("P50KEdit", "p50k_edit")]
+        [InlineData("R50KBase", "r50k_base")]
         [InlineData("O200KBase", "o200k_base")]
         public void Resolve_OpenAiEncoding_ReturnsExactEncoding(string tokenizerType, string expected)
         {
@@ -38,8 +42,6 @@ namespace ConduitLLM.Tests.Core.Services
         [InlineData("Mistral", "cl100k_base")]
         [InlineData("Kimi", "cl100k_base")]
         [InlineData("O200KHarmony", "o200k_base")]
-        [InlineData("P50KEdit", "p50k_base")]
-        [InlineData("R50KBase", "p50k_base")]
         public void Resolve_NonTiktokenTokenizer_ReturnsDocumentedApproximation(string tokenizerType, string expected)
         {
             var result = TokenizerEncodingMap.Resolve(tokenizerType);
@@ -75,8 +77,6 @@ namespace ConduitLLM.Tests.Core.Services
         }
 
         [Theory]
-        [InlineData("p50k_edit", "p50k_base")]
-        [InlineData("r50k_base", "p50k_base")]
         [InlineData("o200k_harmony", "o200k_base")]
         public void Resolve_UnimplementedEncodingIdentifier_ReturnsNearestSupported(string encoding, string expected)
         {

--- a/Tests/ConduitLLM.Tests/Core/Services/TokenizerVocabularyOfflineTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TokenizerVocabularyOfflineTests.cs
@@ -1,0 +1,53 @@
+using ConduitLLM.Core.Services;
+
+using Microsoft.ML.Tokenizers;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Core.Services
+{
+    /// <summary>
+    /// Guards the offline guarantee behind #1227: every encoding the resolution table can hand to
+    /// the counter must construct from vocabulary data bundled with the application, with no
+    /// network access and no files written outside the build output.
+    /// </summary>
+    /// <remarks>
+    /// TiktokenSharp downloaded its BPE files from Azure Blob Storage on first use; when that
+    /// fetch failed, billing silently degraded to a chars/4 estimate. Microsoft.ML.Tokenizers
+    /// ships each vocabulary in a <c>Microsoft.ML.Tokenizers.Data.*</c> package instead. This
+    /// test fails if a <see cref="TokenizerEncodingMap"/> entry is added without referencing the
+    /// matching data package, or if a future tokenizer change reintroduces a runtime download.
+    /// </remarks>
+    public class TokenizerVocabularyOfflineTests
+    {
+        [Fact]
+        public void EveryResolvableEncoding_ConstructsFromBundledData()
+        {
+            foreach (TokenizerType tokenizerType in Enum.GetValues<TokenizerType>())
+            {
+                var resolved = TokenizerEncodingMap.Resolve(tokenizerType.ToString());
+
+                // Throws (failing the test) when the encoding's data package is not referenced.
+                var tokenizer = TiktokenTokenizer.CreateForEncoding(resolved.EncodingName);
+
+                Assert.True(tokenizer.CountTokens("offline vocabulary check") > 0,
+                    $"{resolved.EncodingName} produced no tokens for {tokenizerType}");
+            }
+        }
+
+        [Fact]
+        public void ConstructingEncodings_LeavesNoDownloadArtifacts()
+        {
+            foreach (var encoding in new[] { "cl100k_base", "p50k_base", "p50k_edit", "r50k_base", "o200k_base" })
+            {
+                TiktokenTokenizer.CreateForEncoding(encoding).CountTokens("offline vocabulary check");
+            }
+
+            // TiktokenSharp materialized downloaded vocabularies into a bpe/ directory beside the
+            // binaries (or the temp directory when that was read-only). Neither may reappear.
+            var bpeDirectory = Path.Combine(AppContext.BaseDirectory, "bpe");
+            Assert.False(Directory.Exists(bpeDirectory),
+                $"Tokenizer construction created {bpeDirectory}; vocabulary data must ship in the package, not download at runtime");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces TiktokenSharp 1.2.1 with **Microsoft.ML.Tokenizers 2.0.0** plus its `Data.*` vocabulary packages, making tokenization fully offline and deterministic.

TiktokenSharp shipped no vocabulary data — it downloaded BPE files from `openaipublic.blob.core.windows.net` at runtime, in every container, and a failed fetch silently degraded every token count (spend reservations, TPM rate-limit windows, streaming-fallback billing) to a `chars / 4` estimate with no error, metric, or health signal (#1227). The vulnerable window was real: stale `bpe/` download directories from previous test runs were sitting in this repo's build output when the swap landed.

## Verification against the golden pins (PR #1228)

Those pins were added specifically to make this swap safe, and they did their job: **60 of 66 vocabulary pins reproduce exactly.** The six that moved are the two corpus entries the golden tests always documented as library policy decisions, and they moved in the documented directions:

| Entry | TiktokenSharp | ML.Tokenizers | Why |
|---|---|---|---|
| `special-token-text` | 8 / 9 / 9 | 4 | Registered special tokens (`<|endoftext|>`) count as one token; Python tiktoken reproduces with `allowed_special="all"` |
| `lone-surrogate` | 3 | 4 / 5 | U+FFFD substitution, never throws — this input can no longer land in the chars/4 fallback, and counts move *up* (billing-safe) |

Message-arithmetic pins (`TiktokenCounterGoldenTests` message/JSON shapes) and all other billing invariants are untouched: **123/123 billing-invariant tests, 3,466 main-suite tests pass.**

## Changes

- `TiktokenCounter`: `TikToken.GetEncoding` → `TiktokenTokenizer.CreateForEncoding`, `Encode(x).Count` → `CountTokens(x)` (no id-list allocation on the hot path). Cache, failure-caching (#1051), fallbacks, and message arithmetic byte-identical.
- `TokenizerEncodingMap`: **`P50KEdit` and `R50KBase` promoted from approximations to exact** — TiktokenSharp couldn't construct them; their data packages now ship. Remarks rewritten for the five-encoding world.
- Golden tests: 6 pins updated with provenance notes; 44 new pins for the two promoted encodings; resolution probe extended (whitespace run + fim marker) so all five encodings produce distinct counts, re-pinned via the emitters.
- **New `TokenizerVocabularyOfflineTests`**: every resolvable encoding must construct from bundled data, and construction must leave no download artifacts — the regression test #1227 lacked.
- Security: pins `Microsoft.Bcl.Memory` 9.0.14 — ML.Tokenizers 2.0.0 pulls 9.0.4 transitively, tripping NU1903 (GHSA-73j8-2gch-69rq / CVE-2026-26127). Central pinning isn't enabled, so the override is a direct reference in Core, following existing repo convention.
- Docs: stale TiktokenSharp references in Core README and SETUP_DOTNET_VERSIONING updated.

Deployment note: images grow ~6 MB of embedded vocabulary data and lose an undocumented runtime egress dependency on Azure Blob Storage.

## Non-goals (tracked separately)

Non-OpenAI vocabularies (Claude, Gemini, Llama, …) remain documented cl100k_base approximations — #1230 covers the strategy, #1233 the fidelity signal. Tool-token counting (#1229) and image flat-rating (#1231) are unchanged arithmetic.

Fixes #1227. See #1230 for how this supersedes the abandoned epic #857.