### PR TITLE
feat(core): surface token-count fidelity so billing buffers scale with confidence (#1233)

### DIFF
--- a/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
+++ b/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
@@ -62,7 +62,19 @@ public sealed class ChatSpendEstimator : IChatSpendEstimator
             return Failed("A positive maximum output-token bound is required");
         }
 
-        var promptTokens = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages);
+        var promptEstimate = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages);
+
+        // The reservation must bound the real cost, so a count produced with a stand-in
+        // vocabulary or the chars/4 heuristic is padded by a fidelity-sized buffer (#1233).
+        // Reconciliation against actual usage releases any excess.
+        var promptTokens = promptEstimate.Fidelity switch
+        {
+            TokenCountFidelity.Exact => promptEstimate.Tokens,
+            TokenCountFidelity.ApproximateVocabulary =>
+                (int)Math.Ceiling(promptEstimate.Tokens * (1 + _options.ApproximateVocabularyPromptBuffer)),
+            _ => (int)Math.Ceiling(promptEstimate.Tokens * (1 + _options.CharacterHeuristicPromptBuffer))
+        };
+
         var usage = new Usage
         {
             PromptTokens = promptTokens,

--- a/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
+++ b/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
@@ -62,7 +62,7 @@ public sealed class ChatSpendEstimator : IChatSpendEstimator
             return Failed("A positive maximum output-token bound is required");
         }
 
-        var promptEstimate = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages);
+        var promptEstimate = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages, request.Tools);
 
         // The reservation must bound the real cost, so a count produced with a stand-in
         // vocabulary or the chars/4 heuristic is padded by a fidelity-sized buffer (#1233).

--- a/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.Streaming.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.Streaming.cs
@@ -511,6 +511,7 @@ namespace ConduitLLM.Gateway.Endpoints
                     state.StreamingModel ?? request.Model,
                     request.Messages,
                     completionOutput,
+                    request.Tools,
                     cancellationToken);
 
                 HttpContext.GetOrCreateRequestAccountingContext().RecordProviderUsage(

--- a/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
@@ -590,6 +590,7 @@ public sealed class ResponsesEndpoints : GatewayEndpointHandlerBase
             providerModel ?? request.Model,
             request.Messages,
             output,
+            request.Tools,
             cancellationToken);
         accounting.RecordProviderUsage(estimated, providerModel ?? request.Model, UsageEvidenceSource.Estimated);
         return estimated;
@@ -621,6 +622,7 @@ public sealed class ResponsesEndpoints : GatewayEndpointHandlerBase
                 response.Model ?? request.Model,
                 request.Messages,
                 output,
+                request.Tools,
                 cancellationToken);
             accounting.RecordProviderUsage(
                 estimated,

--- a/Services/ConduitLLM.Gateway/Options/BillingAdmissionOptions.cs
+++ b/Services/ConduitLLM.Gateway/Options/BillingAdmissionOptions.cs
@@ -20,4 +20,19 @@ public sealed class BillingAdmissionOptions
 
     [Range(1, 1_000_000)]
     public int MaximumOutputTokensCap { get; set; } = 32_768;
+
+    /// <summary>
+    /// Buffer applied to the prompt-token estimate when it was produced with a stand-in
+    /// vocabulary (#1233). Exact counts are reserved as-is. Reservations are reconciled against
+    /// real usage, so over-reserving briefly holds budget rather than over-billing.
+    /// </summary>
+    [Range(0.0, 2.0)]
+    public double ApproximateVocabularyPromptBuffer { get; set; } = 0.15;
+
+    /// <summary>
+    /// Buffer applied to the prompt-token estimate when it came from the chars/4 heuristic,
+    /// which under-counts English prose by 20-40% and CJK text by far more (#1233).
+    /// </summary>
+    [Range(0.0, 2.0)]
+    public double CharacterHeuristicPromptBuffer { get; set; } = 0.50;
 }

--- a/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
+++ b/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
@@ -86,7 +86,9 @@ public sealed class RequestTokenEstimator
 
     private async Task<TokenEstimate> EstimateChatAsync(ChatCompletionRequest chat)
     {
-        var prompt = await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages);
+        // Rate-limit windows are estimate-then-reconcile, so the raw count is used without a
+        // fidelity buffer: padding here would only throttle callers earlier than their limit.
+        var prompt = (await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages)).Tokens;
 
         // max_completion_tokens supersedes the legacy max_tokens where both are present.
         var declared = chat.MaxCompletionTokens ?? chat.MaxTokens;
@@ -96,7 +98,7 @@ public sealed class RequestTokenEstimator
     private async Task<TokenEstimate> EstimateEmbeddingAsync(EmbeddingRequest embedding)
     {
         var text = FlattenEmbeddingInput(embedding.Input);
-        var prompt = await _tokenCounter.EstimateTokenCountAsync(embedding.Model, text);
+        var prompt = (await _tokenCounter.EstimateTokenCountAsync(embedding.Model, text)).Tokens;
 
         // Embeddings produce vectors, not tokens, so only the input counts.
         return new TokenEstimate(embedding.Model, prompt, 0);

--- a/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
+++ b/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
@@ -88,7 +88,7 @@ public sealed class RequestTokenEstimator
     {
         // Rate-limit windows are estimate-then-reconcile, so the raw count is used without a
         // fidelity buffer: padding here would only throttle callers earlier than their limit.
-        var prompt = (await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages)).Tokens;
+        var prompt = (await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages, chat.Tools)).Tokens;
 
         // max_completion_tokens supersedes the legacy max_tokens where both are present.
         var declared = chat.MaxCompletionTokens ?? chat.MaxTokens;

--- a/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
@@ -5,6 +5,12 @@ namespace ConduitLLM.Core.Interfaces
     /// <summary>
     /// Interface for estimating token counts in LLM messages.
     /// </summary>
+    /// <remarks>
+    /// Estimates carry a <see cref="TokenCountFidelity"/> alongside the number (#1233).
+    /// Consumers that turn counts into money or limits — spend reservations, fallback billing,
+    /// rate-limit windows — should size any safety buffer by that fidelity rather than applying
+    /// one flat figure: an exact count and a chars/4 guess do not deserve the same treatment.
+    /// </remarks>
     public interface ITokenCounter
     {
         /// <summary>
@@ -12,15 +18,15 @@ namespace ConduitLLM.Core.Interfaces
         /// </summary>
         /// <param name="modelName">Name of the model to use for token estimation</param>
         /// <param name="messages">List of messages to count tokens for</param>
-        /// <returns>Estimated token count</returns>
-        Task<int> EstimateTokenCountAsync(string modelName, List<Message> messages);
+        /// <returns>The estimated token count and its fidelity</returns>
+        Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages);
 
         /// <summary>
         /// Estimates tokens for a single text string.
         /// </summary>
         /// <param name="modelName">Name of the model to use for token estimation</param>
         /// <param name="text">Text to count tokens for</param>
-        /// <returns>Estimated token count</returns>
-        Task<int> EstimateTokenCountAsync(string modelName, string text);
+        /// <returns>The estimated token count and its fidelity</returns>
+        Task<TokenCount> EstimateTokenCountAsync(string modelName, string text);
     }
 }

--- a/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
@@ -17,9 +17,17 @@ namespace ConduitLLM.Core.Interfaces
         /// Estimates tokens for a list of messages, considering model specifics.
         /// </summary>
         /// <param name="modelName">Name of the model to use for token estimation</param>
-        /// <param name="messages">List of messages to count tokens for</param>
+        /// <param name="messages">
+        /// List of messages to count tokens for. Assistant messages' <see cref="Message.ToolCalls"/>
+        /// are counted; providers include them in the prompt on the next turn (#1229).
+        /// </param>
+        /// <param name="tools">
+        /// Tool definitions accompanying the request, or null. Providers inject these schemas into
+        /// the prompt, so omitting them under-counts agentic requests — pass the request's tools
+        /// whenever they are available (#1229).
+        /// </param>
         /// <returns>The estimated token count and its fidelity</returns>
-        Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages);
+        Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages, IReadOnlyList<Tool>? tools = null);
 
         /// <summary>
         /// Estimates tokens for a single text string.

--- a/Shared/ConduitLLM.Core/Interfaces/IUsageEstimationService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IUsageEstimationService.cs
@@ -15,12 +15,17 @@ namespace ConduitLLM.Core.Interfaces
         /// <param name="modelId">The model identifier used for the request</param>
         /// <param name="inputMessages">The input messages sent to the model</param>
         /// <param name="streamedContent">The accumulated content from the streaming response</param>
