### PR TITLE
feat(core): count tool definitions and assistant tool calls in token estimation (#1229)

### DIFF
--- a/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
+++ b/Services/ConduitLLM.Gateway/Billing/ChatSpendEstimator.cs
@@ -62,7 +62,7 @@ public sealed class ChatSpendEstimator : IChatSpendEstimator
             return Failed("A positive maximum output-token bound is required");
         }
 
-        var promptEstimate = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages);
+        var promptEstimate = await _tokenCounter.EstimateTokenCountAsync(request.Model, request.Messages, request.Tools);
 
         // The reservation must bound the real cost, so a count produced with a stand-in
         // vocabulary or the chars/4 heuristic is padded by a fidelity-sized buffer (#1233).

--- a/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.Streaming.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.Streaming.cs
@@ -511,6 +511,7 @@ namespace ConduitLLM.Gateway.Endpoints
                     state.StreamingModel ?? request.Model,
                     request.Messages,
                     completionOutput,
+                    request.Tools,
                     cancellationToken);
 
                 HttpContext.GetOrCreateRequestAccountingContext().RecordProviderUsage(

--- a/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ResponsesEndpoints.cs
@@ -590,6 +590,7 @@ public sealed class ResponsesEndpoints : GatewayEndpointHandlerBase
             providerModel ?? request.Model,
             request.Messages,
             output,
+            request.Tools,
             cancellationToken);
         accounting.RecordProviderUsage(estimated, providerModel ?? request.Model, UsageEvidenceSource.Estimated);
         return estimated;
@@ -621,6 +622,7 @@ public sealed class ResponsesEndpoints : GatewayEndpointHandlerBase
                 response.Model ?? request.Model,
                 request.Messages,
                 output,
+                request.Tools,
                 cancellationToken);
             accounting.RecordProviderUsage(
                 estimated,

--- a/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
+++ b/Services/ConduitLLM.Gateway/RateLimiting/RequestTokenEstimator.cs
@@ -88,7 +88,7 @@ public sealed class RequestTokenEstimator
     {
         // Rate-limit windows are estimate-then-reconcile, so the raw count is used without a
         // fidelity buffer: padding here would only throttle callers earlier than their limit.
-        var prompt = (await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages)).Tokens;
+        var prompt = (await _tokenCounter.EstimateTokenCountAsync(chat.Model, chat.Messages, chat.Tools)).Tokens;
 
         // max_completion_tokens supersedes the legacy max_tokens where both are present.
         var declared = chat.MaxCompletionTokens ?? chat.MaxTokens;

--- a/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/ITokenCounter.cs
@@ -17,9 +17,17 @@ namespace ConduitLLM.Core.Interfaces
         /// Estimates tokens for a list of messages, considering model specifics.
         /// </summary>
         /// <param name="modelName">Name of the model to use for token estimation</param>
-        /// <param name="messages">List of messages to count tokens for</param>
+        /// <param name="messages">
+        /// List of messages to count tokens for. Assistant messages' <see cref="Message.ToolCalls"/>
+        /// are counted; providers include them in the prompt on the next turn (#1229).
+        /// </param>
+        /// <param name="tools">
+        /// Tool definitions accompanying the request, or null. Providers inject these schemas into
+        /// the prompt, so omitting them under-counts agentic requests — pass the request's tools
+        /// whenever they are available (#1229).
+        /// </param>
         /// <returns>The estimated token count and its fidelity</returns>
-        Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages);
+        Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages, IReadOnlyList<Tool>? tools = null);
 
         /// <summary>
         /// Estimates tokens for a single text string.

--- a/Shared/ConduitLLM.Core/Interfaces/IUsageEstimationService.cs
+++ b/Shared/ConduitLLM.Core/Interfaces/IUsageEstimationService.cs
@@ -15,12 +15,17 @@ namespace ConduitLLM.Core.Interfaces
         /// <param name="modelId">The model identifier used for the request</param>
         /// <param name="inputMessages">The input messages sent to the model</param>
         /// <param name="streamedContent">The accumulated content from the streaming response</param>
