### PR TITLE
fix(gateway): remove orphaned component schemas from the published contract

### DIFF
--- a/Services/ConduitLLM.Gateway/Endpoints/GatewayApiEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/GatewayApiEndpoints.cs
@@ -134,7 +134,7 @@ public static class GatewayApiEndpoints
         media.MapGet("/info/{**storageKey}", ([FromServices] MediaEndpoints endpoints, string storageKey) => endpoints.GetMediaInfo(storageKey))
             .RequireAuthorization("VirtualKeyAuthentication").WithName("Media_GetInfo").Produces<MediaInfo>();
         media.MapGet("/{**storageKey}", ([FromServices] MediaEndpoints endpoints, string storageKey) => endpoints.GetMedia(storageKey))
-            .AllowAnonymous().WithName("Media_Get").Produces<Stream>(200, "application/octet-stream");
+            .AllowAnonymous().WithName("Media_Get").Produces<byte[]>(200, "application/octet-stream");
         media.MapMethods("/{**storageKey}", [HttpMethods.Head], ([FromServices] MediaEndpoints endpoints, string storageKey) => endpoints.CheckMediaExists(storageKey))
             .AllowAnonymous().WithName("Media_Head").Produces(200);
 
@@ -147,7 +147,7 @@ public static class GatewayApiEndpoints
         downloads.MapPost("/generate-url", ([FromServices] DownloadsEndpoints endpoints, GenerateUrlRequest request) => endpoints.GenerateDownloadUrl(request))
             .WithName("Downloads_GenerateUrl").Produces<DownloadUrlResponse>();
         downloads.MapGet("/{**fileId}", ([FromServices] DownloadsEndpoints endpoints, string fileId, bool inline = false) => endpoints.DownloadFile(fileId, inline))
-            .WithName("Downloads_Get").Produces<Stream>(200, "application/octet-stream");
+            .WithName("Downloads_Get").Produces<byte[]>(200, "application/octet-stream");
         downloads.MapMethods("/{**fileId}", [HttpMethods.Head], ([FromServices] DownloadsEndpoints endpoints, string fileId) => endpoints.CheckFileExists(fileId))
             .WithName("Downloads_Head").Produces(200);
 

--- a/Services/ConduitLLM.Gateway/OpenApi/OperationIdValidationDocumentTransformer.cs
+++ b/Services/ConduitLLM.Gateway/OpenApi/OperationIdValidationDocumentTransformer.cs
@@ -8,10 +8,6 @@ public sealed class OperationIdValidationDocumentTransformer : IOpenApiDocumentT
 {
     public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
-        // Stream responses are normalized to inline binary schemas by
-        // ResponseContractOperationTransformer. The framework also emits an unused
-        // Stream component for the endpoint metadata, so remove that duplicate.
-        document.Components?.Schemas?.Remove("Stream");
         Validate(document);
         return Task.CompletedTask;
     }

