### PR TITLE
fix(health): make the health dashboard endpoints and SDK report real state (#1067)

### DIFF
--- a/Services/ConduitLLM.Admin/DTOs/HealthMonitoringDtos.cs
+++ b/Services/ConduitLLM.Admin/DTOs/HealthMonitoringDtos.cs
@@ -221,7 +221,8 @@ namespace ConduitLLM.Admin.DTOs
     public class IncidentDto
     {
         /// <summary>
-        /// Unique identifier for the incident.
+        /// Identifier for the incident. Derived from the incident's subject and window rather than
+        /// randomly generated, so the same incident keeps the same id across dashboard polls.
         /// </summary>
         public string Id { get; set; } = string.Empty;
 
@@ -231,7 +232,7 @@ namespace ConduitLLM.Admin.DTOs
         public string Title { get; set; } = string.Empty;
 
         /// <summary>
-        /// Incident type identifier (e.g. service_degradation).
+        /// Incident type identifier (e.g. model_error_spike).
         /// </summary>
         public string Type { get; set; } = string.Empty;
 
@@ -256,9 +257,15 @@ namespace ConduitLLM.Admin.DTOs
         public DateTime? EndTime { get; set; }
 
         /// <summary>
-        /// Name of the affected service.
+        /// Identifier of the affected service, matching an entry in the service health response
+        /// (e.g. core-api).
         /// </summary>
         public string AffectedService { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Model the incident was attributed to, or null when the incident is not model-specific.
+        /// </summary>
+        public string? AffectedModel { get; set; }
 
         /// <summary>
         /// Human-readable impact description.

--- a/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
@@ -28,6 +28,12 @@ namespace ConduitLLM.Admin.Endpoints
         /// </summary>
         internal const int IncidentErrorThreshold = 10;
 
+        /// <summary>Smallest history window the endpoint will report on.</summary>
+        internal const int MinHistoryHours = 1;
+
+        /// <summary>Largest history window the endpoint will report on (30 days).</summary>
+        internal const int MaxHistoryHours = 720;
+
         /// <summary>
         /// Truncates a UTC timestamp to the start of its hour, preserving <see cref="DateTimeKind.Utc"/>.
         /// Incident timestamps built with <c>new DateTime(...)</c> defaulted to
@@ -216,48 +222,24 @@ namespace ConduitLLM.Admin.Endpoints
         {
             using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-            var startTime = DateTime.UtcNow.AddHours(-hours);
-            var intervalMinutes = hours <= 24 ? 15 : 60; // 15 min intervals for 24h, 1h for longer
+            // Bound the window so a caller cannot ask for an unbounded number of buckets.
+            var requestedHours = Math.Clamp(hours, MinHistoryHours, MaxHistoryHours);
+            var now = DateTime.UtcNow;
+            var startTime = now.AddHours(-requestedHours);
+            var intervalMinutes = requestedHours <= 24 ? 15 : 60; // 15 min intervals for 24h, 1h for longer
 
-            var healthHistory = new List<HealthHistoryPointDto>();
-            var currentTime = startTime;
+            // One grouped query for the whole window. This previously issued a separate round trip
+            // per interval — 96 sequential queries for the default 24 hours, on an endpoint the
+            // dashboard polls.
+            var buckets = await QueryHealthIntervals(dbContext.RequestLogs, startTime, now, intervalMinutes)
+                .ToListAsync(cancellationToken);
 
-            while (currentTime < DateTime.UtcNow)
-            {
-                var intervalEnd = currentTime.AddMinutes(intervalMinutes);
-
-                // Get error rates for this interval
-                var errorStats = await dbContext.RequestLogs
-                    .Where(r => r.Timestamp >= currentTime && r.Timestamp < intervalEnd)
-                    .GroupBy(r => 1)
-                    .Select(g => new
-                    {
-                        TotalRequests = g.Count(),
-                        ErrorCount = g.Count(r => r.StatusCode >= 400),
-                        AvgLatency = g.Average(r => (double?)r.ResponseTimeMs) ?? 0
-                    })
-                    .FirstOrDefaultAsync(cancellationToken);
-
-                healthHistory.Add(new HealthHistoryPointDto
-                {
-                    Timestamp = currentTime,
-                    SystemHealth = errorStats?.TotalRequests > 0
-                        ? 100 - (errorStats.ErrorCount * 100.0 / errorStats.TotalRequests)
-                        : 100,
-                    ResponseTime = errorStats?.AvgLatency ?? 0,
-                    RequestVolume = errorStats?.TotalRequests ?? 0,
-                    ErrorRate = errorStats?.TotalRequests > 0
-                        ? errorStats.ErrorCount * 100.0 / errorStats.TotalRequests
-                        : 0
-                });
-
-                currentTime = intervalEnd;
-            }
+            var healthHistory = BuildHealthHistory(buckets, startTime, now, intervalMinutes);
 
             return Results.Ok(new HealthHistoryResponse
             {
-                Timestamp = DateTime.UtcNow,
-                TimeRange = new TimeRangeDto { Start = startTime, End = DateTime.UtcNow },
+                Timestamp = now,
+                TimeRange = new TimeRangeDto { Start = startTime, End = now },
                 IntervalMinutes = intervalMinutes,
                 History = healthHistory
             });
@@ -350,6 +332,79 @@ namespace ConduitLLM.Admin.Endpoints
                     }
                 };
             }).ToList();