+        /// <param name="tools">
+        /// The request's tool definitions, or null. Providers inject these schemas into the
+        /// prompt, so passing them keeps agentic requests from being under-billed (#1229).
+        /// </param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Estimated usage with prompt and completion tokens</returns>
         Task<Usage> EstimateUsageFromStreamingResponseAsync(
             string modelId,
             List<Message> inputMessages,
             string streamedContent,
+            IReadOnlyList<Tool>? tools = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
+++ b/Shared/ConduitLLM.Core/Services/TiktokenCounter.cs
@@ -66,7 +66,7 @@ namespace ConduitLLM.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages)
+        public async Task<TokenCount> EstimateTokenCountAsync(string modelName, List<Message> messages, IReadOnlyList<Tool>? tools = null)
         {
             if (messages == null || !messages.Any())
             {
@@ -80,7 +80,7 @@ namespace ConduitLLM.Core.Services
                 {
                     // Fallback strategy if we can't get the right encoding
                     _logger.LogWarning("Could not determine encoding for model {ModelName}. Using fallback token estimation method.", modelName);
-                    return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
+                    return Finish(new TokenCount(FallbackEstimateTokens(messages, tools), TokenCountFidelity.CharacterHeuristic));
                 }
 
                 int tokenCount = 0;
@@ -151,6 +151,36 @@ namespace ConduitLLM.Core.Services
                         }
                         tokenCount += 1; // Additional overhead for name field
                     }
+
+                    // Assistant tool calls travel back to the provider as prompt content on the
+                    // next turn, so agentic histories are structurally under-counted without them.
+                    if (message.ToolCalls is { Count: > 0 })
+                    {
+                        try
+                        {
+                            tokenCount += CountToolCallTokens(message.ToolCalls, encoding);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Error encoding tool calls. Using fallback estimate.");
+                            tokenCount += ToolCallFallbackChars(message.ToolCalls) / 4;
+                            fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
+                        }
+                    }
+                }
+
+                if (tools is { Count: > 0 })
+                {
+                    try
+                    {
+                        tokenCount += CountToolDefinitionTokens(tools, encoding);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error encoding tool definitions. Using fallback estimate.");
+                        tokenCount += ToolDefinitionFallbackChars(tools) / 4;
+                        fidelity = TokenCount.Worst(fidelity, TokenCountFidelity.CharacterHeuristic);
+                    }
                 }
 
                 tokenCount += 3; // Every reply is primed with <|start|>assistant<|message|>
@@ -160,9 +190,70 @@ namespace ConduitLLM.Core.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error estimating token count. Using fallback method.");
-                return Finish(new TokenCount(FallbackEstimateTokens(messages), TokenCountFidelity.CharacterHeuristic));
+                return Finish(new TokenCount(FallbackEstimateTokens(messages, tools), TokenCountFidelity.CharacterHeuristic));
             }
         }
+
+        /// <summary>
+        /// Counts the tokens an assistant message's tool calls contribute when replayed as prompt
+        /// context: the function name and raw JSON arguments, plus a small per-call framing cost.
+        /// </summary>
+        /// <remarks>
+        /// Providers do not publish their exact serialization of historical tool calls, so the
+        /// per-call overhead of 3 mirrors the reply-priming constant used elsewhere in this
+        /// counter. The name and arguments dominate in practice.
+        /// </remarks>
+        private static int CountToolCallTokens(IReadOnlyList<ToolCall> toolCalls, Tokenizer encoding)
+        {
+            int tokenCount = 0;
+            foreach (var toolCall in toolCalls)
+            {
+                tokenCount += 3;
+                tokenCount += encoding.CountTokens(toolCall.Function.Name);
+                tokenCount += encoding.CountTokens(toolCall.Function.Arguments);
+            }
+
+            return tokenCount;
+        }
+
+        /// <summary>
+        /// Counts the tokens a request's tool definitions contribute: providers inject each
+        /// function's name, description and JSON-schema parameters into the prompt.
+        /// </summary>
+        /// <remarks>
+        /// OpenAI compacts schemas into a TypeScript-like namespace listing before tokenizing;
+        /// counting the raw JSON schema instead over-counts slightly (schema punctuation the
+        /// compaction strips), which errs on the safe side for reservations and fallback billing.
+        /// The constants — 10 for the scaffolding around the tools block, 6 per function — follow
+        /// the same published community measurements the compaction format comes from.
+        /// </remarks>
+        private static int CountToolDefinitionTokens(IReadOnlyList<Tool> tools, Tokenizer encoding)
+        {
+            int tokenCount = 10;
+            foreach (var tool in tools)
+            {
+                tokenCount += 6;
+                tokenCount += encoding.CountTokens(tool.Function.Name);
+                if (!string.IsNullOrEmpty(tool.Function.Description))
+                {
+                    tokenCount += encoding.CountTokens(tool.Function.Description);
+                }
+                if (tool.Function.Parameters is not null)
+                {
+                    tokenCount += encoding.CountTokens(tool.Function.Parameters.ToJsonString());
+                }
+            }
+
+            return tokenCount;
+        }
+
+        private static int ToolCallFallbackChars(IReadOnlyList<ToolCall> toolCalls) =>
+            toolCalls.Sum(c => c.Function.Name.Length + c.Function.Arguments.Length);
+
+        private static int ToolDefinitionFallbackChars(IReadOnlyList<Tool> tools) =>
+            tools.Sum(t => t.Function.Name.Length
+                + (t.Function.Description?.Length ?? 0)
+                + (t.Function.Parameters?.ToJsonString().Length ?? 0));
 
         /// <inheritdoc />
         public async Task<TokenCount> EstimateTokenCountAsync(string modelName, string text)