--- a/Services/ConduitLLM.Gateway/OpenApi/UnusedSchemaPruningDocumentTransformer.cs
+++ b/Services/ConduitLLM.Gateway/OpenApi/UnusedSchemaPruningDocumentTransformer.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace ConduitLLM.Gateway.OpenApi;
+
+/// <summary>Drops component schemas that no published operation can reach.</summary>
+public sealed class UnusedSchemaPruningDocumentTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        Prune(document);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Removes every component schema unreachable from the document's operations. The framework
+    /// hoists a component for each type it walks, including types that later transformers inline
+    /// or drop, and orphans make generated clients carry contract no route can return.
+    /// </summary>
+    public static void Prune(OpenApiDocument document)
+    {
+        var schemas = document.Components?.Schemas;
+        if (schemas is null)
+            return;
+
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        var pending = new Queue<string>(RootReferences(document));
+        var references = new List<string>();
+        while (pending.Count > 0)
+        {
+            var name = pending.Dequeue();
+            if (!reachable.Add(name) || !schemas.TryGetValue(name, out var schema))
+                continue;
+
+            references.Clear();
+            CollectSchema(schema, references);
+            foreach (var reference in references)
+                pending.Enqueue(reference);
+        }
+
+        foreach (var name in schemas.Keys.Where(name => !reachable.Contains(name)).ToList())
+            schemas.Remove(name);
+    }
+
+    private static List<string> RootReferences(OpenApiDocument document)
+    {
+        var references = new List<string>();
+        foreach (var pathItem in Values(document.Paths).Concat(Values(document.Webhooks)))
+            CollectPathItem(pathItem, references);
+
+        // Reusable components other than schemas are roots too: an operation reaches their
+        // schemas through a reference this walk deliberately does not follow.
+        var components = document.Components;
+        foreach (var pathItem in Values(components?.PathItems))
+            CollectPathItem(pathItem, references);
+        foreach (var parameter in Values(components?.Parameters))
+            CollectParameter(parameter, references);
+        foreach (var requestBody in Values(components?.RequestBodies))
+            CollectContent(requestBody.Content, references);
+        foreach (var response in Values(components?.Responses))
+            CollectResponse(response, references);
+        foreach (var header in Values(components?.Headers))
+            CollectHeader(header, references);
+
+        return references;
+    }
+
+    private static void CollectPathItem(IOpenApiPathItem pathItem, ICollection<string> sink)
+    {
+        foreach (var parameter in pathItem.Parameters ?? [])
+            CollectParameter(parameter, sink);
+
+        foreach (var operation in Values(pathItem.Operations))
+        {
+            foreach (var parameter in operation.Parameters ?? [])
+                CollectParameter(parameter, sink);
+
+            CollectContent(operation.RequestBody?.Content, sink);
+
+            foreach (var response in Values(operation.Responses))
+                CollectResponse(response, sink);
+
+            foreach (var callback in Values(operation.Callbacks))
+                foreach (var callbackPathItem in Values(callback.PathItems))
+                    CollectPathItem(callbackPathItem, sink);
+        }
+    }
+
+    private static void CollectParameter(IOpenApiParameter parameter, ICollection<string> sink)
+    {
+        CollectSchema(parameter.Schema, sink);
+        CollectContent(parameter.Content, sink);
+    }
+
+    private static void CollectResponse(IOpenApiResponse response, ICollection<string> sink)
+    {
+        CollectContent(response.Content, sink);
+        foreach (var header in Values(response.Headers))
+            CollectHeader(header, sink);
+    }
+
+    private static void CollectHeader(IOpenApiHeader header, ICollection<string> sink)
+    {
+        CollectSchema(header.Schema, sink);
+        CollectContent(header.Content, sink);
+    }
+
+    private static void CollectContent(IDictionary<string, OpenApiMediaType>? content, ICollection<string> sink)
+    {
+        foreach (var mediaType in Values(content))
+        {
+            CollectSchema(mediaType.Schema, sink);
+            foreach (var encoding in Values(mediaType.Encoding))
+                foreach (var header in Values(encoding.Headers))
+                    CollectHeader(header, sink);
+        }
+    }
+
+    private static void CollectSchema(IOpenApiSchema? schema, ICollection<string> sink)
+    {
+        if (schema is null)
+            return;
+
+        // A reference names its component and stops the walk: the component's own definition is
+        // visited once, from the queue, so recursive schemas cannot loop here.
+        if (schema is OpenApiSchemaReference reference)
+        {
+            if (reference.Reference?.Id is { Length: > 0 } referenceId)
+                sink.Add(referenceId);
+            return;
+        }
+
+        CollectSchema(schema.Items, sink);
+        CollectSchema(schema.Not, sink);
+        CollectSchema(schema.AdditionalProperties, sink);
+        foreach (var composed in (schema.AllOf ?? []).Concat(schema.AnyOf ?? []).Concat(schema.OneOf ?? []))
+            CollectSchema(composed, sink);
+        foreach (var property in Values(schema.Properties).Concat(Values(schema.PatternProperties)))
+            CollectSchema(property, sink);
+        foreach (var mapped in Values(schema.Discriminator?.Mapping))
+            CollectSchema(mapped, sink);
+    }
+
+    private static IEnumerable<TValue> Values<TKey, TValue>(IDictionary<TKey, TValue>? source) =>
+        source?.Values ?? Enumerable.Empty<TValue>();
+}