+        /// <param name="tools">
+        /// The request's tool definitions, or null. Providers inject these schemas into the
+        /// prompt, so passing them keeps agentic requests from being under-billed (#1229).
+        /// </param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Estimated usage with prompt and completion tokens</returns>
         Task<Usage> EstimateUsageFromStreamingResponseAsync(
             string modelId,
             List<Message> inputMessages,
             string streamedContent,
+            IReadOnlyList<Tool>? tools = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/Shared/ConduitLLM.Core/Metrics/TokenCountingMetrics.cs
+++ b/Shared/ConduitLLM.Core/Metrics/TokenCountingMetrics.cs
@@ -1,0 +1,37 @@
+using ConduitLLM.Core.Models;
+
+using Prometheus;
+
+namespace ConduitLLM.Core.Metrics;
+
+/// <summary>
+/// Operational signals for token-count estimation fidelity.
+/// </summary>
+/// <remarks>
+/// The <c>character_heuristic</c> series is the alarm line: it counts estimates produced by the
+/// chars/4 fallback, which only happens when tokenizer vocabulary data is unavailable. Any
+/// sustained rate there means spend reservations and fallback billing are running degraded —
+/// the failure mode #1227 shipped silently before this signal existed.
+/// </remarks>
+public static class TokenCountingMetrics
+{
+    public static readonly Counter Estimates = Prometheus.Metrics.CreateCounter(
+        "conduit_token_count_estimates_total",
+        "Token-count estimates by fidelity tier (exact, approximate_vocabulary, character_heuristic)",
+        new CounterConfiguration
+        {
+            LabelNames = new[] { "fidelity" }
+        });
+
+    /// <summary>Records one estimate at the given fidelity.</summary>
+    public static void Record(TokenCountFidelity fidelity) =>
+        Estimates.WithLabels(LabelFor(fidelity)).Inc();
+
+    private static string LabelFor(TokenCountFidelity fidelity) => fidelity switch
+    {
+        TokenCountFidelity.Exact => "exact",
+        TokenCountFidelity.ApproximateVocabulary => "approximate_vocabulary",
+        TokenCountFidelity.CharacterHeuristic => "character_heuristic",
+        _ => "unknown"
+    };
+}

--- a/Shared/ConduitLLM.Core/Models/TokenCount.cs
+++ b/Shared/ConduitLLM.Core/Models/TokenCount.cs
@@ -1,0 +1,48 @@
+namespace ConduitLLM.Core.Models
+{
+    /// <summary>
+    /// How trustworthy a token count is, ordered from most to least trustworthy.
+    /// </summary>
+    /// <remarks>
+    /// The numeric ordering is meaningful and load-bearing: a higher value is strictly less
+    /// trustworthy, so a count assembled from parts carries the maximum of its parts' values.
+    /// Consumers that reserve or bill on these counts size their safety buffers by tier —
+    /// see <c>ChatSpendEstimator</c> and <c>UsageEstimationService</c>.
+    /// </remarks>
+    public enum TokenCountFidelity
+    {
+        /// <summary>Counted with the model's own vocabulary.</summary>
+        Exact = 0,
+
+        /// <summary>
+        /// Counted with a documented stand-in vocabulary (for example a Claude or Llama model
+        /// counted with <c>cl100k_base</c>). Typically within 10-30% of the true count; worse on
+        /// CJK text and source code.
+        /// </summary>
+        ApproximateVocabulary = 1,
+
+        /// <summary>
+        /// The characters-divided-by-four heuristic; no vocabulary was available. Under-counts
+        /// English prose by roughly 20-40% and CJK text by far more. This tier appearing in
+        /// production means tokenizer data is broken and billing accuracy is degraded (#1227).
+        /// </summary>
+        CharacterHeuristic = 2,
+    }
+
+    /// <summary>
+    /// A token count together with how it was produced.
+    /// </summary>
+    /// <remarks>
+    /// There is deliberately no implicit conversion to or from <see cref="int"/>: dropping
+    /// <see cref="Fidelity"/> is a decision each consumer must make visibly, because the count's
+    /// error margin — and therefore any buffer applied to it — depends on the tier.
+    /// </remarks>
+    /// <param name="Tokens">The estimated token count.</param>
+    /// <param name="Fidelity">How the estimate was produced.</param>
+    public readonly record struct TokenCount(int Tokens, TokenCountFidelity Fidelity)
+    {
+        /// <summary>The less trustworthy of two fidelities, per the enum's severity ordering.</summary>
+        public static TokenCountFidelity Worst(TokenCountFidelity left, TokenCountFidelity right) =>
+            left >= right ? left : right;
+    }
+}

--- a/Shared/ConduitLLM.Core/Services/ContextManager.cs
+++ b/Shared/ConduitLLM.Core/Services/ContextManager.cs
@@ -98,8 +98,9 @@ namespace ConduitLLM.Core.Services
                 return request; // Nothing to do if no limit or no messages
             }
 
-            // Get the current token count using the token counter
-            int currentTokens = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages);
+            // Get the current token count using the token counter. Context trimming compares
+            // against a hard window, so the count alone is enough; fidelity is not consulted.
+            int currentTokens = (await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages)).Tokens;
 
             // Account for completion tokens if MaxTokens is specified in the request
             int reservedCompletionTokens = request.MaxTokens ?? 0;
@@ -171,7 +172,7 @@ namespace ConduitLLM.Core.Services
                 trimmedMessages.RemoveAt(indexToRemove);
 
                 // Re-estimate token count after removal
-                currentTokens = await _tokenCounter.EstimateTokenCountAsync(request.Model, trimmedMessages);
+                currentTokens = (await _tokenCounter.EstimateTokenCountAsync(request.Model, trimmedMessages)).Tokens;
             }
 
             // If we removed messages, create a new request with trimmed messages

--- a/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
@@ -66,7 +66,7 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages)
+        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages, IReadOnlyList<Tool>? tools = null)
         {
             if (messages == null || !messages.Any())
             {
@@ -80,7 +80,7 @@ namespace ConduitLLM.Core.Services
                 {
                     // Fallback strategy if we can't get the right encoding
                     _logger.LogWarning("Could not determine encoding for model {ModelName}. Using fallback token estimation method.", modelName);
-                    return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
+                    return Finish(new TokenCount(FallbackEstimateTokens(messages, tools), TokenCountFidelity.CharacterHeuristic));
                 }
 
                 int tokenCount = 0;
@@ -151,6 +151,36 @@ namespace ConduitLLM.Core.Services
                         }
                         tokenCount += 1; // Additional overhead for name field
                     }
+
+                    // Assistant tool calls travel back to the provider as prompt content on the
+                    // next turn, so agentic histories are structurally under-counted without them.
+                    if (message.ToolCalls is { Count: > 0 })
+                    {
+                        try
+                        {
+                            tokenCount += CountToolCallTokens(message.ToolCalls, encoding);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Error encoding tool calls. Using fallback estimate.");
+                            tokenCount += ToolCallFallbackChars(message.ToolCalls) / 4;
+                            fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
+                        }
+                    }
+                }
+
+                if (tools is { Count: > 0 })
+                {
+                    try
+                    {
+                        tokenCount += CountToolDefinitionTokens(tools, encoding);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error encoding tool definitions. Using fallback estimate.");
+                        tokenCount += ToolDefinitionFallbackChars(tools) / 4;
+                        fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
+                    }
                 }
 
                 tokenCount += 3; // Every reply is primed with <|start|>assistant<|message|>
@@ -160,9 +190,70 @@ namespace ConduitLLM.Core.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error estimating token count. Using fallback method.");
-                return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
+                return Finish(new TokenCount(FallbackEstimateTokens(messages, tools), TokenCountFidelity.CharacterHeuristic));
             }
         }
+
+        /// <summary>
+        /// Counts the tokens an assistant message's tool calls contribute when replayed as prompt
+        /// context: the function name and raw JSON arguments, plus a small per-call framing cost.
+        /// </summary>
+        /// <remarks>
+        /// Providers do not publish their exact serialization of historical tool calls, so the
+        /// per-call overhead of 3 mirrors the reply-priming constant used elsewhere in this
+        /// counter. The name and arguments dominate in practice.
+        /// </remarks>
+        private static int CountToolCallTokens(IReadOnlyList<ToolCall> toolCalls, Tokenizer encoding)
+        {
+            int tokenCount = 0;
+            foreach (var toolCall in toolCalls)
+            {
+                tokenCount += 3;
+                tokenCount += encoding.CountTokens(toolCall.Function.Name);
+                tokenCount += encoding.CountTokens(toolCall.Function.Arguments);
+            }
+
+            return tokenCount;
+        }
+
+        /// <summary>
+        /// Counts the tokens a request's tool definitions contribute: providers inject each
+        /// function's name, description and JSON-schema parameters into the prompt.
+        /// </summary>
+        /// <remarks>
+        /// OpenAI compacts schemas into a TypeScript-like namespace listing before tokenizing;
+        /// counting the raw JSON schema instead over-counts slightly (schema punctuation the
+        /// compaction strips), which errs on the safe side for reservations and fallback billing.
+        /// The constants — 10 for the scaffolding around the tools block, 6 per function — follow
+        /// the same published community measurements the compaction format comes from.
+        /// </remarks>
+        private static int CountToolDefinitionTokens(IReadOnlyList<Tool> tools, Tokenizer encoding)
+        {
+            int tokenCount = 10;
+            foreach (var tool in tools)
+            {
+                tokenCount += 6;
+                tokenCount += encoding.CountTokens(tool.Function.Name);
+                if (!string.IsNullOrEmpty(tool.Function.Description))
+                {
+                    tokenCount += encoding.CountTokens(tool.Function.Description);
+                }
+                if (tool.Function.Parameters is not null)
+                {
+                    tokenCount += encoding.CountTokens(tool.Function.Parameters.ToJsonString());
+                }
+            }
+
+            return tokenCount;
+        }
+
+        private static int ToolCallFallbackChars(IReadOnlyList<ToolCall> toolCalls) =>
+            toolCalls.Sum(c => c.Function.Name.Length + c.Function.Arguments.Length);
+
+        private static int ToolDefinitionFallbackChars(IReadOnlyList<Tool> tools) =>
+            tools.Sum(t => t.Function.Name.Length
+                + (t.Function.Description?.Length ?? 0)
+                + (t.Function.Parameters?.ToJsonString().Length ?? 0));
 
         /// <inheritdoc />
         public async Task<TokenCount> EstimateTokenCountAsync(string modelName, string text)