@@ -469,13 +560,19 @@ namespace ConduitLLM.Core.Services
         /// estimate when the correct encoder is unavailable or fails.
         /// </para>
         /// </remarks>
-        private int FallbackEstimateTokens(List<Message> messages)
+        private int FallbackEstimateTokens(List<Message> messages, IReadOnlyList<Tool>? tools = null)
         {
             // Very rough estimation based on characters
             int totalCharacters = messages.Sum(m =>
                 (m.Content != null ? m.Content.ToString()?.Length ?? 0 : 0) +
                 (m.Role?.Length ?? 0) +
-                (m.Name?.Length ?? 0));
+                (m.Name?.Length ?? 0) +
+                (m.ToolCalls is { Count: > 0 } ? ToolCallFallbackChars(m.ToolCalls) : 0));
+
+            if (tools is { Count: > 0 })
+            {
+                totalCharacters += ToolDefinitionFallbackChars(tools);
+            }
 
             // Rough estimate: 1 token ≈ 4 characters in English
             return totalCharacters / 4;

--- a/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
+++ b/Shared/ConduitLLM.Core/Services/UsageEstimationService.cs
@@ -49,6 +49,7 @@ namespace ConduitLLM.Core.Services
             string modelId,
             List<Message> inputMessages,
             string streamedContent,
+            IReadOnlyList<Tool>? tools = null,
             CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(modelId))
@@ -63,8 +64,8 @@ namespace ConduitLLM.Core.Services
                 _logger.LogInformation("Estimating usage for model {Model} with {MessageCount} input messages and {OutputLength} characters of output",
                     modelId, inputMessages.Count, streamedContent.Length);
 
-                // Estimate prompt tokens from input messages
-                var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputMessages);
+                // Estimate prompt tokens from input messages, including tool definitions
+                var promptTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, inputMessages, tools);
 
                 // Estimate completion tokens from streamed content
                 var completionTokens = await _tokenCounter.EstimateTokenCountAsync(modelId, streamedContent);

--- a/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
@@ -57,6 +57,7 @@ public sealed class StreamingAbortFaultTests(BillingFaultFixture fixture)
         var estimator = new Mock<IUsageEstimationService>();
         estimator.Setup(service => service.EstimateUsageFromStreamingResponseAsync(
                 "fault-model", It.IsAny<List<Message>>(), "partial completion",
+                It.IsAny<IReadOnlyList<Tool>?>(),
                 It.Is<CancellationToken>(ct => ct.CanBeCanceled)))
             .ReturnsAsync(new Usage { PromptTokens = 20, CompletionTokens = 30, TotalTokens = 50 });
         var endpoints = new ChatEndpoints(

--- a/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/TiktokenCounterGoldenTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
@@ -132,6 +133,47 @@ namespace ConduitLLM.Tests.Core.Services
                 {
                     new Message { Role = "user", Content = "" }
                 },
+                // Agentic history: the assistant's tool call and the tool result both travel back
+                // to the provider as prompt context, so both must contribute tokens (#1229).
+                ["msgs-tool-call-round-trip"] = new()
+                {
+                    new Message { Role = "user", Content = "What is the weather in Paris?" },
+                    new Message
+                    {
+                        Role = "assistant",
+                        Content = null,
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new ToolCall
+                            {
+                                Id = "call_1",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Paris\"}" }
+                            }
+                        }
+                    },
+                    new Message { Role = "tool", Content = "{\"temp_c\":21}", ToolCallId = "call_1" }
+                },
+                ["msgs-parallel-tool-calls"] = new()
+                {
+                    new Message
+                    {
+                        Role = "assistant",
+                        Content = null,
+                        ToolCalls = new List<ToolCall>
+                        {
+                            new ToolCall
+                            {
+                                Id = "call_1",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Paris\"}" }
+                            },
+                            new ToolCall
+                            {
+                                Id = "call_2",
+                                Function = new FunctionCall { Name = "get_weather", Arguments = "{\"city\":\"Berlin\"}" }
+                            }
+                        }
+                    }
+                },
             };
 
         private static readonly IReadOnlyDictionary<string, int> ExpectedByMessageShape =