--- a/Services/ConduitLLM.Gateway/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Gateway/Program.Monitoring.cs
@@ -122,6 +122,7 @@ public partial class Program
             options.AddOperationTransformer<ConduitLLM.Gateway.OpenApi.VirtualKeySecurityOperationTransformer>();
             options.AddOperationTransformer<ConduitLLM.Gateway.OpenApi.ResponseContractOperationTransformer>();
             options.AddSchemaTransformer<ConduitLLM.Gateway.OpenApi.StructuredJsonSchemaTransformer>();
+            options.AddDocumentTransformer<ConduitLLM.Gateway.OpenApi.UnusedSchemaPruningDocumentTransformer>();
             options.AddDocumentTransformer<ConduitLLM.Gateway.OpenApi.OperationIdValidationDocumentTransformer>();
         });
     }

--- a/Services/ConduitLLM.Gateway/openapi-gateway.json
+++ b/Services/ConduitLLM.Gateway/openapi-gateway.json
@@ -5823,33 +5823,6 @@
         },
         "description": "Operator-configured pricing for a discovered model, in USD per million tokens.\r\nOnly the standard token rates and the pricing-model discriminator are projected;\r\nclients should treat any `pricing_model` other than `standard` as too\r\ncomplex to preview rather than rendering a number from these fields."
       },
-      "OpenAIError": {
-        "required": [
-          "message",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "param": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "code": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        }
-      },
       "OpenAIErrorResponse": {
         "required": [
           "error"

--- a/Tests/ConduitLLM.Tests/OpenApi/AuthoritativeContractTests.cs
+++ b/Tests/ConduitLLM.Tests/OpenApi/AuthoritativeContractTests.cs
@@ -320,6 +320,31 @@ public sealed class AuthoritativeContractTests : IDisposable
         paths.Should().Contain("/v1/conduit/discovery/models");
         paths.Should().Contain("/v1/conduit/functions/execute");
         paths.Should().Contain("/v1/conduit/videos/generations/async");
+        paths.Should().NotContain("/v1/completions",
+            "the legacy stub only ever answers 501, so no generated client should type a call to it");
+    }
+
+    [Fact]
+    public void Gateway_PublishesNoSchemaComponentThatOperationsCannotReach()
+    {
+        var schemas = _gateway.RootElement.GetProperty("components").GetProperty("schemas");
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        var pending = new Queue<string>(
+            SchemaReferences(_gateway.RootElement.GetProperty("paths")));
+
+        while (pending.Count > 0)
+        {
+            var name = pending.Dequeue();
+            if (!reachable.Add(name) || !schemas.TryGetProperty(name, out var schema))
+                continue;
+
+            foreach (var reference in SchemaReferences(schema))
+                pending.Enqueue(reference);
+        }
+
+        schemas.EnumerateObject().Select(schema => schema.Name)
+            .Should().OnlyContain(name => reachable.Contains(name),
+                "orphaned components make generated clients carry contract no route can return");
     }
 
     [Fact]
@@ -829,6 +854,18 @@ public sealed class AuthoritativeContractTests : IDisposable
                 }
             }
         }