@@ -469,13 +560,19 @@ namespace ConduitLLM.Core.Services
         /// estimate when the correct encoder is unavailable or fails.
         /// </para>
         /// </remarks>
-        private int FallbackEstimateTokens(List<Message> messages)
+        private int FallbackEstimateTokens(List<Message> messages, IReadOnlyList<Tool>? tools = null)
         {
             // Very rough estimation based on characters
             int totalCharacters = messages.Sum(m =>
                 (m.Content != null ? m.Content.ToString()?.Length ?? 0 : 0) +
                 (m.Role?.Length ?? 0) +
-                (m.Name?.Length ?? 0));
+                (m.Name?.Length ?? 0) +
+                (m.ToolCalls is { Count: > 0 } ? ToolCallFallbackChars(m.ToolCalls) : 0));
+
+            if (tools is { Count: > 0 })
+            {
+                totalCharacters += ToolDefinitionFallbackChars(tools);
+            }
 
             // Rough estimate: 1 token ≈ 4 characters in English
             return totalCharacters / 4;

--- a/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 
 using ConduitLLM.Core.Interfaces;
+using ConduitLLM.Core.Metrics;
 using ConduitLLM.Core.Models;
 
 using Microsoft.Extensions.Logging;
@@ -40,8 +41,9 @@ namespace ConduitLLM.Core.Services
     public class TiktokenCounter : ITokenCounter
     {
         // Cache encodings for performance, keyed by the requested tokenizer identifier.
-        // A null value is a cached failure and means "use character-based estimation".
-        private static readonly Dictionary<string, Tokenizer?> _encodings = new();
+        // A null tokenizer is a cached failure and means "use character-based estimation";
+        // the fidelity is cached alongside so it is computed once per tokenizer, not per count.
+        private static readonly Dictionary<string, (Tokenizer? Encoding, TokenCountFidelity Fidelity)> _encodings = new();
         private static readonly object _lock = new();
         private readonly ILogger<TiktokenCounter> _logger;
         private readonly IModelCapabilityService? _capabilityService;
@@ -64,21 +66,21 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<int> EstimateTokenCountAsync(string modelName, List<Message> messages)
+        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages)
         {
             if (messages == null || !messages.Any())
             {
-                return 0;
+                return Finish(new TokenCount(0, TokenCountFidelity.Exact));
             }
 
             try
             {
-                var encoding = await GetEncodingForModelAsync(modelName);
+                var (encoding, fidelity) = await GetEncodingForModelAsync(modelName);
                 if (encoding == null)
                 {
                     // Fallback strategy if we can't get the right encoding
                     _logger.LogWarning("Could not determine encoding for model {ModelName}. Using fallback token estimation method.", modelName);
-                    return FallbackEstimateTokens(messages);
+                    return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
                 }
 
                 int tokenCount = 0;
@@ -99,6 +101,7 @@ namespace ConduitLLM.Core.Services
                         {
                             _logger.LogWarning(ex, "Error encoding role. Using fallback estimate.");
                             tokenCount += message.Role.Length / 4;
+                            fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
                         }
                     }
 
@@ -129,6 +132,7 @@ namespace ConduitLLM.Core.Services
                             // Fallback calculation
                             string contentStr = message.Content.ToString() ?? "";
                             tokenCount += contentStr.Length / 4;
+                            fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
                         }
                     }
 
@@ -143,6 +147,7 @@ namespace ConduitLLM.Core.Services
                         {
                             _logger.LogWarning(ex, "Error encoding name. Using fallback estimate.");
                             tokenCount += message.Name.Length / 4;
+                            fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
                         }
                         tokenCount += 1; // Additional overhead for name field
                     }
@@ -150,56 +155,67 @@ namespace ConduitLLM.Core.Services
 
                 tokenCount += 3; // Every reply is primed with <|start|>assistant<|message|>
 
-                return tokenCount;
+                return Finish(new TokenCount(tokenCount, fidelity));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error estimating token count. Using fallback method.");
-                return FallbackEstimateTokens(messages);
+                return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
             }
         }
 
         /// <inheritdoc />
-        public async Task<int> EstimateTokenCountAsync(string modelName, string text)
+        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, string text)
         {
             if (string.IsNullOrEmpty(text))
             {
-                return 0;
+                return Finish(new TokenCount(0, TokenCountFidelity.Exact));
             }
 
             try
             {
-                var encoding = await GetEncodingForModelAsync(modelName);
+                var (encoding, fidelity) = await GetEncodingForModelAsync(modelName);
                 if (encoding == null)
                 {
                     // Fallback strategy
                     _logger.LogWarning("Could not determine encoding for model {ModelName}. Using fallback token estimation method.", modelName);
-                    return FallbackEstimateTokens(text);
+                    return Finish(new TokenCount(FallbackEstimateTokens(text), TokenCountFidelity.CharacterHeuristic));
                 }
 
                 try
                 {
-                    return encoding.CountTokens(text);
+                    return Finish(new TokenCount(encoding.CountTokens(text), fidelity));
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Error encoding text. Using fallback estimate.");
-                    return FallbackEstimateTokens(text);
+                    return Finish(new TokenCount(FallbackEstimateTokens(text), TokenCountFidelity.CharacterHeuristic));
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error estimating token count. Using fallback method.");
-                return FallbackEstimateTokens(text);
+                return Finish(new TokenCount(FallbackEstimateTokens(text), TokenCountFidelity.CharacterHeuristic));
             }
         }
 
         /// <summary>
-        /// Gets the appropriate tiktoken tokenizer for a given model asynchronously.
+        /// Records the estimate's fidelity to metrics before handing it back. The
+        /// character_heuristic series is the operational alarm for broken vocabulary data (#1227).
+        /// </summary>
+        private static TokenCount Finish(TokenCount count)
+        {
+            TokenCountingMetrics.Record(count.Fidelity);
+            return count;
+        }
+
+        /// <summary>
+        /// Gets the appropriate tiktoken tokenizer, and the fidelity its counts will have, for a
+        /// given model asynchronously.
         /// </summary>
         /// <param name="modelName">The name of the model to get encoding for.</param>
-        /// <returns>The appropriate tokenizer, or null if it cannot be determined.</returns>
-        private async Task<Tokenizer?> GetEncodingForModelAsync(string modelName)
+        /// <returns>The tokenizer (null if it cannot be determined) and the resulting fidelity.</returns>
+        private async Task<(Tokenizer? Encoding, TokenCountFidelity Fidelity)> GetEncodingForModelAsync(string modelName)
         {
             try
             {
@@ -227,7 +243,7 @@ namespace ConduitLLM.Core.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error in GetEncodingForModelAsync");
-                return null;
+                return (null, TokenCountFidelity.CharacterHeuristic);
             }
         }
 
@@ -239,14 +255,14 @@ namespace ConduitLLM.Core.Services
         /// <c>Cl100KBase</c> or <c>LLaMA3</c>), or null to use the default encoding.
         /// </param>
         /// <param name="modelName">The model name (for logging purposes).</param>
-        /// <returns>The tokenizer, or null if it cannot be created.</returns>
+        /// <returns>The tokenizer (null if it cannot be created) and the resulting fidelity.</returns>
         /// <remarks>
         /// The cache is keyed on <paramref name="tokenizerType"/> rather than on the resolved
         /// encoding name. Keying it on the resolved name meant an unresolvable tokenizer never
         /// populated an entry under the key that was looked up, so every single token count
         /// re-entered the failure path and re-logged (#1051).
         /// </remarks>
-        private Tokenizer? GetOrCreateEncoding(string? tokenizerType, string modelName)
+        private (Tokenizer? Encoding, TokenCountFidelity Fidelity) GetOrCreateEncoding(string? tokenizerType, string modelName)
         {
             var cacheKey = tokenizerType?.Trim() ?? string.Empty;
 
@@ -288,9 +304,15 @@ namespace ConduitLLM.Core.Services
                     encoding = null;
                 }
 
+                var fidelity = encoding is null
+                    ? TokenCountFidelity.CharacterHeuristic
+                    : resolved.IsApproximation || !resolved.IsRecognized
+                        ? TokenCountFidelity.ApproximateVocabulary
+                        : TokenCountFidelity.Exact;
+
                 // Cache the failure too, so a broken encoding does not re-throw on every request.
-                _encodings[cacheKey] = encoding;
-                return encoding;
+                _encodings[cacheKey] = (encoding, fidelity);
+                return (encoding, fidelity);
             }
         }
 