@@ -142,7 +184,91 @@ namespace ConduitLLM.Tests.Core.Services
                 ["msgs-empty-list"] = 0,
                 ["msgs-named"] = 11,
                 ["msgs-null-content"] = 8,
+                ["msgs-parallel-tool-calls"] = 28,
                 ["msgs-single-user"] = 11,
+                ["msgs-tool-call-round-trip"] = 41,
+            };
+
+        /// <summary>
+        /// Tool-definition shapes counted alongside a fixed single-user message
+        /// (<c>msgs-single-user</c>, pinned at 11), so each pin isolates what the tools add (#1229).
+        /// </summary>
+        /// <remarks>
+        /// The heuristic being pinned: 10 tokens of scaffolding when any tools are present, 6 per
+        /// function, plus the tokenized name, description, and compact-serialized parameter schema.
+        /// Counting the raw JSON schema over-counts slightly against OpenAI's TypeScript-style
+        /// compaction — deliberate, since these counts feed reservations and fallback billing.
+        /// </remarks>
+        private static readonly IReadOnlyDictionary<string, IReadOnlyList<Tool>> ToolShapes =
+            new Dictionary<string, IReadOnlyList<Tool>>(StringComparer.Ordinal)
+            {
+                ["tools-name-only"] = new List<Tool>
+                {
+                    new Tool { Function = new FunctionDefinition { Name = "get_weather" } }
+                },
+                ["tools-with-description"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city."
+                        }
+                    }
+                },
+                ["tools-with-parameters"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city.",
+                            Parameters = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["city"] = new JsonObject
+                                    {
+                                        ["type"] = "string",
+                                        ["description"] = "City name"
+                                    }
+                                },
+                                ["required"] = new JsonArray("city")
+                            }
+                        }
+                    }
+                },
+                ["tools-two-functions"] = new List<Tool>
+                {
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a city."
+                        }
+                    },
+                    new Tool
+                    {
+                        Function = new FunctionDefinition
+                        {
+                            Name = "get_forecast",
+                            Description = "Get a five day forecast for a city."
+                        }
+                    }
+                },
+            };
+
+        private static readonly IReadOnlyDictionary<string, int> ExpectedByToolShape =
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["tools-name-only"] = 29,
+                ["tools-two-functions"] = 55,
+                ["tools-with-description"] = 37,
+                ["tools-with-parameters"] = 60,
             };
 
         /// <summary>
@@ -202,6 +328,8 @@ namespace ConduitLLM.Tests.Core.Services
 
         public static TheoryData<string> JsonShapeIds() => Keys(JsonContentShapes.Keys);
 
+        public static TheoryData<string> ToolShapeIds() => Keys(ToolShapes.Keys);
+
         private static TheoryData<string> Keys(IEnumerable<string> keys)
         {
             var data = new TheoryData<string>();
@@ -243,6 +371,18 @@ namespace ConduitLLM.Tests.Core.Services
             var actual = await counter.EstimateTokenCountAsync("probe-json", JsonMessage(shapeId));
 
             Assert.Equal(ExpectedByJsonShape[shapeId], actual.Tokens);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToolShapeIds))]
+        public async Task ToolShape_ProducesPinnedTokenCount(string shapeId)
+        {
+            var counter = CounterFor("cl100k_base");
+
+            var actual = await counter.EstimateTokenCountAsync(
+                "probe-tools", MessageShapes["msgs-single-user"], ToolShapes[shapeId]);
+
+            Assert.Equal(ExpectedByToolShape[shapeId], actual.Tokens);
         }
 
         /// <summary>