+    }
+
+    private static IEnumerable<string> SchemaReferences(JsonElement element)
+    {
+        const string prefix = "#/components/schemas/";
+
+        // Covers both $ref values and the schema names a discriminator maps to.
+        return Descendants(element)
+            .Where(item => item.ValueKind == JsonValueKind.String)
+            .Select(item => item.GetString()!)
+            .Where(value => value.StartsWith(prefix, StringComparison.Ordinal))
+            .Select(value => value[prefix.Length..]);
     }
 
     private static JsonElement ResolveSchema(JsonDocument document, JsonElement schema)

--- a/Tests/ConduitLLM.Tests/OpenApi/UnusedSchemaPruningDocumentTransformerTests.cs
+++ b/Tests/ConduitLLM.Tests/OpenApi/UnusedSchemaPruningDocumentTransformerTests.cs
@@ -1,0 +1,80 @@
+using System.Net.Http;
+
+using ConduitLLM.Gateway.OpenApi;
+
+using FluentAssertions;
+
+using Microsoft.OpenApi;
+
+namespace ConduitLLM.Tests.OpenApi;
+
+[Trait("Category", "Unit")]
+[Trait("Component", "OpenApi")]
+public sealed class UnusedSchemaPruningDocumentTransformerTests
+{
+    [Fact]
+    public void Prune_RemovesSchemasNoOperationCanReach()
+    {
+        var document = DocumentWithSchemas();
+        document.Components!.Schemas!["Response"] = ObjectWith("thing", Reference(document, "Thing"));
+        document.Components.Schemas["Thing"] = ObjectWith("child", Reference(document, "Child"));
+        document.Components.Schemas["Child"] = new OpenApiSchema { Type = JsonSchemaType.String };
+        document.Components.Schemas["Orphan"] = ObjectWith("child", Reference(document, "OrphanChild"));
+        document.Components.Schemas["OrphanChild"] = new OpenApiSchema { Type = JsonSchemaType.String };
+        document.Paths = new OpenApiPaths { ["/things"] = PathReturning(Reference(document, "Response")) };
+
+        UnusedSchemaPruningDocumentTransformer.Prune(document);
+
+        document.Components.Schemas.Keys.Should().BeEquivalentTo("Response", "Thing", "Child");
+    }
+
+    [Fact]
+    public void Prune_KeepsSelfReferencingSchemasAndReusableComponentBodies()
+    {
+        var document = DocumentWithSchemas();
+        document.Components!.Schemas!["Node"] = ObjectWith("parent", Reference(document, "Node"));
+        document.Components.Schemas["SharedError"] = new OpenApiSchema { Type = JsonSchemaType.Object };
+        document.Components.Responses = new Dictionary<string, IOpenApiResponse>
+        {
+            ["Error"] = ResponseReturning(Reference(document, "SharedError"))
+        };
+        document.Paths = new OpenApiPaths { ["/nodes"] = PathReturning(Reference(document, "Node")) };
+
+        UnusedSchemaPruningDocumentTransformer.Prune(document);
+
+        document.Components.Schemas.Keys.Should().BeEquivalentTo("Node", "SharedError");
+    }
+
+    private static OpenApiDocument DocumentWithSchemas() => new()
+    {
+        Components = new OpenApiComponents { Schemas = new Dictionary<string, IOpenApiSchema>() }
+    };
+
+    private static OpenApiSchemaReference Reference(OpenApiDocument document, string schemaName) =>
+        new(schemaName, document);
+
+    private static OpenApiSchema ObjectWith(string propertyName, IOpenApiSchema property) => new()
+    {
+        Type = JsonSchemaType.Object,
+        Properties = new Dictionary<string, IOpenApiSchema> { [propertyName] = property }
+    };
+
+    private static OpenApiPathItem PathReturning(IOpenApiSchema schema) => new()
+    {
+        Operations = new Dictionary<HttpMethod, OpenApiOperation>
+        {
+            [HttpMethod.Get] = new()
+            {
+                Responses = new OpenApiResponses { ["200"] = ResponseReturning(schema) }
+            }
+        }
+    };
+
+    private static OpenApiResponse ResponseReturning(IOpenApiSchema schema) => new()
+    {
+        Content = new Dictionary<string, OpenApiMediaType>
+        {
+            ["application/json"] = new() { Schema = schema }
+        }
+    };
+}