+
+        /// <summary>
+        /// Request totals for one interval of the health history. Mutable for the same reason as
+        /// <see cref="ErrorSpikeRow"/> — EF projects grouping aggregates via object initializers.
+        /// </summary>
+        internal sealed class HealthIntervalRow
+        {
+            /// <summary>Zero-based interval index measured from the window start.</summary>
+            public int Bucket { get; set; }
+
+            /// <summary>Requests recorded in the interval.</summary>
+            public int TotalRequests { get; set; }
+
+            /// <summary>Requests in the interval that returned a 4xx or 5xx status.</summary>
+            public int ErrorCount { get; set; }
+
+            /// <summary>Mean response time in milliseconds, or null when the interval is empty.</summary>
+            public double? AvgLatency { get; set; }
+        }
+
+        /// <summary>
+        /// Aggregates request logs into fixed-width intervals in a single grouped query. Intervals
+        /// are an epoch offset from <paramref name="startTime"/> for the same timezone-safety reason
+        /// as <see cref="QueryErrorSpikes"/>. Intervals with no traffic produce no row.
+        /// </summary>
+        internal static IQueryable<HealthIntervalRow> QueryHealthIntervals(
+            IQueryable<RequestLog> requestLogs,
+            DateTime startTime,
+            DateTime endTime,
+            int intervalMinutes) =>
+            requestLogs
+                .Where(r => r.Timestamp >= startTime && r.Timestamp < endTime)
+                .GroupBy(r => (int)Math.Floor((r.Timestamp - startTime).TotalMinutes / intervalMinutes))
+                .Select(g => new HealthIntervalRow
+                {
+                    Bucket = g.Key,
+                    TotalRequests = g.Count(),
+                    ErrorCount = g.Count(r => r.StatusCode >= 400),
+                    AvgLatency = g.Average(r => (double?)r.ResponseTimeMs)
+                });
+
+        /// <summary>
+        /// Expands sparse interval aggregates into a contiguous time series, filling intervals with
+        /// no traffic the same way the previous per-interval queries did (100% health, zero volume).
+        /// </summary>
+        internal static List<HealthHistoryPointDto> BuildHealthHistory(
+            IEnumerable<HealthIntervalRow> buckets,
+            DateTime startTime,
+            DateTime endTime,
+            int intervalMinutes)
+        {
+            var byBucket = buckets.ToDictionary(bucket => bucket.Bucket);
+            var history = new List<HealthHistoryPointDto>();
+
+            for (var index = 0; startTime.AddMinutes((double)index * intervalMinutes) < endTime; index++)
+            {
+                var hasTraffic = byBucket.TryGetValue(index, out var row) && row.TotalRequests > 0;
+                var errorRate = hasTraffic
+                    ? row!.ErrorCount * 100.0 / row.TotalRequests
+                    : 0;
+
+                history.Add(new HealthHistoryPointDto
+                {
+                    Timestamp = startTime.AddMinutes((double)index * intervalMinutes),
+                    SystemHealth = 100 - errorRate,
+                    ResponseTime = hasTraffic ? row!.AvgLatency ?? 0 : 0,
+                    RequestVolume = hasTraffic ? row!.TotalRequests : 0,
+                    ErrorRate = errorRate
+                });
+            }
+
+            return history;
+        }
 
         internal static ServiceStatusDto BuildClusterServiceStatus(
             string id,

--- a/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/HealthMonitoringEndpoints.cs
@@ -4,6 +4,7 @@ using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Configuration.Utilities;
 using ConduitLLM.Core.Constants;
@@ -22,6 +23,20 @@ namespace ConduitLLM.Admin.Endpoints
     /// </summary>
     public static class HealthMonitoringEndpoints
     {
+        /// <summary>
+        /// Number of failed requests in a one-hour window before it is reported as an incident.
+        /// </summary>
+        internal const int IncidentErrorThreshold = 10;
+
+        /// <summary>
+        /// Truncates a UTC timestamp to the start of its hour, preserving <see cref="DateTimeKind.Utc"/>.
+        /// Incident timestamps built with <c>new DateTime(...)</c> defaulted to
+        /// <see cref="DateTimeKind.Unspecified"/> and serialized without a <c>Z</c> suffix, so clients
+        /// read them as local time while every sibling timestamp in the response was UTC.
+        /// </summary>
+        internal static DateTime FloorToHourUtc(DateTime value) =>
+            new(value.Year, value.Month, value.Day, value.Hour, 0, 0, DateTimeKind.Utc);
+
         public static IEndpointRouteBuilder MapHealthMonitoringEndpoints(this IEndpointRouteBuilder app)
         {
             var group = app.MapGroup("/v1/admin/health-status")
@@ -150,56 +165,27 @@ namespace ConduitLLM.Admin.Endpoints
         {
             using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
 
-            var startDate = DateTime.UtcNow.AddDays(-days);
+            var now = DateTime.UtcNow;
+            var startDate = now.AddDays(-days);
 
-            // Analyze request logs for incidents
-            var errorSpikes = await dbContext.RequestLogs
-                .Where(r => r.Timestamp >= startDate && r.StatusCode >= 400)
-                .GroupBy(r => new
-                {
-                    Date = r.Timestamp.Date,
-                    Hour = r.Timestamp.Hour,
-                    Model = r.ModelName
-                })
-                .Select(g => new
-                {
-                    Date = g.Key.Date,
-                    Hour = g.Key.Hour,
-                    Service = g.Key.Model, // Using ModelName as service identifier
-                    ErrorCount = g.Count(),
-                    ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
-                })
-                .Where(g => g.ErrorCount >= 10) // Threshold for incident
+            // Bucket on exact UTC hour boundaries. Grouping by `Timestamp.Date`/`.Hour` translated to
+            // date_trunc over a timestamptz column, which resolves in the PostgreSQL server's
+            // `timezone` GUC rather than UTC; offsetting from a UTC anchor keeps the windows correct
+            // regardless of how the server is configured.
+            var windowStart = FloorToHourUtc(startDate);
+            var currentHour = FloorToHourUtc(now);
+
+            var errorSpikes = await QueryErrorSpikes(dbContext.RequestLogs, windowStart)
                 .ToListAsync(cancellationToken);
 
-            // Convert to incidents
-            var incidents = errorSpikes.Select(spike => new IncidentDto
-            {
-                Id = Guid.NewGuid().ToString(),
-                Title = $"{spike.Service} Service Degradation",
-                Type = "service_degradation",
-                Severity = spike.ErrorCount >= 50 ? "critical" : (spike.ErrorCount >= 25 ? "major" : "minor"),
-                Status = spike.Date.Date == DateTime.UtcNow.Date ? "active" : "resolved",
-                StartTime = new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 0, 0),
-                EndTime = spike.Date.Date == DateTime.UtcNow.Date ? (DateTime?)null :
-                         new DateTime(spike.Date.Year, spike.Date.Month, spike.Date.Day, spike.Hour, 59, 59),
-                AffectedService = spike.Service,
-                Impact = $"{spike.ErrorCount} errors in 1 hour period",
-                Details = new IncidentDetailsDto
-                {
-                    ErrorCount = spike.ErrorCount,
-                    UniqueErrorTypes = spike.ErrorTypes
-                }
-            }).ToList();
-
-            var allIncidents = incidents
+            var allIncidents = BuildIncidents(errorSpikes, windowStart, currentHour)
                 .OrderByDescending(i => i.StartTime)
                 .ToList();
 
             return Results.Ok(new IncidentsResponse
             {
-                Timestamp = DateTime.UtcNow,
-                TimeRange = new TimeRangeDto { Start = startDate, End = DateTime.UtcNow },
+                Timestamp = now,
+                TimeRange = new TimeRangeDto { Start = windowStart, End = now },
                 TotalIncidents = allIncidents.Count,
                 ActiveIncidents = allIncidents.Count(i => i.Status == "active"),
                 IncidentsByType = allIncidents.GroupBy(i => i.Type).Select(g => new IncidentTypeCountDto
@@ -276,6 +262,94 @@ namespace ConduitLLM.Admin.Endpoints
                 History = healthHistory
             });
         }
+
+        /// <summary>
+        /// One hour of failed requests for a single model. Written as a mutable class projected via
+        /// an object initializer because EF cannot translate a grouping aggregate into a positional
+        /// record constructor.
+        /// </summary>
+        internal sealed class ErrorSpikeRow
+        {
+            /// <summary>Whole hours between the window start and this bucket's start.</summary>
+            public int HourOffset { get; set; }
+
+            /// <summary>Model the failed requests were routed to.</summary>
+            public string Model { get; set; } = string.Empty;
+
+            /// <summary>Number of failed requests in the bucket.</summary>
+            public int ErrorCount { get; set; }
+
+            /// <summary>Number of distinct HTTP status codes in the bucket.</summary>
+            public int ErrorTypes { get; set; }
+        }
+
+        /// <summary>
+        /// Groups failed requests into hourly buckets per model, keeping the whole aggregation in
+        /// PostgreSQL. Buckets are measured as an epoch offset from <paramref name="windowStart"/>
+        /// rather than via <c>Timestamp.Date</c>/<c>.Hour</c>, which would translate to
+        /// <c>date_trunc</c> over a <c>timestamptz</c> column and resolve in the server's
+        /// <c>timezone</c> setting instead of UTC.
+        /// </summary>
+        internal static IQueryable<ErrorSpikeRow> QueryErrorSpikes(
+            IQueryable<RequestLog> requestLogs,
+            DateTime windowStart) =>
+            requestLogs
+                .Where(r => r.Timestamp >= windowStart && r.StatusCode >= 400)
+                .GroupBy(r => new
+                {
+                    HourOffset = (int)Math.Floor((r.Timestamp - windowStart).TotalHours),
+                    Model = r.ModelName
+                })
+                .Select(g => new ErrorSpikeRow
+                {
+                    HourOffset = g.Key.HourOffset,
+                    Model = g.Key.Model,
+                    ErrorCount = g.Count(),
+                    ErrorTypes = g.Select(r => r.StatusCode).Distinct().Count()
+                })
+                .Where(row => row.ErrorCount >= IncidentErrorThreshold);
+
+        /// <summary>
+        /// Maps hourly error buckets to incidents with stable ids and UTC timestamps.
+        /// </summary>
+        /// <param name="spikes">Hourly error buckets from <see cref="QueryErrorSpikes"/>.</param>
+        /// <param name="windowStart">UTC hour the query window began at.</param>
+        /// <param name="currentHourUtc">Start of the current UTC hour.</param>
+        internal static List<IncidentDto> BuildIncidents(
+            IEnumerable<ErrorSpikeRow> spikes,
+            DateTime windowStart,
+            DateTime currentHourUtc) =>
+            spikes.Select(spike =>
+            {
+                var spikeStart = windowStart.AddHours(spike.HourOffset);
+                // Only the hour still accruing traffic can be ongoing. The previous check compared
+                // calendar dates, so a spike that ended at 00:30 stayed "active" for the rest of the
+                // day while one at 23:30 yesterday was reported "resolved" thirty minutes later.
+                var isActive = spikeStart == currentHourUtc;
+                return new IncidentDto
+                {
+                    // Deterministic so the dashboard can correlate the same incident across polls;
+                    // this was previously a fresh Guid on every request.
+                    Id = $"model-error-spike:{spike.Model}:{spikeStart:yyyyMMddTHHmmssZ}",
+                    Title = $"Elevated error rate for model {spike.Model}",
+                    Type = "model_error_spike",
+                    Severity = spike.ErrorCount >= 50 ? "critical" : (spike.ErrorCount >= 25 ? "major" : "minor"),
+                    Status = isActive ? "active" : "resolved",
+                    StartTime = spikeStart,
+                    EndTime = isActive ? null : spikeStart.AddHours(1),
+                    // Request logs only record traffic served by the Gateway, so that is the affected
+                    // service. The model is reported separately instead of being passed off as one —
+                    // a model error spike is not an outage of a service named after the model.
+                    AffectedService = "core-api",
+                    AffectedModel = spike.Model,
+                    Impact = $"{spike.ErrorCount} failed requests in a 1 hour period",
+                    Details = new IncidentDetailsDto
+                    {
+                        ErrorCount = spike.ErrorCount,
+                        UniqueErrorTypes = spike.ErrorTypes
+                    }
+                };
+            }).ToList();
 
         internal static ServiceStatusDto BuildClusterServiceStatus(
             string id,

--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -28092,7 +28092,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique identifier for the incident."
+            "description": "Identifier for the incident. Derived from the incident's subject and window rather than\r\nrandomly generated, so the same incident keeps the same id across dashboard polls."
           },
           "title": {
             "type": "string",
@@ -28100,7 +28100,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Incident type identifier (e.g. service_degradation)."
+            "description": "Incident type identifier (e.g. model_error_spike)."
           },
           "severity": {
             "type": "string",
@@ -28125,7 +28125,14 @@
           },
           "affectedService": {
             "type": "string",
-            "description": "Name of the affected service."
+            "description": "Identifier of the affected service, matching an entry in the service health response\r\n(e.g. core-api)."
+          },
+          "affectedModel": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "Model the incident was attributed to, or null when the incident is not model-specific."
           },
           "impact": {
             "type": "string",

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringHistoryTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringHistoryTests.cs
@@ -1,0 +1,145 @@
+using ConduitLLM.Admin.Endpoints;
+using ConduitLLM.Configuration;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace ConduitLLM.Tests.Admin.Endpoints;
+
+/// <summary>
+/// Covers the time series behind <c>/v1/admin/health-status/history</c>, which previously issued one
+/// database round trip per interval — 96 sequential queries for the default 24 hour window (#1067).
+/// </summary>
+public class HealthMonitoringHistoryTests
+{
+    private static readonly DateTime StartTime =
+        new(2026, 7, 25, 0, 0, 0, DateTimeKind.Utc);
+
+    private const int IntervalMinutes = 15;
+
+    private static HealthMonitoringEndpoints.HealthIntervalRow Row(
+        int bucket,
+        int totalRequests,
+        int errorCount,
+        double? avgLatency = 120.0) =>
+        new()
+        {
+            Bucket = bucket,
+            TotalRequests = totalRequests,
+            ErrorCount = errorCount,
+            AvgLatency = avgLatency
+        };
+
+    [Fact]
+    public void BuildHealthHistory_ProducesOnePointPerInterval()
+    {
+        var history = HealthMonitoringEndpoints.BuildHealthHistory(
+            [], StartTime, StartTime.AddHours(24), IntervalMinutes);
+
+        history.Should().HaveCount(96);
+        history[0].Timestamp.Should().Be(StartTime);
+        history[95].Timestamp.Should().Be(StartTime.AddMinutes(95 * IntervalMinutes));
+    }
+
+    [Fact]
+    public void BuildHealthHistory_TimestampsAreUtcAndEvenlySpaced()
+    {
+        var history = HealthMonitoringEndpoints.BuildHealthHistory(
+            [], StartTime, StartTime.AddHours(2), IntervalMinutes);
+
+        history.Should().OnlyContain(point => point.Timestamp.Kind == DateTimeKind.Utc);
+        history.Zip(history.Skip(1))
+            .Should().OnlyContain(pair => pair.Second.Timestamp - pair.First.Timestamp
+                == TimeSpan.FromMinutes(IntervalMinutes));
+    }
+
+    [Fact]
+    public void BuildHealthHistory_IntervalsWithoutTraffic_ReportFullHealthAndZeroVolume()
+    {
+        var history = HealthMonitoringEndpoints.BuildHealthHistory(
+            [Row(1, totalRequests: 10, errorCount: 0)],
+            StartTime,
+            StartTime.AddHours(1),
+            IntervalMinutes);
+
+        var empty = history[0];
+        empty.RequestVolume.Should().Be(0);
+        empty.SystemHealth.Should().Be(100);
+        empty.ErrorRate.Should().Be(0);
+        empty.ResponseTime.Should().Be(0);
+    }
+
+    [Fact]
+    public void BuildHealthHistory_PlacesAggregatesInTheirOwnBucket()
+    {
+        var history = HealthMonitoringEndpoints.BuildHealthHistory(
+            [Row(2, totalRequests: 200, errorCount: 50, avgLatency: 340.5)],
+            StartTime,
+            StartTime.AddHours(1),
+            IntervalMinutes);
+
+        var populated = history[2];
+        populated.Timestamp.Should().Be(StartTime.AddMinutes(2 * IntervalMinutes));
+        populated.RequestVolume.Should().Be(200);
+        populated.ErrorRate.Should().Be(25);
+        populated.SystemHealth.Should().Be(75);
+        populated.ResponseTime.Should().Be(340.5);
+
+        history.Where((_, index) => index != 2)
+            .Should().OnlyContain(point => point.RequestVolume == 0);
+    }
+
+    [Fact]
+    public void BuildHealthHistory_NullAverageLatency_ReportsZero()
+    {
+        var history = HealthMonitoringEndpoints.BuildHealthHistory(
+            [Row(0, totalRequests: 5, errorCount: 0, avgLatency: null)],
+            StartTime,
+            StartTime.AddMinutes(IntervalMinutes),
+            IntervalMinutes);
+
+        history.Single().ResponseTime.Should().Be(0);
+    }
+
+    [Fact]
+    public void QueryHealthIntervals_AggregatesEveryIntervalInASingleQuery()
+    {
+        using var db = NpgsqlModelContext();
+
+        var sql = HealthMonitoringEndpoints
+            .QueryHealthIntervals(db.RequestLogs, StartTime, StartTime.AddHours(24), IntervalMinutes)
+            .ToQueryString();
+
+        // A single grouped statement covers the whole window: one SELECT, one GROUP BY, and the
+        // error tally as a filtered aggregate rather than a second query.
+        sql.Should().Contain("GROUP BY");
+        sql.Should().Contain("FILTER (WHERE");
+        // Interval assignment must be epoch arithmetic, not timezone-dependent truncation.
+        sql.Should().Contain("date_part('epoch'");
+        sql.Should().NotContain("date_trunc");
+    }
+
+    [Theory]
+    [InlineData(0, HealthMonitoringEndpoints.MinHistoryHours)]
+    [InlineData(-5, HealthMonitoringEndpoints.MinHistoryHours)]
+    [InlineData(24, 24)]
+    [InlineData(100_000, HealthMonitoringEndpoints.MaxHistoryHours)]
+    public void HistoryWindow_IsClampedToASaneRange(int requested, int expected)
+    {
+        Math.Clamp(
+            requested,
+            HealthMonitoringEndpoints.MinHistoryHours,
+            HealthMonitoringEndpoints.MaxHistoryHours)
+            .Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Builds a PostgreSQL-shaped context for SQL translation assertions. No connection is opened;
+    /// <c>ToQueryString</c> only needs the provider's query pipeline.
+    /// </summary>
+    private static ConduitDbContext NpgsqlModelContext() =>
+        new(new DbContextOptionsBuilder<ConduitDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-probe;Username=u;Password=p")
+            .Options);
+}

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringIncidentTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringIncidentTests.cs
@@ -1,0 +1,167 @@
+using ConduitLLM.Admin.Endpoints;
+using ConduitLLM.Configuration;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace ConduitLLM.Tests.Admin.Endpoints;
+
+/// <summary>
+/// Covers the incident projection behind <c>/v1/admin/health-status/incidents</c>, which previously
+/// reported model names as affected services, minted a fresh incident id on every poll, and emitted
+/// timestamps without a UTC marker (#1067).
+/// </summary>
+public class HealthMonitoringIncidentTests
+{
+    private static readonly DateTime WindowStart =
+        new(2026, 7, 18, 9, 0, 0, DateTimeKind.Utc);
+
+    private static readonly DateTime CurrentHour =
+        new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
+
+    private static HealthMonitoringEndpoints.ErrorSpikeRow Spike(
+        int hourOffset,
+        string model = "gpt-4o",
+        int errorCount = 12,
+        int errorTypes = 2) =>
+        new()
+        {
+            HourOffset = hourOffset,
+            Model = model,
+            ErrorCount = errorCount,
+            ErrorTypes = errorTypes
+        };
+
+    /// <summary>Hours from <see cref="WindowStart"/> to <see cref="CurrentHour"/>.</summary>
+    private static int CurrentHourOffset => (int)(CurrentHour - WindowStart).TotalHours;
+
+    [Fact]
+    public void Incident_AttributesModelToAffectedModel_NotAffectedService()
+    {
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(0, model: "claude-opus-5")], WindowStart, CurrentHour)
+            .Single();
+
+        incident.AffectedModel.Should().Be("claude-opus-5");
+        // The service card the dashboard should light up is the Gateway, not a service named
+        // after the model.
+        incident.AffectedService.Should().Be("core-api");
+        incident.Type.Should().Be("model_error_spike");
+        incident.Title.Should().NotContain("Service Degradation");
+    }
+
+    [Fact]
+    public void Incident_Id_IsStableAcrossPolls()
+    {
+        var first = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(3)], WindowStart, CurrentHour).Single();
+        var second = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(3)], WindowStart, CurrentHour.AddMinutes(5)).Single();
+
+        second.Id.Should().Be(first.Id);
+    }
+
+    [Fact]
+    public void Incident_Id_DiffersPerModelAndHour()
+    {
+        var incidents = HealthMonitoringEndpoints.BuildIncidents(
+            [Spike(1, model: "a"), Spike(2, model: "a"), Spike(1, model: "b")],
+            WindowStart,
+            CurrentHour);
+
+        incidents.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Incident_Timestamps_AreUtcKind()
+    {
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(4)], WindowStart, CurrentHour).Single();
+
+        incident.StartTime.Kind.Should().Be(DateTimeKind.Utc);
+        incident.EndTime!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public void Incident_StartTime_IsTheBucketHour()
+    {
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(5)], WindowStart, CurrentHour).Single();
+
+        incident.StartTime.Should().Be(WindowStart.AddHours(5));
+        incident.EndTime.Should().Be(WindowStart.AddHours(6));
+    }
+
+    [Fact]
+    public void Incident_InCurrentHour_IsActiveWithNoEndTime()
+    {
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(CurrentHourOffset)], WindowStart, CurrentHour).Single();
+
+        incident.Status.Should().Be("active");
+        incident.EndTime.Should().BeNull();
+    }
+
+    [Fact]
+    public void Incident_EarlierInSameDay_IsResolved()
+    {
+        // The old implementation compared calendar dates, so any spike from today stayed "active".
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(CurrentHourOffset - 1)], WindowStart, CurrentHour).Single();
+
+        incident.Status.Should().Be("resolved");
+        incident.EndTime.Should().Be(CurrentHour);
+    }
+
+    [Theory]
+    [InlineData(10, "minor")]
+    [InlineData(24, "minor")]
+    [InlineData(25, "major")]
+    [InlineData(49, "major")]
+    [InlineData(50, "critical")]
+    public void Incident_Severity_TracksErrorCount(int errorCount, string expected)
+    {
+        var incident = HealthMonitoringEndpoints
+            .BuildIncidents([Spike(0, errorCount: errorCount)], WindowStart, CurrentHour).Single();
+
+        incident.Severity.Should().Be(expected);
+    }
+
+    [Fact]
+    public void FloorToHourUtc_TruncatesAndKeepsUtcKind()
+    {
+        var floored = HealthMonitoringEndpoints.FloorToHourUtc(
+            new DateTime(2026, 7, 25, 12, 47, 31, DateTimeKind.Utc));
+
+        floored.Should().Be(new DateTime(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc));
+        floored.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public void QueryErrorSpikes_AggregatesInPostgres_WithoutTimezoneDependentTruncation()
+    {
+        using var db = NpgsqlModelContext();
+
+        var sql = HealthMonitoringEndpoints
+            .QueryErrorSpikes(db.RequestLogs, WindowStart)
+            .ToQueryString();
+
+        // Bucketing must be epoch arithmetic against the UTC anchor. date_trunc over a timestamptz
+        // column resolves in the server's `timezone` GUC, which would shift incident windows.
+        sql.Should().Contain("date_part('epoch'");
+        sql.Should().NotContain("date_trunc");
+        // Grouping and thresholding stay server-side — one round trip, no client evaluation.
+        sql.Should().Contain("GROUP BY");
+        sql.Should().Contain("HAVING");
+    }
+
+    /// <summary>
+    /// Builds a PostgreSQL-shaped context for SQL translation assertions. No connection is opened;
+    /// <c>ToQueryString</c> only needs the provider's query pipeline.
+    /// </summary>
+    private static ConduitDbContext NpgsqlModelContext() =>
+        new(new DbContextOptionsBuilder<ConduitDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-probe;Username=u;Password=p")
+            .Options);
+}