@@ -288,6 +428,8 @@ namespace ConduitLLM.Tests.Core.Services
                 .Where(k => !ExpectedByMessageShape.ContainsKey(k)).Select(k => $"messages:{k}"));
             missing.AddRange(JsonContentShapes.Keys
                 .Where(k => !ExpectedByJsonShape.ContainsKey(k)).Select(k => $"json:{k}"));
+            missing.AddRange(ToolShapes.Keys
+                .Where(k => !ExpectedByToolShape.ContainsKey(k)).Select(k => $"tools:{k}"));
 
             Assert.True(missing.Count == 0, "Unpinned shapes: " + string.Join(", ", missing));
         }
@@ -317,6 +459,14 @@ namespace ConduitLLM.Tests.Core.Services
             {
                 var count = await CounterFor("cl100k_base")
                     .EstimateTokenCountAsync("probe-json", JsonMessage(id));
+                _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
+            }
+
+            _output.WriteLine("--- TOOLS ---");
+            foreach (var id in ToolShapes.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var count = await CounterFor("cl100k_base")
+                    .EstimateTokenCountAsync("probe-tools", MessageShapes["msgs-single-user"], ToolShapes[id]);
                 _output.WriteLine($"                [\"{id}\"] = {count.Tokens},");
             }
         }

--- a/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/UsageEstimationServiceTests.cs
@@ -221,6 +221,29 @@ namespace ConduitLLM.Tests.Core.Services
         }
 
         [Fact]
+        public async Task EstimateUsageFromStreamingResponseAsync_ToolDefinitions_ReachTheCounter()
+        {
+            // Tool schemas are part of the billed prompt; the fallback estimate must include them
+            // or agentic streams without provider usage are under-billed (#1229).
+            var modelId = "gpt-4";
+            var inputMessages = new List<Message> { new Message { Role = "user", Content = "hello" } };
+            var streamedContent = "response";
+            var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, inputMessages, tools))
+                .ReturnsAsync(new TokenCount(300, TokenCountFidelity.Exact));
+            _mockTokenCounter.Setup(x => x.EstimateTokenCountAsync(modelId, streamedContent))
+                .ReturnsAsync(new TokenCount(10, TokenCountFidelity.Exact));
+
+            var result = await _service.EstimateUsageFromStreamingResponseAsync(
+                modelId, inputMessages, streamedContent, tools);
+
+            // 300 * 1.1 = 330: the tools-inclusive count is what gets buffered and billed.
+            Assert.Equal(330, result.PromptTokens);
+            _mockTokenCounter.Verify(x => x.EstimateTokenCountAsync(modelId, inputMessages, tools), Times.Once);
+        }
+
+        [Fact]
         public async Task EstimateUsageFromStreamingResponseAsync_ApproximateVocabulary_AppliesLargerBuffer()
         {
             // Arrange: a Claude-style model whose counts come from a stand-in vocabulary.

--- a/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Billing/ChatSpendEstimatorTests.cs
@@ -140,4 +140,45 @@ public class ChatSpendEstimatorTests
         // The cost mock only matches the buffered prompt count, so a wrong buffer fails here too.
         Assert.Equal(0.10m, result.Amount);
     }
+
+    [Fact]
+    public async Task EstimateForwardsToolDefinitionsToTheCounter()
+    {
+        // Tool schemas become prompt tokens at the provider; a reservation that ignores them
+        // under-bounds every agentic request (#1229).
+        var mappingService = new Mock<IModelProviderMappingService>();
+        mappingService.Setup(x => x.GetMappingByModelAliasAsync("model"))
+            .ReturnsAsync(new ModelProviderMapping
+            {
+                ModelAlias = "model",
+                ProviderModelId = "provider-model",
+                ModelProviderTypeAssociation = new ModelProviderTypeAssociation { ModelCostId = 9 }
+            });
+        var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+        var tokenCounter = new Mock<ITokenCounter>();
+        tokenCounter.Setup(x => x.EstimateTokenCountAsync("model", It.IsAny<List<Message>>(), tools))
+            .ReturnsAsync(new TokenCount(700, TokenCountFidelity.Exact));
+        var costService = new Mock<ICostCalculationService>();
+        costService.Setup(x => x.CalculateCostByIdAsync(
+                9,
+                It.Is<Usage>(usage => usage.PromptTokens == 700),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.20m);
+        var estimator = new ChatSpendEstimator(
+            mappingService.Object,
+            tokenCounter.Object,
+            costService.Object,
+            Options.Create(new BillingAdmissionOptions()));
+
+        var result = await estimator.EstimateMaximumCostAsync(new ChatCompletionRequest
+        {
+            Model = "model",
+            Messages = [new Message { Role = "user", Content = "hello" }],
+            Tools = tools,
+            MaxCompletionTokens = 64
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(700, result.PromptTokens);
+    }
 }

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
@@ -284,6 +284,7 @@ public sealed class ResponsesEndpointsTests
                 It.IsAny<string>(),
                 It.IsAny<List<Message>>(),
                 It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<Tool>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Usage { PromptTokens = 1, CompletionTokens = 1, TotalTokens = 2 });
 

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
@@ -110,6 +110,24 @@ public class RequestTokenEstimatorTests
     }
 
     [Fact]