--- a/WebAdmin/src/generated/gateway-api.ts
+++ b/WebAdmin/src/generated/gateway-api.ts
@@ -1139,12 +1139,6 @@ export interface components {
       embedding_cost_per_million_tokens: null | number | string;
       currency: string;
     };
-    OpenAIError: {
-      message: string;
-      type: string;
-      param?: null | string;
-      code?: null | string;
-    };
     OpenAIErrorResponse: {
       error: {
         message: string;


### PR DESCRIPTION
Closes #1086.

## What the lint said vs. what was actually left

The issue reported two `redocly lint` warnings on `openapi-gateway.json`. One of them
(`operation-2xx-response` on `POST /v1/completions`) is already gone — the endpoint carries
`.ExcludeFromDescription()` today, so the always-501 stub is not published. What remained was
`no-unused-components`, and the root causes behind it were still in place.

## Changes (one commit each)

**1. `Produces<byte[]>` for binary reads.** `Media_Get` / `Downloads_Get` declared
`.Produces<Stream>(...)`, which made the framework hoist `System.IO.Stream` into
`components/schemas` even though `ResponseContractOperationTransformer` renders both bodies
inline as `{type: string, format: binary}`. Nothing `$ref`-ed the component, so
`OperationIdValidationDocumentTransformer` carried an unrelated `Remove("Stream")` workaround to
delete it after the fact. Both endpoints now use `.Produces<byte[]>(...)` — the shape
`Audio_CreateSpeech` already uses — and the workaround is gone. Regenerated contract: byte-for-byte
unchanged.

**2. Tree-shake unreachable component schemas.** The same hoisting left a second orphan the
workaround did not cover: `OpenAIError`, published even though `OpenAIErrorResponse` renders its
error object inline. `UnusedSchemaPruningDocumentTransformer` walks operations (plus the reusable
non-schema components, which operations reach by reference) and drops every component schema that
walk cannot reach — the "optional hardening" the issue suggested, which also retires the
special-case removal. Only `OpenAIError` drops out of `openapi-gateway.json` and
`WebAdmin/src/generated/gateway-api.ts`; nothing in the repo referenced that generated type.

**3. Regression tests.** Unit tests for the transformer (reachable chains survive, orphans and
their private children go, self-referencing schemas terminate, schemas reached only through a
reusable response component are kept); a contract test asserting no Gateway component schema is
unreachable from an operation — it fails against the pre-fix spec on `OpenAIError`; and
`/v1/completions` is now named explicitly in the published-routes test so the stub cannot drift
back in. Its runtime 501 stays covered by `MigratedGatewayEndpointsTests`.

## Verification

- `npm run validate:openapi` (ratchet self-test + redocly lint + invariants) — passes.
- `npm run verify:offline` — contracts and WebAdmin types byte-identical across two isolated generations.
- `npm run generate:offline` output committed, so CI's drift check is clean.
- `dotnet test --filter FullyQualifiedName~ConduitLLM.Tests.OpenApi` — 75 passed;
  `MigratedGatewayEndpointsTests` — 4 passed.
- Gateway `no-unused-components`: 1 → 0. The remaining 54 Gateway warnings are the
  `operation-summary` / `operation-4xx-response` debt tracked by the ratchet allowlist, so
  "0 Gateway warnings" is not reachable here — that is the separate CI issue the ticket mentions.

## Out of scope / follow-up

`openapi-admin.json` has two orphans of its own (`ProblemDetails`, `CacheServiceUnavailableResponse`).
Left alone deliberately: `CacheServiceUnavailableResponse` reads like a response type that was
never wired up, and pruning it would hide that rather than fix it. The Admin service can adopt the
same transformer once those two are triaged.