--- a/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
+++ b/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
@@ -15,10 +15,24 @@ namespace ConduitLLM.Core.Services
         private readonly ILogger<UsageEstimationService> _logger;
         
         /// <summary>
-        /// Buffer percentage to add to estimated tokens to ensure we don't undercharge.
-        /// Default is 10% overhead for conservative estimation.
+        /// Buffer percentage added to estimated tokens to ensure we don't undercharge, sized by
+        /// how the count was produced (#1233).
         /// </summary>
-        private const double ConservativeBufferPercentage = 0.10;
+        /// <remarks>
+        /// An exact count keeps the historical 10% — the per-message overhead arithmetic is still
+        /// an estimate. A stand-in vocabulary (Claude counted with cl100k_base, ...) is typically
+        /// 10-30% off, and the chars/4 heuristic under-counts English prose by 20-40% and CJK by
+        /// far more, so those tiers carry proportionally larger buffers.
+        /// </remarks>
+        private static double BufferFor(TokenCountFidelity fidelity) => fidelity switch
+        {
+            TokenCountFidelity.Exact => 0.10,
+            TokenCountFidelity.ApproximateVocabulary => 0.20,
+            _ => 0.40,
+        };
+
+        /// <summary>Buffer applied on the character-based fallback paths below.</summary>
+        private const double CharacterHeuristicBuffer = 0.40;
 
         public UsageEstimationService(
             ITokenCounter tokenCounter,
@@ -51,14 +65,14 @@ namespace ConduitLLM.Core.Services
 
                 // Estimate prompt tokens from input messages
                 var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputMessages);
-                
+
                 // Estimate completion tokens from streamed content
                 var completionTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, streamedContent);
-                
-                // Apply conservative buffer to avoid undercharging
-                var bufferedPromptTokens = (int)Math.Ceiling(promptTokens * (1 + ConservativeBufferPercentage));
-                var bufferedCompletionTokens = (int)Math.Ceiling(completionTokens * (1 + ConservativeBufferPercentage));
-                
+
+                // Apply a fidelity-sized buffer to avoid undercharging
+                var bufferedPromptTokens = (int)Math.Ceiling(promptTokens.Tokens * (1 + BufferFor(promptTokens.Fidelity)));
+                var bufferedCompletionTokens = (int)Math.Ceiling(completionTokens.Tokens * (1 + BufferFor(completionTokens.Fidelity)));
+
                 var usage = new Usage
                 {
                     PromptTokens = bufferedPromptTokens,
@@ -67,11 +81,11 @@ namespace ConduitLLM.Core.Services
                 };
 
                 _logger.LogInformation(
-                    "Estimated usage for model {Model}: Prompt={PromptTokens} (raw={RawPrompt}), " +
-                    "Completion={CompletionTokens} (raw={RawCompletion}), Total={TotalTokens}, Buffer={Buffer:P0}",
-                    modelId, usage.PromptTokens, promptTokens, 
-                    usage.CompletionTokens, completionTokens, 
-                    usage.TotalTokens, ConservativeBufferPercentage);
+                    "Estimated usage for model {Model}: Prompt={PromptTokens} (raw={RawPrompt}, {PromptFidelity}), " +
+                    "Completion={CompletionTokens} (raw={RawCompletion}, {CompletionFidelity}), Total={TotalTokens}",
+                    modelId, usage.PromptTokens, promptTokens.Tokens, promptTokens.Fidelity,
+                    usage.CompletionTokens, completionTokens.Tokens, completionTokens.Fidelity,
+                    usage.TotalTokens);
 
                 return usage;
             }
@@ -83,10 +97,10 @@ namespace ConduitLLM.Core.Services
                 // Using conservative 4 characters per token estimate
                 var fallbackPromptTokens = EstimateTokensFromCharacters(await GetTotalCharacterCountAsync(inputMessages));
                 var fallbackCompletionTokens = EstimateTokensFromCharacters(streamedContent.Length);
-                
-                // Apply conservative buffer
-                var bufferedPromptTokens = (int)Math.Ceiling(fallbackPromptTokens * (1 + ConservativeBufferPercentage));
-                var bufferedCompletionTokens = (int)Math.Ceiling(fallbackCompletionTokens * (1 + ConservativeBufferPercentage));
+
+                // This path is character-heuristic by construction, so it gets that tier's buffer
+                var bufferedPromptTokens = (int)Math.Ceiling(fallbackPromptTokens * (1 + CharacterHeuristicBuffer));
+                var bufferedCompletionTokens = (int)Math.Ceiling(fallbackCompletionTokens * (1 + CharacterHeuristicBuffer));
                 
                 var fallbackUsage = new Usage
                 {
@@ -126,10 +140,10 @@ namespace ConduitLLM.Core.Services
                 // Estimate tokens for input and output
                 var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputText);
                 var completionTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, outputText);
-                
-                // Apply conservative buffer
-                var bufferedPromptTokens = (int)Math.Ceiling(promptTokens * (1 + ConservativeBufferPercentage));
-                var bufferedCompletionTokens = (int)Math.Ceiling(completionTokens * (1 + ConservativeBufferPercentage));
+
+                // Apply a fidelity-sized buffer
+                var bufferedPromptTokens = (int)Math.Ceiling(promptTokens.Tokens * (1 + BufferFor(promptTokens.Fidelity)));
+                var bufferedCompletionTokens = (int)Math.Ceiling(completionTokens.Tokens * (1 + BufferFor(completionTokens.Fidelity)));
                 
                 var usage = new Usage
                 {
@@ -151,10 +165,10 @@ namespace ConduitLLM.Core.Services
                 // Fallback to character-based estimation
                 var fallbackPromptTokens = EstimateTokensFromCharacters(inputText.Length);
                 var fallbackCompletionTokens = EstimateTokensFromCharacters(outputText.Length);
-                
-                // Apply conservative buffer
-                var bufferedPromptTokens = (int)Math.Ceiling(fallbackPromptTokens * (1 + ConservativeBufferPercentage));
-                var bufferedCompletionTokens = (int)Math.Ceiling(fallbackCompletionTokens * (1 + ConservativeBufferPercentage));
+
+                // This path is character-heuristic by construction, so it gets that tier's buffer
+                var bufferedPromptTokens = (int)Math.Ceiling(fallbackPromptTokens * (1 + CharacterHeuristicBuffer));
+                var bufferedCompletionTokens = (int)Math.Ceiling(fallbackCompletionTokens * (1 + CharacterHeuristicBuffer));
                 
                 return new Usage
                 {

--- a/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
+++ b/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
@@ -49,6 +49,7 @@ namespace ConduitLLM.Core.Services
             string modelId,
             List<Message> inputMessages,
             string streamedContent,
+            IReadOnlyList<Tool>? tools = null,
             CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(modelId))
@@ -63,8 +64,8 @@ namespace ConduitLLM.Core.Services
                 _logger.LogInformation("Estimating usage for model {Model} with {MessageCount} input messages and {OutputLength} characters of output",
                     modelId, inputMessages.Count, streamedContent.Length);
 
-                // Estimate prompt tokens from input messages
-                var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputMessages);
+                // Estimate prompt tokens from input messages, including tool definitions
+                var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputMessages, tools);
 
                 // Estimate completion tokens from streamed content
                 var completionTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, streamedContent);

--- a/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
+++ b/Tests/ConduitLLM.BillingInvariantTests/TokenVocabularyGoldenTests.cs
@@ -291,7 +291,7 @@ public sealed class TokenVocabularyGoldenTests
 
         var actual = await counter.EstimateTokenCountAsync($"probe-{encoding}", Corpus[corpusId]);
 
-        Assert.Equal(Expected[$"{encoding}|{corpusId}"], actual);
+        Assert.Equal(Expected[$"{encoding}|{corpusId}"], actual.Tokens);
     }
 
     /// <summary>
@@ -338,7 +338,7 @@ public sealed class TokenVocabularyGoldenTests
             foreach (var id in Corpus.Keys.OrderBy(k => k, StringComparer.Ordinal))
             {
                 var count = await counter.EstimateTokenCountAsync($"probe-{encoding}", Corpus[id]);
-                _output.WriteLine($"            [\"{encoding}|{id}\"] = {count},");
+                _output.WriteLine($"            [\"{encoding}|{id}\"] = {count.Tokens},");
             }
         }
     }

--- a/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
@@ -57,6 +57,7 @@ public sealed class StreamingAbortFaultTests(BillingFaultFixture fixture)
         var estimator = new Mock<IUsageEstimationService>();
         estimator.Setup(service => service.EstimateUsageFromStreamingResponseAsync(
                 "fault-model", It.IsAny<List<Message>>(), "partial completion",
+                It.IsAny<IReadOnlyList<Tool>?>(),
                 It.Is<CancellationToken>(ct => ct.CanBeCanceled)))
             .ReturnsAsync(new Usage { PromptTokens = 20, CompletionTokens = 30, TotalTokens = 50 });
         var endpoints = new ChatEndpoints(

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterEncodingTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterEncodingTests.cs
@@ -51,7 +51,8 @@ namespace ConduitLLM.Tests.Core.Services
 
             var count = await counter.EstimateTokenCountAsync($"model-{tokenizerType}", Messages);
 
-            Assert.True(count > 0, $"{tokenizerType} produced no tokens");
+            Assert.True(count.Tokens > 0, $"{tokenizerType} produced no tokens");
+            Assert.NotEqual(TokenCountFidelity.CharacterHeuristic, count.Fidelity);
             Assert.Equal(0, CountLogs(logger, LogLevel.Warning));
             Assert.Equal(0, CountLogs(logger, LogLevel.Error));
         }