--- a/WebAdmin/src/generated/admin-api.ts
+++ b/WebAdmin/src/generated/admin-api.ts
@@ -4757,11 +4757,12 @@ export interface components {
     };
     /** @description A single incident derived from request log analysis. */
     IncidentDto: {
-      /** @description Unique identifier for the incident. */
+      /** @description Identifier for the incident. Derived from the incident's subject and window rather than
+       *     randomly generated, so the same incident keeps the same id across dashboard polls. */
       id?: string;
       /** @description Human-readable incident title. */
       title?: string;
-      /** @description Incident type identifier (e.g. service_degradation). */
+      /** @description Incident type identifier (e.g. model_error_spike). */
       type?: string;
       /** @description Incident severity (critical, major, or minor). */
       severity?: string;
@@ -4777,8 +4778,11 @@ export interface components {
        * @description When the incident ended (UTC), or null if still active.
        */
       endTime?: null | string;
-      /** @description Name of the affected service. */
+      /** @description Identifier of the affected service, matching an entry in the service health response
+       *     (e.g. core-api). */
       affectedService?: string;
+      /** @description Model the incident was attributed to, or null when the incident is not model-specific. */
+      affectedModel?: null | string;
       /** @description Human-readable impact description. */
       impact?: string;
       /** @description Additional incident detail metrics. */

--- a/WebAdmin/src/lib/admin-api/models/system.ts
+++ b/WebAdmin/src/lib/admin-api/models/system.ts
@@ -258,27 +258,35 @@ export interface FeatureAvailability {
   timestamp: string;
 }
 
+/**
+ * Health status of a single component. `unknown` means the backend could not determine the
+ * status — most often a service that has not reported a heartbeat yet. It is deliberately
+ * distinct from `healthy`: treating "not known" as "fine" is what made the health dashboard
+ * report green during an outage (issue #1067).
+ */
+export type ComponentHealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
 // Issue #427 - System Health SDK Methods
 export interface SystemHealthDto {
-  overall: 'healthy' | 'degraded' | 'unhealthy';
+  overall: ComponentHealthStatus;
   components: {
     api: {
-      status: 'healthy' | 'degraded' | 'unhealthy';
+      status: ComponentHealthStatus;
       message?: string;
       lastChecked: string;
     };
     database: {
-      status: 'healthy' | 'degraded' | 'unhealthy';
+      status: ComponentHealthStatus;
       message?: string;
       lastChecked: string;
     };
     cache: {
-      status: 'healthy' | 'degraded' | 'unhealthy';
+      status: ComponentHealthStatus;
       message?: string;
       lastChecked: string;
     };
     queue: {
-      status: 'healthy' | 'degraded' | 'unhealthy';
+      status: ComponentHealthStatus;
       message?: string;
       lastChecked: string;
     };
@@ -307,24 +315,33 @@ export interface SystemResourceMetricsDto {
 // intentionally named differently to avoid a false type-drift pairing. See issue #1038.
 export interface ServiceStatusMapDto {
   coreApi: {
-    status: 'healthy' | 'degraded' | 'unhealthy';
-    latency: number;
+    status: ComponentHealthStatus;
+    /** Probe round-trip in ms, or null when the status comes from a heartbeat rather than a probe. */
+    latency: number | null;
     endpoint: string;
   };
   adminApi: {
-    status: 'healthy' | 'degraded' | 'unhealthy';
-    latency: number;
+    status: ComponentHealthStatus;
+    /** Probe round-trip in ms, or null when the status comes from a heartbeat rather than a probe. */
+    latency: number | null;
     endpoint: string;
   };
   database: {
-    status: 'healthy' | 'degraded' | 'unhealthy';
-    latency: number;
-    connections: number;
+    status: ComponentHealthStatus;
+    latency: number | null;
+    /** Null — the Admin API no longer reports a connection count (it was a hardcoded 5). */
+    connections: number | null;
   };
   cache: {
-    status: 'healthy' | 'degraded' | 'unhealthy';
-    latency: number;
-    hitRate: number;
+    status: ComponentHealthStatus;
+    latency: number | null;
+    /** Null — the service health endpoint does not report a cache hit rate. */
+    hitRate: number | null;
+  };
+  /** Messaging (Wolverine) transport health. */
+  queue: {
+    status: ComponentHealthStatus;
+    latency: number | null;
   };
 }
 

--- a/WebAdmin/src/lib/admin-api/services/FetchSystemHealthService.test.ts
+++ b/WebAdmin/src/lib/admin-api/services/FetchSystemHealthService.test.ts
@@ -1,0 +1,225 @@
+import type { FetchBaseApiClient } from '../client/FetchBaseApiClient';
+import { FetchSystemHealthService } from './FetchSystemHealthService';
+
+/**
+ * The service health endpoint returns `{ timestamp, overallStatus, summary, services[] }`. The
+ * previous mapping cast it to `{ coreApi, adminApi, database, cache }`, so every lookup was
+ * `undefined` and `normalizeStatus` turned each one into `healthy` — the dashboard showed green
+ * no matter what the backend reported (issue #1067).
+ */
+const serviceHealthResponse = {
+  timestamp: '2026-07-25T12:00:00Z',
+  overallStatus: 'unhealthy',
+  summary: { healthy: 2, degraded: 1, unhealthy: 1, unknown: 1, total: 5 },
+  services: [
+    { id: 'core-api', name: 'Gateway API', status: 'unhealthy', responseTime: null },
+    { id: 'admin-api', name: 'Admin API', status: 'healthy', responseTime: null },
+    { id: 'database', name: 'PostgreSQL Database', status: 'healthy', responseTime: 3 },
+    { id: 'redis', name: 'Redis', status: 'degraded', responseTime: 11 },
+    { id: 'messaging', name: 'Messaging', status: 'unhealthy', responseTime: 42 },
+  ],
+};
+
+const mockGetServiceHealth = jest.fn();
+const mockGetHealth = jest.fn();
+
+jest.mock('./FetchSystemService', () => ({
+  FetchSystemService: jest.fn(() => ({
+    getServiceHealth: mockGetServiceHealth,
+    getHealth: mockGetHealth,
+  })),
+}));
+
+jest.mock('./FetchSystemMetricsService', () => ({
+  FetchSystemMetricsService: jest.fn(() => ({
+    getActiveConnections: jest.fn().mockResolvedValue(0),
+  })),
+}));
+
+/** Builds the service over a stub client exposing only the methods a test needs. */
+function createService(clientOverrides: unknown = {}) {
+  return new FetchSystemHealthService(clientOverrides as FetchBaseApiClient);
+}
+
+describe('FetchSystemHealthService.getServiceStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServiceHealth.mockResolvedValue(serviceHealthResponse);
+  });
+
+  it('reports each service the status the backend actually returned', async () => {
+    const status = await createService().getServiceStatus();
+
+    expect(status.coreApi.status).toBe('unhealthy');
+    expect(status.adminApi.status).toBe('healthy');
+    expect(status.database.status).toBe('healthy');
+    expect(status.cache.status).toBe('degraded');
+    expect(status.queue.status).toBe('unhealthy');
+  });
+
+  it('does not report a downed Gateway as healthy', async () => {
+    const status = await createService().getServiceStatus();
+
+    // The regression this guards: an outage rendered green.
+    expect(status.coreApi.status).not.toBe('healthy');
+  });
+
+  it('reports null latency when a status comes from a heartbeat rather than a probe', async () => {
+    const status = await createService().getServiceStatus();
+
+    // `0` would imply a probe that returned instantly; these services are not probed.
+    expect(status.coreApi.latency).toBeNull();
+    expect(status.adminApi.latency).toBeNull();
+    expect(status.database.latency).toBe(3);
+    expect(status.cache.latency).toBe(11);
+  });
+
+  it('reports unknown for a service missing from the response', async () => {
+    mockGetServiceHealth.mockResolvedValue({ ...serviceHealthResponse, services: [] });
+
+    const status = await createService().getServiceStatus();
+
+    expect(status.coreApi.status).toBe('unknown');
+    expect(status.adminApi.status).toBe('unknown');
+    expect(status.queue.status).toBe('unknown');
+  });
+
+  it('does not fabricate connection counts or cache hit rates', async () => {
+    const status = await createService().getServiceStatus();
+
+    expect(status.database.connections).toBeNull();
+    expect(status.cache.hitRate).toBeNull();
+  });
+
+  it('falls back to unknown for the Gateway when the endpoint is unreachable', async () => {
+    mockGetServiceHealth.mockRejectedValue(new Error('unreachable'));
+    mockGetHealth.mockResolvedValue({
+      status: 'healthy',
+      totalDuration: 7,
+      checks: { database: { status: 'degraded', duration: 4 } },
+    });
+
+    const status = await createService().getServiceStatus();
+
+    // The Admin's own readiness says nothing about the Gateway; it previously inherited it.
+    expect(status.coreApi.status).toBe('unknown');
+    expect(status.adminApi.status).toBe('healthy');
+    expect(status.database.status).toBe('degraded');
+    expect(status.cache.status).toBe('unknown');
+  });
+});
+
+describe('FetchSystemHealthService.getSystemHealth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServiceHealth.mockResolvedValue(serviceHealthResponse);
+  });
+
+  it('derives queue health from the messaging service instead of pinning it healthy', async () => {
+    const health = await createService().getSystemHealth();
+
+    expect(health.components.queue.status).toBe('unhealthy');
+    expect(health.components.queue.message).not.toMatch(/processing normally/);
+  });
+
+  it('rolls unhealthy components up to an unhealthy overall status', async () => {
+    const health = await createService().getSystemHealth();
+
+    expect(health.overall).toBe('unhealthy');
+  });
+
+  it('treats unknown components as degrading, not healthy', async () => {
+    mockGetServiceHealth.mockResolvedValue({
+      ...serviceHealthResponse,
+      services: [{ id: 'database', name: 'PostgreSQL Database', status: 'healthy', responseTime: 2 }],
+    });
+
+    const health = await createService().getSystemHealth();
+
+    expect(health.components.api.status).toBe('unknown');
+    expect(health.overall).toBe('degraded');
+  });
+});
+
+describe('FetchSystemHealthService.getHealthEvents', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('derives events from real incidents with stable ids and reported timestamps', async () => {
+    const get = jest.fn().mockResolvedValue({
+      incidents: [
+        {
+          id: 'model-error-spike:gpt-4o:20260725T110000Z',
+          title: 'Elevated error rate for model gpt-4o',
+          severity: 'critical',
+          affectedService: 'core-api',
+          affectedModel: 'gpt-4o',
+          impact: '80 failed requests in a 1 hour period',
+          startTime: '2026-07-25T11:00:00Z',
+          endTime: '2026-07-25T12:00:00Z',
+        },
+      ],
+    });
+
+    const events = await createService({ get })
+      .getHealthEvents();
+
+    expect(get).toHaveBeenCalledWith('/v1/admin/health-status/incidents', expect.anything());
+    expect(events.events).toHaveLength(2);
+    // Newest first: the recovery, then the onset — at the times the backend reported, not
+    // `Math.random()` offsets from now.
+    expect(events.events[0].timestamp).toBe('2026-07-25T12:00:00Z');
+    expect(events.events[0].type).toBe('system_recovered');
+    expect(events.events[1].timestamp).toBe('2026-07-25T11:00:00Z');
+    expect(events.events[1].type).toBe('system_issue');
+    expect(events.events[1].source).toBe('core-api');
+    expect(events.events[1].id).toContain('model-error-spike:gpt-4o:20260725T110000Z');
+  });
+
+  it('emits no recovery event while an incident is still active', async () => {
+    const get = jest.fn().mockResolvedValue({
+      incidents: [
+        {
+          id: 'active-incident',
+          title: 'Elevated error rate for model claude-opus-5',
+          severity: 'minor',
+          affectedService: 'core-api',
+          startTime: '2026-07-25T12:00:00Z',
+          endTime: null,
+        },
+      ],
+    });
+
+    const events = await createService({ get })
+      .getHealthEvents();
+
+    expect(events.events).toHaveLength(1);
+    expect(events.events[0].type).toBe('system_issue');
+  });
+
+  it('returns ids that are stable across polls', async () => {
+    const incident = {
+      id: 'model-error-spike:gpt-4o:20260725T110000Z',
+      title: 'Elevated error rate for model gpt-4o',
+      severity: 'major',
+      affectedService: 'core-api',
+      startTime: '2026-07-25T11:00:00Z',
+      endTime: '2026-07-25T12:00:00Z',
+    };
+    const get = jest.fn().mockResolvedValue({ incidents: [incident] });
+    const service = createService({ get });
+
+    const first = await service.getHealthEvents();
+    const second = await service.getHealthEvents();
+
+    expect(second.events.map(e => e.id)).toEqual(first.events.map(e => e.id));
+  });
+
+  it('returns no events when the incidents endpoint fails', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const events = await createService({ get })
+      .getHealthEvents();
+
+    expect(events.events).toEqual([]);
+  });
+});