+    public async Task EstimateAsync_Chat_ForwardsToolDefinitionsToTheCounter()
+    {
+        // Tool schemas are injected into the prompt by the provider, so leaving them out of the
+        // estimate under-counts agentic traffic against the token window (#1229).
+        var tools = new List<Tool> { new() { Function = new FunctionDefinition { Name = "get_weather" } } };
+        _counter.Setup(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>(), tools))
+            .ReturnsAsync(new TokenCount(500, TokenCountFidelity.Exact));
+
+        var request = Chat(maxTokens: 100);
+        request.Tools = tools;
+
+        var estimate = await Estimator().EstimateAsync(request);
+
+        estimate!.Value.PromptTokens.Should().Be(500);
+        _counter.Verify(x => x.EstimateTokenCountAsync("gpt-5", It.IsAny<List<Message>>(), tools), Times.Once);
+    }
+
+    [Fact]
     public async Task EstimateAsync_RequestWithoutTokenSemantics_ReturnsNull()
     {
         // Image and audio requests are not measured in tokens, so they carry no token window.


### PR DESCRIPTION
## Summary

Implements #1229: the two agentic inputs providers charge for but Conduit never counted now reach the token counter.

- **`Message.ToolCalls`** — an assistant turn's function name + JSON arguments, replayed as prompt context on every subsequent turn of an agentic conversation. Counted inside the existing message loop, so every consumer benefits without a call-site change.
- **`ChatCompletionRequest.Tools`** — tool/function schemas the provider injects into the prompt, routinely thousands of tokens. `ITokenCounter`'s messages overload gains an optional `tools` parameter, and all three money/limit consumers pass the request's tools through.

**Stacked on #1236** (fidelity), which is stacked on #1235 (tokenizer swap). Base branch is `feat/1233-token-count-fidelity`; GitHub retargets as the stack merges. Only the last commit is this PR. Merge order: #1235 → #1236 → this.

## Scope of the fix

| Path | Before | After |
|---|---|---|
| `ChatSpendEstimator` reservation | Tool schemas + historical tool calls invisible | Both counted (then fidelity-buffered per #1236) |
| `UsageEstimationService` streaming-fallback billing | Prompt side blind to tools | `IUsageEstimationService` gains `tools`; chat + Responses streaming endpoints pass `request.Tools` |
| `RequestTokenEstimator` TPM windows | Agentic callers got free throughput | Tools counted in the window estimate |
| chars/4 fallback | Ignored tool text entirely | Includes tool-call and definition characters, so heuristic and vocabulary estimates stay comparable |

Complements #1019 (closed), which fixed the *output* side — tool-call deltas in streams; this is the input side it left open.

## Accounting heuristics (documented in-code)

Per tool call: name + arguments + 3 framing tokens. Per tool definition: name + description + compact-serialized parameter schema + 6/function + 10 scaffolding when any tools are present. Providers don't publish their exact serialization; counting the raw JSON schema over-counts slightly versus OpenAI's TypeScript-style compaction, which errs in the safe direction for reservations and fallback billing. A tool-counting failure degrades fidelity to `CharacterHeuristic` like every other partial fallback.

## Verification

Full solution builds clean. **123/123 billing-invariant**, **3,490 main-suite**, **4/4 fault-injection** tests pass. New golden pins: two agentic message shapes (`msgs-tool-call-round-trip` = 41, `msgs-parallel-tool-calls` = 28) and four tool-definition shapes, emitted via the established emitter workflow; pass-through asserted for all three consumers. All pre-existing pins unchanged.

Closes #1229.