@@ -67,7 +68,32 @@ namespace ConduitLLM.Tests.Core.Services
 
             // LLaMA3 has no Tiktoken equivalent and is documented as a cl100k_base approximation,
             // so the two must agree — a divergence would mean the approximation silently changed.
-            Assert.Equal(exact, approximate);
+            Assert.Equal(exact.Tokens, approximate.Tokens);
+
+            // Same number, different trust: the stand-in vocabulary must be labeled as such (#1233).
+            Assert.Equal(TokenCountFidelity.Exact, exact.Fidelity);
+            Assert.Equal(TokenCountFidelity.ApproximateVocabulary, approximate.Fidelity);
+        }
+
+        [Theory]
+        [InlineData("Cl100KBase", TokenCountFidelity.Exact)]
+        [InlineData("P50KBase", TokenCountFidelity.Exact)]
+        [InlineData("P50KEdit", TokenCountFidelity.Exact)]
+        [InlineData("R50KBase", TokenCountFidelity.Exact)]
+        [InlineData("O200KBase", TokenCountFidelity.Exact)]
+        [InlineData("Claude3", TokenCountFidelity.ApproximateVocabulary)]
+        [InlineData("Gemini", TokenCountFidelity.ApproximateVocabulary)]
+        [InlineData("LLaMA3", TokenCountFidelity.ApproximateVocabulary)]
+        [InlineData("O200KHarmony", TokenCountFidelity.ApproximateVocabulary)]
+        [InlineData("None", TokenCountFidelity.ApproximateVocabulary)]
+        public async Task EstimateTokenCountAsync_ReportsFidelityMatchingTheResolutionTier(
+            string tokenizerType, TokenCountFidelity expected)
+        {
+            var (counter, _) = CreateCounter(tokenizerType);
+
+            var count = await counter.EstimateTokenCountAsync($"model-{tokenizerType}", Messages);
+
+            Assert.Equal(expected, count.Fidelity);
         }
 
         [Fact]
@@ -81,7 +107,8 @@ namespace ConduitLLM.Tests.Core.Services
             for (var i = 0; i < 25; i++)
             {
                 var count = await counter.EstimateTokenCountAsync("model-unknown", Messages);
-                Assert.True(count > 0);
+                Assert.True(count.Tokens > 0);
+                Assert.Equal(TokenCountFidelity.ApproximateVocabulary, count.Fidelity);
             }
 
             // Before #1051 the failed resolution was cached under the *resolved* name while the

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
@@ -220,7 +220,7 @@ namespace ConduitLLM.Tests.Core.Services
 
             var actual = await counter.EstimateTokenCountAsync($"probe-{tokenizerType}", Probe);
 
-            Assert.Equal(ExpectedByTokenizer[tokenizerType], actual);
+            Assert.Equal(ExpectedByTokenizer[tokenizerType], actual.Tokens);
         }
 
         [Theory]
@@ -231,7 +231,7 @@ namespace ConduitLLM.Tests.Core.Services
 
             var actual = await counter.EstimateTokenCountAsync("probe-messages", MessageShapes[shapeId]);
 
-            Assert.Equal(ExpectedByMessageShape[shapeId], actual);
+            Assert.Equal(ExpectedByMessageShape[shapeId], actual.Tokens);
         }
 
         [Theory]
@@ -242,7 +242,7 @@ namespace ConduitLLM.Tests.Core.Services
 
             var actual = await counter.EstimateTokenCountAsync("probe-json", JsonMessage(shapeId));
 
-            Assert.Equal(ExpectedByJsonShape[shapeId], actual);
+            Assert.Equal(ExpectedByJsonShape[shapeId], actual.Tokens);
         }
 
         /// <summary>
@@ -261,8 +261,8 @@ namespace ConduitLLM.Tests.Core.Services
             var counts = new Dictionary<string, int>(StringComparer.Ordinal);
             foreach (var encoding in new[] { "cl100k_base", "p50k_base", "p50k_edit", "r50k_base", "o200k_base" })
             {
-                counts[encoding] = await CounterFor(encoding)
-                    .EstimateTokenCountAsync($"probe-{encoding}", Probe);
+                counts[encoding] = (await CounterFor(encoding)
+                    .EstimateTokenCountAsync($"probe-{encoding}", Probe)).Tokens;
             }
 
             Assert.Equal(counts.Count, counts.Values.Distinct().Count());
@@ -301,7 +301,7 @@ namespace ConduitLLM.Tests.Core.Services
             {
                 var name = tokenizerType.ToString();
                 var count = await CounterFor(name).EstimateTokenCountAsync($"probe-{name}", Probe);
-                _output.WriteLine($"                [\"{name}\"] = {count},");
+                _output.WriteLine($"                [\"{name}\"] = {count.Tokens},");
             }
 
             _output.WriteLine("--- MESSAGES ---");
@@ -309,7 +309,7 @@ namespace ConduitLLM.Tests.Core.Services
             {
                 var count = await CounterFor("cl100k_base")
                     .EstimateTokenCountAsync("probe-messages", MessageShapes[id]);
-                _output.WriteLine($"                [\"{id}\"] = {count},");
+                _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
             }
 
             _output.WriteLine("--- JSON ---");
@@ -317,7 +317,7 @@ namespace ConduitLLM.Tests.Core.Services
             {
                 var count = await CounterFor("cl100k_base")
                     .EstimateTokenCountAsync("probe-json", JsonMessage(id));
-                _output.WriteLine($"                [\"{id}\"] = {count},");
+                _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
             }
         }
 

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
@@ -132,6 +133,47 @@ namespace ConduitLLM.Tests.Core.Services
                 {
                     new Message { Role = "user", Content = "" }
                 },
+                // Agentic history: the assistant's tool call and the tool result both travel back
+                // to the provider as prompt context, so both must contribute tokens (#1229).
+                ["msgs-tool-call-round-trip"] = new()
+                {
+                    new Message { Role = "user", Content = "What is the weather in Paris?" },
+                    new Message
+                    {
+                        Role = "assistant",
+                        Content = null,
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new ToolCall
+                            {
+                                Id = "call_1",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Paris\"}" }
+                            }
+                        }
+                    },
+                    new Message { Role = "tool", Content = "{\"temp_c\":21}", ToolCallId = "call_1" }
+                },
+                ["msgs-parallel-tool-calls"] = new()
+                {
+                    new Message
+                    {
+                        Role = "assistant",
+                        Content = null,
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new ToolCall
+                            {
+                                Id = "call_1",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Paris\"}" }
+                            },
+                            new ToolCall
+                            {
+                                Id = "call_2",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Berlin\"}" }
+                            }
+                        }
+                    }
+                },
             };
 
         private static readonly IReadOnlyDictionary<string, int> ExpectedByMessageShape =
@@ -142,7 +184,91 @@ namespace ConduitLLM.Tests.Core.Services
                 ["msgs-empty-list"] = 0,
                 ["msgs-named"] = 11,
                 ["msgs-null-content"] = 8,
+                ["msgs-parallel-tool-calls"] = 28,
                 ["msgs-single-user"] = 11,
+                ["msgs-tool-call-round-trip"] = 41,
+            };
+
+        /// <summary>
+        /// Tool-definition shapes counted alongside a fixed single-user message
+        /// (<c>msgs-single-user</c>, pinned at 11), so each pin isolates what the tools add (#1229).
+        /// </summary>
+        /// <remarks>
+        /// The heuristic being pinned: 10 tokens of scaffolding when any tools are present, 6 per
+        /// function, plus the tokenized name, description, and compact-serialized parameter schema.
+        /// Counting the raw JSON schema over-counts slightly against OpenAI's TypeScript-style
+        /// compaction — deliberate, since these counts feed reservations and fallback billing.
+        /// </remarks>
+        private static readonly IReadOnlyDictionary<string, IReadOnlyList<Tool>> ToolShapes =
+            new Dictionary<string, IReadOnlyList<Tool>>(StringComparer.Ordinal)
+            {
+                ["tools-name-only"] = new List<Tool>
+                {
+                    new Tool { Function = new FunctionDefinition { Name = "get_weather" } }
+                },
+                ["tools-with-description"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city."
+                        }
+                    }
+                },
+                ["tools-with-parameters"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city.",
+                            Parameters = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["city"] = new JsonObject
+                                    {
+                                        ["type"] = "string",
+                                        ["description"] = "City name"
+                                    }
+                                },
+                                ["required"] = new JsonArray("city")
+                            }
+                        }
+                    }
+                },
+                ["tools-two-functions"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city."
+                        }
+                    },
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_forecast",
+                            Description = "Get a five day forecast for a city."
+                        }
+                    }
+                },
+            };
+
+        private static readonly IReadOnlyDictionary<string, int> ExpectedByToolShape =
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["tools-name-only"] = 29,
+                ["tools-two-functions"] = 55,
+                ["tools-with-description"] = 37,
+                ["tools-with-parameters"] = 60,
             };
 
         /// <summary>