--- a/WebAdmin/src/lib/admin-api/services/FetchSystemHealthService.ts
+++ b/WebAdmin/src/lib/admin-api/services/FetchSystemHealthService.ts
@@ -1,8 +1,10 @@
 import type { FetchBaseApiClient } from '../client/FetchBaseApiClient';
+import type { components } from '../generated/admin-api';
 import type { RequestConfig } from '../client/types';
 import type {
   SystemHealthDto,
   ServiceStatusMapDto,
+  ComponentHealthStatus,
   HealthEventDto,
   HealthEventsResponseDto,
   HealthEventSubscriptionOptions,
@@ -13,6 +15,38 @@ import { ENDPOINTS } from '../constants';
 import { FetchSystemService } from './FetchSystemService';
 import { FetchSystemMetricsService } from './FetchSystemMetricsService';
 import { FetchSystemHelpers } from './FetchSystemHelpers';
+
+type ServiceStatusEntry = NonNullable<
+  components['schemas']['ServiceHealthResponse']['services']
+>[number];
+type IncidentsResponse = components['schemas']['IncidentsResponse'];
+
+/**
+ * Service ids as reported by `/v1/admin/health-status/services`. Keeping them in one place makes
+ * the mapping auditable — a renamed id shows up here rather than silently degrading a card to
+ * `unknown`.
+ */
+const SERVICE_IDS = {
+  gateway: 'core-api',
+  admin: 'admin-api',
+  database: 'database',
+  cache: 'redis',
+  queue: 'messaging',
+} as const;
+
+/** Human-readable status line for a component, honest about `unknown`. */
+function describeComponent(name: string, status: ComponentHealthStatus): string {
+  switch (status) {
+    case 'healthy':
+      return `${name} responding normally`;
+    case 'degraded':
+      return `${name} degraded`;
+    case 'unhealthy':
+      return `${name} unavailable`;
+    default:
+      return `${name} status unknown`;
+  }
+}
 
 /**
  * Type-safe System health service using native fetch
@@ -41,39 +75,43 @@ export class FetchSystemHealthService implements ISystemHealthService {
   async getSystemHealth(config?: RequestConfig): Promise<SystemHealthDto> {
     // Get service status for detailed component health
     const serviceStatus = await this.getServiceStatus(config);
+    const lastChecked = new Date().toISOString();
 
     // Transform the data to match the expected SystemHealthDto structure
     const components = {
       api: {
         status: serviceStatus.coreApi.status,
-        message: serviceStatus.coreApi.status === 'healthy' ? 'API responding normally' : 'API experiencing issues',
-        lastChecked: new Date().toISOString(),
+        message: describeComponent('Gateway API', serviceStatus.coreApi.status),
+        lastChecked,
       },
       database: {
         status: serviceStatus.database.status,
-        message: serviceStatus.database.status === 'healthy' ? 'Database connections stable' : 'Database connectivity issues',
-        lastChecked: new Date().toISOString(),
+        message: describeComponent('Database', serviceStatus.database.status),
+        lastChecked,
       },
       cache: {
         status: serviceStatus.cache.status,
-        message: serviceStatus.cache.status === 'healthy' ? 'Cache performing normally' : 'Cache performance issues',
-        lastChecked: new Date().toISOString(),
+        message: describeComponent('Cache', serviceStatus.cache.status),
+        lastChecked,
       },
+      // Real messaging health. This was pinned to `healthy` with the message "Message queue
+      // processing normally" regardless of the transport's actual state (issue #1067).
       queue: {
-        status: 'healthy' as const, // Default to healthy - will be enhanced when queue monitoring is available
-        message: 'Message queue processing normally',
-        lastChecked: new Date().toISOString(),
+        status: serviceStatus.queue.status,
+        message: describeComponent('Message queue', serviceStatus.queue.status),
+        lastChecked,
       },
     };
 
-    // Calculate overall status based on components
+    // Calculate overall status based on components. `unknown` is not healthy — it degrades the
+    // rollup, matching how the Admin API rolls up its own service list.
     const componentStatuses = Object.values(components).map(c => c.status);
     const hasUnhealthy = componentStatuses.some(s => s === 'unhealthy');
-    const hasDegraded = componentStatuses.some(s => s === 'degraded');
+    const hasDegradedOrUnknown = componentStatuses.some(s => s === 'degraded' || s === 'unknown');
 
-    let overall: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
+    let overall: ComponentHealthStatus = 'healthy';
     if (hasUnhealthy) overall = 'unhealthy';
-    else if (hasDegraded) overall = 'degraded';
+    else if (hasDegradedOrUnknown) overall = 'degraded';
 
     // Get active connections count (fallback to estimated value based on system load)
     const metricsService = new FetchSystemMetricsService(this.client);
@@ -117,79 +155,92 @@ export class FetchSystemHealthService implements ISystemHealthService {
    */
   async getServiceStatus(config?: RequestConfig): Promise<ServiceStatusMapDto> {
     try {
-      // Try to get from dedicated services endpoint
-      const response = await this.client['get']<Record<string, unknown>>(
-        ENDPOINTS.SYSTEM.SERVICES,
-        {
-          signal: config?.signal,
-          timeout: config?.timeout,
-          headers: config?.headers,
-        }
-      );
-
-      // Transform response to match ServiceStatusMapDto structure
-      // The /v1/admin/health-status/services endpoint returns a different format, so we'll map it
-      const typedResponse = response as {
-        coreApi?: { status?: string; responseTime?: number; endpoint?: string };
-        adminApi?: { status?: string; responseTime?: number; endpoint?: string };
-        database?: { status?: string; responseTime?: number; connectionCount?: number };
-        cache?: { status?: string; responseTime?: number; hitRate?: number };
-      };
+      const byId = await this.getServiceEntriesById(config);
 
       return {
         coreApi: {
-          status: this.helpers.normalizeStatus(typedResponse.coreApi?.status),
-          latency: typedResponse.coreApi?.responseTime ?? 0,
-          endpoint: typedResponse.coreApi?.endpoint ?? '/api',
+          status: this.statusOf(byId, SERVICE_IDS.gateway),
+          latency: this.latencyOf(byId, SERVICE_IDS.gateway),
+          endpoint: '/api',
         },
         adminApi: {
-          status: this.helpers.normalizeStatus(typedResponse.adminApi?.status),
-          latency: typedResponse.adminApi?.responseTime ?? 0,
-          endpoint: typedResponse.adminApi?.endpoint ?? '/api',
+          status: this.statusOf(byId, SERVICE_IDS.admin),
+          latency: this.latencyOf(byId, SERVICE_IDS.admin),
+          endpoint: '/api',
         },
         database: {
-          status: this.helpers.normalizeStatus(typedResponse.database?.status),
-          latency: typedResponse.database?.responseTime ?? 0,
-          connections: typedResponse.database?.connectionCount ?? 0,
+          status: this.statusOf(byId, SERVICE_IDS.database),
+          latency: this.latencyOf(byId, SERVICE_IDS.database),
+          connections: null,
         },
         cache: {
-          status: this.helpers.normalizeStatus(typedResponse.cache?.status),
-          latency: typedResponse.cache?.responseTime ?? 0,
-          hitRate: typedResponse.cache?.hitRate ?? 0,
+          status: this.statusOf(byId, SERVICE_IDS.cache),
+          latency: this.latencyOf(byId, SERVICE_IDS.cache),
+          hitRate: null,
+        },
+        queue: {
+          status: this.statusOf(byId, SERVICE_IDS.queue),
+          latency: this.latencyOf(byId, SERVICE_IDS.queue),
         },
       };
     } catch {
-      // Fallback: construct from health and system info
+      // Fallback when the service health endpoint is unreachable. Only the Admin's own readiness
+      // is knowable from here, so everything else is reported `unknown` rather than being given
+      // the Admin's status — the Gateway previously inherited it and looked healthy while down.
       const systemService = new FetchSystemService(this.client);
       const health = await systemService.getHealth(config);
-
-      // Map health checks to service status
-      const dbStatus = health.checks.database?.status ?? 'healthy';
-      const apiStatus = health.status; // Overall status as proxy for API health
+      const adminStatus = this.helpers.normalizeStatus(health.status);
 
       return {
-        coreApi: {
-          status: apiStatus,
-          latency: health.totalDuration ?? 0,
-          endpoint: '/api',
-        },
+        coreApi: { status: 'unknown', latency: null, endpoint: '/api' },
         adminApi: {
-          status: apiStatus,
-          latency: health.totalDuration ?? 0,
+          status: adminStatus,
+          latency: health.totalDuration ?? null,
           endpoint: '/api',
         },
         database: {
-          status: dbStatus,
-          latency: health.checks.database?.duration ?? 0,
-          connections: 1, // Fallback value
+          status: this.helpers.normalizeStatus(health.checks.database?.status),
+          latency: health.checks.database?.duration ?? null,
+          connections: null,
         },
-        cache: {
-          status: 'healthy', // Default when no cache info available
-          latency: 0,
-          hitRate: 0,
-        },
+        cache: { status: 'unknown', latency: null, hitRate: null },
+        queue: { status: 'unknown', latency: null },
       };
     }
+  }
+
+  /**
+   * Fetches the service health response and indexes its entries by service id.
+   *
+   * The previous implementation cast the response to `{ coreApi, adminApi, database, cache }`.
+   * The endpoint has never returned that shape — it returns `{ timestamp, overallStatus,
+   * summary, services[] }` — so every lookup was `undefined` and every service was reported
+   * `healthy` with zero latency, regardless of what the backend actually said (issue #1067).
+   */
+  private async getServiceEntriesById(
+    config?: RequestConfig
+  ): Promise<Map<string, ServiceStatusEntry>> {
+    const systemService = new FetchSystemService(this.client);
+    const response = await systemService.getServiceHealth(config);
+    return new Map(
+      (response.services ?? [])
+        .filter((service): service is ServiceStatusEntry & { id: string } =>
+          typeof service.id === 'string'
+        )
+        .map(service => [service.id, service])
+    );
+  }
+
+  private statusOf(byId: Map<string, ServiceStatusEntry>, id: string): ComponentHealthStatus {
+    return this.helpers.normalizeStatus(byId.get(id)?.status);
+  }
+
+  /**
+   * Probe round-trip for a service, or null when it does not have one. Heartbeat-derived
+   * services report `responseTime: null`; rendering that as `0 ms` implies a probe that never ran.
+   */
+  private latencyOf(byId: Map<string, ServiceStatusEntry>, id: string): number | null {
+    return byId.get(id)?.responseTime ?? null;
   }
 
   /**
@@ -229,55 +280,60 @@ export class FetchSystemHealthService implements ISystemHealthService {
    * @since Issue #428 - Health Events SDK Methods
    */
   async getHealthEvents(limit?: number, config?: RequestConfig): Promise<HealthEventsResponseDto> {
-    const searchParams = new URLSearchParams();
-    if (limit) {
-      searchParams.set('limit', limit.toString());
-    }
-
     try {
-      // Health events endpoint no longer exists - construct from available health data
-      const systemService = new FetchSystemService(this.client);
-      const healthStatus = await systemService.getHealth(config);
-      const systemInfo = await systemService.getSystemInfo(config);
-
-      // Generate mock events based on current health status
-      const now = new Date();
-      const events: HealthEventDto[] = [];
-
-      // Add system startup event (runtime.startTime is the process start timestamp)
-      const startupTime = systemInfo.runtime?.startTime
-        ? new Date(systemInfo.runtime.startTime)
-        : now;
-      events.push({
-        id: `system-startup-${startupTime.getTime()}`,
-        timestamp: startupTime.toISOString(),
-        type: 'system_recovered',
-        message: 'System started successfully',
-        severity: 'info',
-        source: 'system',
-        metadata: {
-          componentName: 'core',
-          duration: 0,
-        },
-      });
-
-      // Add events based on current health checks
-      Object.entries(healthStatus.checks).forEach(([componentName, check]) => {
-        if (check.status !== 'healthy') {
-          events.push({
-            id: `${componentName}-issue-${Date.now()}`,
-            timestamp: new Date(now.getTime() - Math.random() * 3600000).toISOString(), // Random time in last hour
-            type: 'system_issue',
-            message: check.description ?? `${componentName} experiencing issues`,
-            severity: check.status === 'degraded' ? 'warning' : 'error',
-            source: componentName,
-            metadata: {
-              componentName,
-              errorDetails: check.error,
-              duration: check.duration,
-            },
-          });
+      // Derived from the Admin incident history rather than synthesized. The previous
+      // implementation invented events from the current health snapshot and stamped them with
+      // `Date.now()` ids and `Math.random()` timestamps, so every poll produced a different
+      // "history" of things that never happened at those times (issue #1067).
+      const incidents = await this.client['get']<IncidentsResponse>(
+        ENDPOINTS.SYSTEM.HEALTH_INCIDENTS,
+        {
+          signal: config?.signal,
+          timeout: config?.timeout,
+          headers: config?.headers,
         }
+      );
+
+      const events: HealthEventDto[] = (incidents.incidents ?? []).flatMap(incident => {
+        if (!incident.startTime) {
+          return [];
+        }
+
+        const source = incident.affectedService ?? 'system';
+        const detail = incident.affectedModel
+          ? `${incident.impact ?? 'Elevated error rate'} (model ${incident.affectedModel})`
+          : incident.impact ?? 'Elevated error rate';
+
+        const onset: HealthEventDto = {
+          // The Admin API now returns stable incident ids, so these stay stable across polls.
+          id: `${incident.id ?? source}-onset`,
+          timestamp: incident.startTime,
+          type: 'system_issue',
+          message: incident.title ?? 'Service degradation',
+          severity: incident.severity === 'critical' ? 'error' : 'warning',
+          source,
+          metadata: {
+            componentName: source,
+            errorDetails: detail,
+          },
+        };
+
+        if (!incident.endTime) {
+          return [onset];
+        }
+
+        return [
+          onset,
+          {
+            id: `${incident.id ?? source}-recovered`,
+            timestamp: incident.endTime,
+            type: 'system_recovered',
+            message: `${incident.title ?? 'Service degradation'} resolved`,
+            severity: 'info',
+            source,
+            metadata: { componentName: source },
+          },
+        ];
       });
 
       // Sort events by timestamp (newest first)

--- a/WebAdmin/src/lib/admin-api/services/FetchSystemHelpers.ts
+++ b/WebAdmin/src/lib/admin-api/services/FetchSystemHelpers.ts
@@ -1,4 +1,4 @@
-import type { SystemInfoDto, HealthStatusDto } from '../models/system';
+import type { SystemInfoDto, HealthStatusDto, ComponentHealthStatus } from '../models/system';
 import type { BackendSystemInfoResponse, ISystemHelpers } from './types/system-service.types';
 
 /**
@@ -59,12 +59,21 @@ export class FetchSystemHelpers implements ISystemHelpers {
   }
 
   /**
-   * Helper function to ensure valid status values
+   * Coerce a wire status string into a known component status.
+   *
+   * An unrecognized or missing status maps to `unknown`, never `healthy`. The previous
+   * `healthy` fallback meant any gap in the response — including a shape mismatch that made
+   * every lookup `undefined` — was rendered as a green service (issue #1067).
    */
-  normalizeStatus(status?: string): 'healthy' | 'degraded' | 'unhealthy' {
-    if (status === 'healthy' || status === 'degraded' || status === 'unhealthy') {
+  normalizeStatus(status?: string): ComponentHealthStatus {
+    if (
+      status === 'healthy' ||
+      status === 'degraded' ||
+      status === 'unhealthy' ||
+      status === 'unknown'
+    ) {
       return status;
     }
-    return 'healthy'; // Default fallback
+    return 'unknown';
   }
 }


### PR DESCRIPTION
## Summary

Closes #1067.

The evidence #1067 cites was fixed by PR #1085 (merged into `dev` on 2026-07-22). That PR said "Closes #1067", but GitHub only auto-closes on the default branch (`master`), so the issue stayed open. Gateway and Admin status genuinely come from heartbeat events today.

Re-auditing the surface turned up unfixed residue of **the same defect class** — a dashboard reporting green regardless of actual state — which this PR clears. Three commits, one concern each.

## 1. `/health-status/incidents` reported misleading data

- `AffectedService` was set to the request's **`ModelName`** and rendered as `"{model} Service Degradation"`, so a misbehaving model looked like a downed service. Attribution now splits: `AffectedService` is `core-api` (request logs only cover Gateway traffic) and a new `AffectedModel` carries the model.
- Incident ids were `Guid.NewGuid()` — every poll returned "new" incidents, so the UI could not correlate or acknowledge them. Ids now derive from the model and bucket hour.
- `StartTime`/`EndTime` were built with `new DateTime(...)`, defaulting to `DateTimeKind.Unspecified` and serializing **without a `Z`** while every sibling timestamp was UTC, so clients read them as local time.
- Active/resolved compared *calendar dates*: a spike ending at 00:30 stayed "active" all day, while one at 23:30 was "resolved" 30 minutes later. Only the hour still accruing traffic is active now.
- Hourly buckets came from `Timestamp.Date`/`.Hour`, which translate to `date_trunc` over a `timestamptz` column and resolve in the PostgreSQL server's `timezone` GUC rather than UTC. Bucketing is now epoch arithmetic against a UTC anchor.

## 2. `/health-status/history` issued one query per interval

The endpoint looped over the window running a separate `GROUP BY` per interval — **96 sequential round trips** for the default 24 hours, on an endpoint the dashboard polls. The window was unbounded too, so `?hours=100000` meant 100,000 queries.

Now a single grouped statement covers the window, with errors tallied via `count(*) FILTER (WHERE ...)`; `BuildHealthHistory` expands the sparse result back into a contiguous series, filling traffic-free intervals exactly as before. `hours` is clamped to 1..720.

## 3. WebAdmin SDK reported every service healthy

`FetchSystemHealthService.getServiceStatus` cast the response to `{ coreApi, adminApi, database, cache }`. The endpoint has never returned that shape — it returns `{ timestamp, overallStatus, summary, services[] }` — so **every property access was `undefined`**, and `normalizeStatus(undefined)` returned `'healthy'`. All four services rendered green with 0 ms latency regardless of backend state. Entries are now looked up by id from `services[]`.

Same class, same file:

- `normalizeStatus` fell back to `healthy`; it now falls back to `unknown`, so a gap can never read as healthy. `ComponentHealthStatus` gains `unknown` (what the backend emits for a service with no heartbeat yet), and `unknown` degrades rollups.
- `getSystemHealth` pinned `queue` to `healthy` with "Message queue processing normally"; it now reflects the real `messaging` entry.
- `getHealthEvents` synthesized events with `Date.now()` ids and `Math.random()` timestamps — each poll invented a different history. It now derives events from the incidents endpoint, whose ids and UTC timestamps are stable as of commit 1.
- Latency is `number | null` rather than `0` for heartbeat-derived services; fabricated `connections`/`hitRate` are `null`.
- The unreachable-endpoint fallback gave the Gateway the *Admin's* readiness, so a downed Gateway inherited "healthy". It now reports `unknown`.

WebAdmin's own health page uses the contract-typed `getServiceHealth()` and is unaffected; these methods remain on the SDK service surface.

## Contract

Additive only: `IncidentDto.affectedModel`, plus description updates. `openapi-admin.json` and the generated WebAdmin types are regenerated; `verify:offline` confirms byte-identical output across two isolated generations, and `validate:openapi` passes.

## Verification

- Full solution builds clean.
- Backend: **3,596 passed, 0 failed** (7 skipped). 24 new tests across `HealthMonitoringIncidentTests` and `HealthMonitoringHistoryTests`, including SQL-translation assertions that both aggregations stay server-side and timezone-independent (`date_part('epoch'` present, `date_trunc` absent).
- WebAdmin: `type-check` clean, `lint` 0 errors (warning count unchanged at 50), `check:api-boundary` passes. 13 new tests in `FetchSystemHealthService.test.ts`; **146 passed** across the admin-api and system-info suites.

Not exercised: a live end-to-end run against a running stack — same gap PR #1085 noted, since the running containers carry pre-change code.