@@ -202,6 +328,8 @@ namespace ConduitLLM.Tests.Core.Services
 
         public static TheoryData<string> JsonShapeIds() => Keys(JsonContentShapes.Keys);
 
+        public static TheoryData<string> ToolShapeIds() => Keys(ToolShapes.Keys);
+
         private static TheoryData<string> Keys(IEnumerable<string> keys)
         {
             var data = new TheoryData<string>();
@@ -243,6 +371,18 @@ namespace ConduitLLM.Tests.Core.Services
             var actual = await counter.EstimateTokenCountAsync("probe-json", JsonMessage(shapeId));
 
             Assert.Equal(ExpectedByJsonShape[shapeId], actual.Tokens);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToolShapeIds))]
+        public async Task ToolShape_ProducesPinnedTokenCount(string shapeId)
+        {
+            var counter = CounterFor("cl100k_base");
+
+            var actual = await counter.EstimateTokenCountAsync(
+                "probe-tools", MessageShapes["msgs-single-user"], ToolShapes[shapeId]);
+
+            Assert.Equal(ExpectedByToolShape[shapeId], actual.Tokens);
         }
 
         /// <summary>
@@ -288,6 +428,8 @@ namespace ConduitLLM.Tests.Core.Services
                 .Where(k => !ExpectedByMessageShape.ContainsKey(k)).Select(k => $"messages:{k}"));
             missing.AddRange(JsonContentShapes.Keys
                 .Where(k => !ExpectedByJsonShape.ContainsKey(k)).Select(k => $"json:{k}"));
+            missing.AddRange(ToolShapes.Keys
+                .Where(k => !ExpectedByToolShape.ContainsKey(k)).Select(k => $"tools:{k}"));
 
             Assert.True(missing.Count == 0, "Unpinned shapes: " + string.Join(", ", missing));
         }
@@ -317,6 +459,14 @@ namespace ConduitLLM.Tests.Core.Services
             {
                 var count = await CounterFor("cl100k_base")
                     .EstimateTokenCountAsync("probe-json", JsonMessage(id));
+                _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
+            }
+
+            _output.WriteLine("--- TOOLS ---");
+            foreach (var id in ToolShapes.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var count = await CounterFor("cl100k_base")
+                    .EstimateTokenCountAsync("probe-tools", MessageShapes["msgs-single-user"], ToolShapes[id]);
                 _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
             }
         }

--- a/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
@@ -221,6 +221,29 @@ namespace ConduitLLM.Tests.Core.Services
         }
 
         [Fact]
+        public async Task EstimateUsageFromStreamingResponseAsync_ToolDefinitions_ReachTheCounter()
+        {
+            // Tool schemas are part of the billed prompt; the fallback estimate must include them
+            // or agentic streams without provider usage are under-billed (#1229).
+            var modelId = "gpt-4";
+            var inputMessages = new List<Message> { new Message { Role = "user", Content = "hello" } };
+            var streamedContent = "response";
+            var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages, tools))
+                .ReturnsAsync(new TokenCount(300, TokenCountFidelity.Exact));
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
+                .ReturnsAsync(new TokenCount(10, TokenCountFidelity.Exact));
+
+            var result = await _service.EstimateUsageFromStreamingResponseAsync(
+                modelId, inputMessages, streamedContent, tools);
+
+            // 300 * 1.1 = 330: the tools-inclusive count is what gets buffered and billed.
+            Assert.Equal(330, result.PromptTokens);
+            _mockTokenCounter.Verify(x => x.EstimateTokenCountAsync(modelId, inputMessages, tools), Times.Once);
+        }
+
+        [Fact]
         public async Task EstimateUsageFromStreamingResponseAsync_ApproximateVocabulary_AppliesLargerBuffer()
         {
             // Arrange: a Claude-style model whose counts come from a stand-in vocabulary.

--- a/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
@@ -36,9 +36,9 @@ namespace ConduitLLM.Tests.Core.Services
             
             // Mock token counts (raw, without buffer)
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages))
-                .ReturnsAsync(10);
+                .ReturnsAsync(new TokenCount(10, TokenCountFidelity.Exact));
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
-                .ReturnsAsync(15);
+                .ReturnsAsync(new TokenCount(15, TokenCountFidelity.Exact));
 
             // Act
             var result = await _service.EstimateUsageFromStreamingResponseAsync(
@@ -103,9 +103,9 @@ namespace ConduitLLM.Tests.Core.Services
             var outputText = "The capital of France is Paris.";
             
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputText))
-                .ReturnsAsync(8);
+                .ReturnsAsync(new TokenCount(8, TokenCountFidelity.Exact));
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, outputText))
-                .ReturnsAsync(7);
+                .ReturnsAsync(new TokenCount(7, TokenCountFidelity.Exact));
 
             // Act
             var result = await _service.EstimateUsageFromTextAsync(modelId, inputText, outputText);
@@ -167,11 +167,11 @@ namespace ConduitLLM.Tests.Core.Services
             var streamedContent = "The image shows a beautiful sunset over the ocean.";
             
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages))
-                .ReturnsAsync(100); // Including image tokens
+                .ReturnsAsync(new TokenCount(100, TokenCountFidelity.Exact)); // Including image tokens
             _mockImageTokenCalculator.Setup(x => x.CalculateImageTokensAsync(It.IsAny<ImageUrl>()))
                 .ReturnsAsync(850); // Standard high-res image tokens
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
-                .ReturnsAsync(12);
+                .ReturnsAsync(new TokenCount(12, TokenCountFidelity.Exact));
 
             // Act
             var result = await _service.EstimateUsageFromStreamingResponseAsync(
@@ -203,9 +203,9 @@ namespace ConduitLLM.Tests.Core.Services
             }
             
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages))
-                .ReturnsAsync(50);
+                .ReturnsAsync(new TokenCount(50, TokenCountFidelity.Exact));
             _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent.ToString()))
-                .ReturnsAsync(2000);
+                .ReturnsAsync(new TokenCount(2000, TokenCountFidelity.Exact));
 
             // Act
             var result = await _service.EstimateUsageFromStreamingResponseAsync(
@@ -218,6 +218,50 @@ namespace ConduitLLM.Tests.Core.Services
             Assert.InRange(result.PromptTokens!.Value, 55, 56);
             Assert.Equal(2200, result.CompletionTokens);
             Assert.InRange(result.TotalTokens!.Value, 2255, 2256);
+        }
+
+        [Fact]
+        public async Task EstimateUsageFromStreamingResponseAsync_ApproximateVocabulary_AppliesLargerBuffer()
+        {
+            // Arrange: a Claude-style model whose counts come from a stand-in vocabulary.
+            var modelId = "claude-model";
+            var inputMessages = new List<Message> { new Message { Role = "user", Content = "hello" } };
+            var streamedContent = "response";
+
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages))
+                .ReturnsAsync(new TokenCount(100, TokenCountFidelity.ApproximateVocabulary));
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
+                .ReturnsAsync(new TokenCount(200, TokenCountFidelity.ApproximateVocabulary));
+
+            // Act
+            var result = await _service.EstimateUsageFromStreamingResponseAsync(
+                modelId, inputMessages, streamedContent);
+
+            // Assert: 20% buffer for the approximate-vocabulary tier
+            Assert.Equal(120, result.PromptTokens);
+            Assert.Equal(240, result.CompletionTokens);
+        }
+
+        [Fact]
+        public async Task EstimateUsageFromStreamingResponseAsync_CharacterHeuristic_AppliesLargestBuffer()
+        {
+            // Arrange: counts that came from the chars/4 fallback (broken vocabulary data).
+            var modelId = "degraded-model";
+            var inputMessages = new List<Message> { new Message { Role = "user", Content = "hello" } };
+            var streamedContent = "response";
+
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages))
+                .ReturnsAsync(new TokenCount(100, TokenCountFidelity.CharacterHeuristic));
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
+                .ReturnsAsync(new TokenCount(200, TokenCountFidelity.CharacterHeuristic));
+
+            // Act
+            var result = await _service.EstimateUsageFromStreamingResponseAsync(
+                modelId, inputMessages, streamedContent);
+
+            // Assert: 40% buffer for the character-heuristic tier, which under-counts by 20-40%
+            Assert.Equal(140, result.PromptTokens);
+            Assert.Equal(280, result.CompletionTokens);
         }
     }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
@@ -140,4 +140,45 @@ public class ChatSpendEstimatorTests
         // The cost mock only matches the buffered prompt count, so a wrong buffer fails here too.
         Assert.Equal(0.10m, result.Amount);
     }
+
+    [Fact]
+    public async Task EstimateForwardsToolDefinitionsToTheCounter()
+    {
+        // Tool schemas become prompt tokens at the provider; a reservation that ignores them
+        // under-bounds every agentic request (#1229).
+        var mappingService = new Mock<IModelProviderMappingService>();
+        mappingService.Setup(x => x.GetMappingByModelAliasAsync("model"))
+            .ReturnsAsync(new ModelProviderMapping
+            {
+                ModelAlias = "model",
+                ProviderModelId = "provider-model",
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation { ModelCostId = 9 }
+            });
+        var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+        var tokenCounter = new Mock<ITokenCounter>();
+        tokenCounter.Setup(x => x.EstimateTokenCountAsync("model", It.IsAny<List<Message>>(), tools))
+            .ReturnsAsync(new TokenCount(700, TokenCountFidelity.Exact));
+        var costService = new Mock<ICostCalculationService>();
+        costService.Setup(x => x.CalculateCostByIdAsync(
+                9,
+                It.Is<Usage>(usage => usage.PromptTokens == 700),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.20m);
+        var estimator = new ChatSpendEstimator(
+            mappingService.Object,
+            tokenCounter.Object,
+            costService.Object,
+            Options.Create(new BillingAdmissionOptions()));
+
+        var result = await estimator.EstimateMaximumCostAsync(new ChatCompletionRequest
+        {
+            Model = "model",
+            Messages = [new Message { Role = "user", Content = "hello" }],
+            Tools = tools,
+            MaxCompletionTokens = 64
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(700, result.PromptTokens);
+    }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
@@ -31,7 +31,7 @@ public class ChatSpendEstimatorTests
             });
         var tokenCounter = new Mock<ITokenCounter>();
         tokenCounter.Setup(x => x.EstimateTokenCountAsync("model", It.IsAny<List<Message>>()))
-            .ReturnsAsync(100);
+            .ReturnsAsync(new TokenCount(100, TokenCountFidelity.Exact));
         var costService = new Mock<ICostCalculationService>();
         costService.Setup(x => x.CalculateCostByIdAsync(
                 9,
@@ -73,7 +73,7 @@ public class ChatSpendEstimatorTests
             });
         var tokenCounter = new Mock<ITokenCounter>();
         tokenCounter.Setup(x => x.EstimateTokenCountAsync("model", It.IsAny<List<Message>>()))
-            .ReturnsAsync(10);
+            .ReturnsAsync(new TokenCount(10, TokenCountFidelity.Exact));
         var costService = new Mock<ICostCalculationService>();
         costService.Setup(x => x.CalculateCostByIdAsync(
                 9,
@@ -96,5 +96,48 @@ public class ChatSpendEstimatorTests
 
         Assert.True(result.Succeeded);
         Assert.Equal(64, result.MaximumOutputTokens);
+    }
+
+    [Theory]
+    [InlineData(TokenCountFidelity.Exact, 1000, 1000)]
+    [InlineData(TokenCountFidelity.ApproximateVocabulary, 1000, 1150)]  // +15% default buffer
+    [InlineData(TokenCountFidelity.CharacterHeuristic, 1000, 1500)]     // +50% default buffer
+    public async Task EstimateBuffersPromptTokensByCountFidelity(
+        TokenCountFidelity fidelity, int rawTokens, int expectedReservedPromptTokens)
+    {
+        var mappingService = new Mock<IModelProviderMappingService>();
+        mappingService.Setup(x => x.GetMappingByModelAliasAsync("model"))
+            .ReturnsAsync(new ModelProviderMapping
+            {
+                ModelAlias = "model",
+                ProviderModelId = "provider-model",
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation { ModelCostId = 9 }
+            });
+        var tokenCounter = new Mock<ITokenCounter>();
+        tokenCounter.Setup(x => x.EstimateTokenCountAsync("model", It.IsAny<List<Message>>()))
+            .ReturnsAsync(new TokenCount(rawTokens, fidelity));
+        var costService = new Mock<ICostCalculationService>();
+        costService.Setup(x => x.CalculateCostByIdAsync(
+                9,
+                It.Is<Usage>(usage => usage.PromptTokens == expectedReservedPromptTokens),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.10m);
+        var estimator = new ChatSpendEstimator(
+            mappingService.Object,
+            tokenCounter.Object,
+            costService.Object,
+            Options.Create(new BillingAdmissionOptions()));
+
+        var result = await estimator.EstimateMaximumCostAsync(new ChatCompletionRequest
+        {
+            Model = "model",
+            Messages = [new Message { Role = "user", Content = "hello" }],
+            MaxCompletionTokens = 64
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(expectedReservedPromptTokens, result.PromptTokens);
+        // The cost mock only matches the buffered prompt count, so a wrong buffer fails here too.
+        Assert.Equal(0.10m, result.Amount);
     }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
@@ -284,6 +284,7 @@ public sealed class ResponsesEndpointsTests
                 It.IsAny<string>(),
                 It.IsAny<List<Message>>(),
                 It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<Tool>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Usage { PromptTokens = 1, CompletionTokens = 1, TotalTokens = 2 });
 

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
@@ -28,7 +28,8 @@ public class RequestTokenEstimatorTests
     [Fact]
     public async Task EstimateAsync_Chat_AddsThePromptToTheDeclaredCompletionCeiling()
     {
-        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>())).ReturnsAsync(3_400);
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>()))
+            .ReturnsAsync(new TokenCount(3_400, TokenCountFidelity.Exact));
 
         var estimate = await Estimator().EstimateAsync(Chat(maxTokens: 600));
 
@@ -41,7 +42,8 @@ public class RequestTokenEstimatorTests
     public async Task EstimateAsync_Chat_WithoutADeclaredCeiling_UsesTheConfiguredDefault()
     {
         // An uncapped request could otherwise reserve — and block — the entire window.
-        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>())).ReturnsAsync(100);
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>()))
+            .ReturnsAsync(new TokenCount(100, TokenCountFidelity.Exact));
 
         var estimate = await Estimator().EstimateAsync(Chat(maxTokens: null));
 
@@ -51,7 +53,8 @@ public class RequestTokenEstimatorTests
     [Fact]
     public async Task EstimateAsync_Chat_PrefersMaxCompletionTokensOverLegacyMaxTokens()
     {
-        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>())).ReturnsAsync(50);
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>()))
+            .ReturnsAsync(new TokenCount(50, TokenCountFidelity.Exact));
 
         var request = Chat(maxTokens: 100);
         request.MaxCompletionTokens = 900;
@@ -64,7 +67,8 @@ public class RequestTokenEstimatorTests
     [Fact]
     public async Task EstimateAsync_Chat_ClampsAnOutsizedDeclaredCeiling()
     {
-        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>())).ReturnsAsync(10);
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>()))
+            .ReturnsAsync(new TokenCount(10, TokenCountFidelity.Exact));
 
         var estimate = await Estimator().EstimateAsync(Chat(maxTokens: 5_000_000));
 
@@ -75,7 +79,8 @@ public class RequestTokenEstimatorTests
     [Fact]
     public async Task EstimateAsync_Embedding_CountsInputOnly()
     {
-        _counter.Setup(x => x.EstimateTokenCountAsync("text-embedding-3", It.IsAny<string>())).ReturnsAsync(250);
+        _counter.Setup(x => x.EstimateTokenCountAsync("text-embedding-3", It.IsAny<string>()))
+            .ReturnsAsync(new TokenCount(250, TokenCountFidelity.Exact));
 
         var estimate = await Estimator().EstimateAsync(new EmbeddingRequest
         {
@@ -93,7 +98,7 @@ public class RequestTokenEstimatorTests
         string? counted = null;
         _counter.Setup(x => x.EstimateTokenCountAsync(It.IsAny<string>(), It.IsAny<string>()))
             .Callback((string _, string text) => counted = text)
-            .ReturnsAsync(12);
+            .ReturnsAsync(new TokenCount(12, TokenCountFidelity.Exact));
 
         await Estimator().EstimateAsync(new EmbeddingRequest
         {

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
@@ -110,6 +110,24 @@ public class RequestTokenEstimatorTests
     }
 
     [Fact]
+    public async Task EstimateAsync_Chat_ForwardsToolDefinitionsToTheCounter()
+    {
+        // Tool schemas are injected into the prompt by the provider, so leaving them out of the
+        // estimate under-counts agentic traffic against the token window (#1229).
+        var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>(), tools))
+            .ReturnsAsync(new TokenCount(500, TokenCountFidelity.Exact));
+
+        var request = Chat(maxTokens: 100);
+        request.Tools = tools;
+
+        var estimate = await Estimator().EstimateAsync(request);
+
+        estimate!.Value.PromptTokens.Should().Be(500);
+        _counter.Verify(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>(), tools), Times.Once);
+    }
+
+    [Fact]
     public async Task EstimateAsync_RequestWithoutTokenSemantics_ReturnsNull()
     {
         // Image and audio requests are not measured in tokens, so they carry no token window.

--- a/Tests/ConduitLLM.Tests/TestHelpers/TokenCounterMockExtensions.cs
+++ b/Tests/ConduitLLM.Tests/TestHelpers/TokenCounterMockExtensions.cs
@@ -6,56 +6,62 @@ using Moq;
 namespace ConduitLLM.Tests.TestHelpers
 {
     /// <summary>
-    /// Extension methods for setting up ITokenCounter mocks.
+    /// Extension methods for setting up ITokenCounter mocks. Counts default to
+    /// <see cref="TokenCountFidelity.Exact"/>; pass a fidelity to exercise buffer tiers.
     /// </summary>
     public static class TokenCounterMockExtensions
     {
         /// <summary>
         /// Sets up token counting for text strings.
         /// </summary>
-        public static void SetupTokenCount(this Mock<ITokenCounter> mock, string modelName, string text, int tokenCount)
+        public static void SetupTokenCount(this Mock<ITokenCounter> mock, string modelName, string text, int tokenCount,
+            TokenCountFidelity fidelity = TokenCountFidelity.Exact)
         {
             mock.Setup(x => x.EstimateTokenCountAsync(modelName, text))
-                .ReturnsAsync(tokenCount);
+                .ReturnsAsync(new TokenCount(tokenCount, fidelity));
         }
 
         /// <summary>
         /// Sets up token counting for any text with a specific model.
         /// </summary>
-        public static void SetupTokenCountForAnyText(this Mock<ITokenCounter> mock, string modelName, int tokenCount)
+        public static void SetupTokenCountForAnyText(this Mock<ITokenCounter> mock, string modelName, int tokenCount,
+            TokenCountFidelity fidelity = TokenCountFidelity.Exact)
         {
             mock.Setup(x => x.EstimateTokenCountAsync(modelName, It.IsAny<string>()))
-                .ReturnsAsync(tokenCount);
+                .ReturnsAsync(new TokenCount(tokenCount, fidelity));
         }
 
         /// <summary>
         /// Sets up token counting for messages.
         /// </summary>
-        public static void SetupMessageTokenCount(this Mock<ITokenCounter> mock, string modelName, List<Message> messages, int tokenCount)
+        public static void SetupMessageTokenCount(this Mock<ITokenCounter> mock, string modelName, List<Message> messages, int tokenCount,
+            TokenCountFidelity fidelity = TokenCountFidelity.Exact)
         {
             mock.Setup(x => x.EstimateTokenCountAsync(modelName, messages))
-                .ReturnsAsync(tokenCount);
+                .ReturnsAsync(new TokenCount(tokenCount, fidelity));
         }
 
         /// <summary>
         /// Sets up token counting for any messages with a specific model.
         /// </summary>
-        public static void SetupMessageTokenCountForAny(this Mock<ITokenCounter> mock, string modelName, int tokenCount)
+        public static void SetupMessageTokenCountForAny(this Mock<ITokenCounter> mock, string modelName, int tokenCount,
+            TokenCountFidelity fidelity = TokenCountFidelity.Exact)
         {
             mock.Setup(x => x.EstimateTokenCountAsync(modelName, It.IsAny<List<Message>>()))
-                .ReturnsAsync(tokenCount);
+                .ReturnsAsync(new TokenCount(tokenCount, fidelity));
         }
 
         /// <summary>
         /// Sets up default token counting for any model and input.
         /// </summary>
-        public static void SetupDefaultTokenCounting(this Mock<ITokenCounter> mock, int defaultTextTokens = 10, int defaultMessageTokens = 20)
+        public static void SetupDefaultTokenCounting(this Mock<ITokenCounter> mock, int defaultTextTokens = 10, int defaultMessageTokens = 20,
+            TokenCountFidelity fidelity = TokenCountFidelity.Exact)
         {
             mock.Setup(x => x.EstimateTokenCountAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(defaultTextTokens);
+                .ReturnsAsync(new TokenCount(defaultTextTokens, fidelity));
 
             mock.Setup(x => x.EstimateTokenCountAsync(It.IsAny<string>(), It.IsAny<List<Message>>()))
-                .ReturnsAsync(defaultMessageTokens);
+                .ReturnsAsync(new TokenCount(defaultMessageTokens, fidelity));
         }
     }
 }

--- a/docs/billing-alerting.md
+++ b/docs/billing-alerting.md
@@ -30,6 +30,20 @@ update the stale threshold in `grafana/provisioning/alerting/billing-alerting-ru
 - `Model Cost Canary Failed` fires when an active mapping has no usable cost, invalid pricing JSON,
   an expired/inactive cost, a calculation error, or a non-positive result.
 - `Model Cost Canary Stale` fires when the canary is absent or has not completed for 15 minutes.
+- `Token Counting Degraded to Character Heuristic` fires when any token estimate falls back to the
+  chars/4 heuristic (`conduit_token_count_estimates_total{fidelity="character_heuristic"}`). That
+  only happens when tokenizer vocabulary data cannot be loaded, which means spend reservations and
+  streaming-fallback billing are running on estimates that under-count by 20-40%. Larger safety
+  buffers are applied automatically on this tier, but the underlying cause — look for
+  `Failed to load encoding` in Gateway/Admin logs — should be fixed promptly.
+
+## Token-count fidelity metric
+
+`conduit_token_count_estimates_total{fidelity=...}` counts every token estimate by how it was
+produced: `exact` (the model's own vocabulary), `approximate_vocabulary` (a documented tiktoken
+stand-in, normal for non-OpenAI models), or `character_heuristic` (vocabulary unavailable — the
+alarm condition above). The exact-to-approximate ratio is expected to reflect your provider mix;
+`character_heuristic` is expected to be permanently zero.
 
 ## Response
 

--- a/grafana/provisioning/alerting/billing-alerting-rules.yml
+++ b/grafana/provisioning/alerting/billing-alerting-rules.yml
@@ -2,6 +2,8 @@ apiVersion: 1
 
 deleteRules:
   - orgId: 1
+    uid: conduit-token-count-degraded
+  - orgId: 1
     uid: conduit-billing-revenue-loss
   - orgId: 1
     uid: conduit-billing-zero-cost
@@ -101,6 +103,50 @@ groups:
         annotations:
           summary: A request with positive usage was billed at zero
           description: "A zero-cost billing event occurred in the last five minutes. Check the model and reason labels and the billing audit log."
+          runbook_url: "https://github.com/nickna/Conduit/blob/main/docs/billing-alerting.md"
+        labels: { severity: warning, service: conduit-billing }
+
+      - uid: conduit-token-count-degraded
+        title: Token Counting Degraded to Character Heuristic
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(conduit_token_count_estimates_total{fidelity="character_heuristic"}[5m]))
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: B
+              refId: C
+              type: threshold
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          summary: Token counts are falling back to the chars/4 heuristic
+          description: "Tokenizer vocabulary data is unavailable, so spend reservations and fallback billing are running on character-based estimates. Check Gateway logs for 'Failed to load encoding'."
           runbook_url: "https://github.com/nickna/Conduit/blob/main/docs/billing-alerting.md"
         labels: { severity: warning, service: conduit-billing }
 


### PR DESCRIPTION
## Summary

Implements #1233: `ITokenCounter` now returns `TokenCount(Tokens, Fidelity)` — the count plus how it was produced (`Exact` | `ApproximateVocabulary` | `CharacterHeuristic`) — and the consumers that turn counts into money size their safety buffers by tier instead of applying one flat figure.

**Stacked on #1235** (the Microsoft.ML.Tokenizers swap); the base branch is `fix/1227-bundled-tokenizer-vocabulary` and GitHub will retarget to `dev` when that merges. Only the last commit is this PR.

## What changes per consumer

| Consumer | Before | After |
|---|---|---|
| `ChatSpendEstimator` (spend reservation) | No buffer, regardless of count quality | Exact: unchanged. Approximate: +15%. Character-heuristic: +50%. Configurable via `BillingAdmissionOptions`; reconciliation releases the excess. |
| `UsageEstimationService` (billed usage when a stream omits it) | Flat +10% | +10% / +20% / +40% by tier — the flat 10% never covered a stand-in vocabulary's 10-30% error, let alone chars/4's 20-40% under-count |
| `RequestTokenEstimator` (TPM windows) | Raw count | Raw count, **deliberately** — padding rate-limit windows would only throttle callers before their limit; estimate-then-reconcile already corrects |
| `ContextManager` (trimming) | Raw count | Raw count — trimming compares against a hard window |

## The observability half (closes the loop on #1227)

New metric `conduit_token_count_estimates_total{fidelity}` records every estimate, and a provisioned Grafana rule (`Token Counting Degraded to Character Heuristic`) fires on any `character_heuristic` increase — the alarm that didn't exist when TiktokenSharp's vocabulary download failed silently. `docs/billing-alerting.md` documents the metric and the response.

## Design notes

- `TokenCountFidelity`'s numeric ordering encodes severity, so a message count assembled from parts carries the worst tier of its parts — a partial chars/4 fallback inside one message can't masquerade as exact.
- No implicit `int` conversions on `TokenCount`: dropping fidelity is a visible decision at every call site.
- Golden pins are untouched (assertions read `.Tokens`); fidelity itself is pinned per resolution tier, including the newly-exact `p50k_edit`/`r50k_base`.
- This is the interface-shape change #1229 (tool-token counting) will extend — one breaking pass, as both issues noted.

## Verification

Full solution builds clean; **123/123 billing-invariant** and **3,481 main-suite** tests pass (15 new: fidelity tiers, buffer arithmetic for all three tiers in both billing consumers).

Closes #1233.