### PR TITLE
feat(providers): Amazon Bedrock adapter — completes epic #1177 Phase 4 (#1187)

### DIFF
--- a/Services/ConduitLLM.Admin/openapi-admin.json
+++ b/Services/ConduitLLM.Admin/openapi-admin.json
@@ -32559,7 +32559,8 @@
           "cloudflare",
           "openRouter",
           "meta",
-          "azure"
+          "azure",
+          "bedrock"
         ]
       },
       "PruneMediaRequest": {

--- a/Shared/ConduitLLM.Configuration/Enums/ProviderType.cs
+++ b/Shared/ConduitLLM.Configuration/Enums/ProviderType.cs
@@ -87,7 +87,12 @@ namespace ConduitLLM.Configuration
         /// <summary>
         /// Azure OpenAI Service (deployment-scoped OpenAI models on an Azure resource)
         /// </summary>
-        Azure = 15
+        Azure = 15,
+
+        /// <summary>
+        /// Amazon Bedrock (AWS-hosted foundation models via the Converse API, SigV4 or API-key auth)
+        /// </summary>
+        Bedrock = 16
     }
 
     /// <summary>

--- a/Shared/ConduitLLM.Configuration/Providers/ProviderAdapterDefaultsRegistry.cs
+++ b/Shared/ConduitLLM.Configuration/Providers/ProviderAdapterDefaultsRegistry.cs
@@ -29,7 +29,8 @@ public static class ProviderAdapterDefaultsRegistry
             [ProviderType.Cloudflare] = new("https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"),
             [ProviderType.OpenRouter] = new("https://openrouter.ai/api/v1"),
             [ProviderType.Meta] = new("https://api.meta.ai/v1"),
-            [ProviderType.Azure] = new("https://{resource_name}.openai.azure.com")
+            [ProviderType.Azure] = new("https://{resource_name}.openai.azure.com"),
+            [ProviderType.Bedrock] = new("https://bedrock-runtime.{region}.amazonaws.com")
         };
 
     public static ProviderAdapterDefaults GetRequired(ProviderType providerType) =>

--- a/Shared/ConduitLLM.Core/Providers/Metadata/AllProviders.cs
+++ b/Shared/ConduitLLM.Core/Providers/Metadata/AllProviders.cs
@@ -242,6 +242,33 @@ namespace ConduitLLM.Core.Providers.Metadata
     }
 
     /// <summary>
+    /// Provider metadata for Amazon Bedrock.
+    /// </summary>
+    public class BedrockProviderMetadata : BaseProviderMetadata
+    {
+        public override ProviderType ProviderType => ProviderType.Bedrock;
+        public override string DisplayName => "Amazon Bedrock";
+        public override string DefaultBaseUrl => ProviderAdapterDefaultsRegistry.GetRequired(ProviderType).DefaultBaseUrl;
+
+        public BedrockProviderMetadata()
+        {
+            ConfigurationHints.DocumentationUrl = "https://docs.aws.amazon.com/bedrock/";
+            ConfigurationHints.Tips.Add(new ConfigurationTip
+            {
+                Title = "Two Ways To Authenticate",
+                Description = "Enter an IAM access key ID as the API key and the secret access key (plus a session token for temporary credentials) on the key credential, or enter a Bedrock API key alone.",
+                Severity = TipSeverity.Info
+            });
+            ConfigurationHints.Tips.Add(new ConfigurationTip
+            {
+                Title = "Region Determines Endpoint And Models",
+                Description = "The AWS Region setting builds the endpoint and scopes request signing. Models must be enabled for that region in the Bedrock console; many models require a cross-region inference profile ID (e.g. us.anthropic...).",
+                Severity = TipSeverity.Warning
+            });
+        }
+    }
+
+    /// <summary>
     /// Provider metadata for Meta AI (Meta Model API).
     /// </summary>
     public class MetaProviderMetadata : BaseProviderMetadata

--- a/Shared/ConduitLLM.Providers/Authentication/AwsSigV4Signer.cs
+++ b/Shared/ConduitLLM.Providers/Authentication/AwsSigV4Signer.cs
@@ -1,0 +1,210 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ConduitLLM.Providers.Authentication
+{
+    /// <summary>
+    /// The AWS credential material used to produce a Signature Version 4 signature.
+    /// </summary>
+    /// <param name="AccessKeyId">The AWS access key ID (for example <c>AKIA…</c> or a temporary <c>ASIA…</c>).</param>
+    /// <param name="SecretAccessKey">The AWS secret access key paired with <paramref name="AccessKeyId"/>.</param>
+    /// <param name="SessionToken">The STS session token when the credentials are temporary; null for long-term keys.</param>
+    public sealed record AwsSigV4Credentials(
+        string AccessKeyId,
+        string SecretAccessKey,
+        string? SessionToken = null);
+
+    /// <summary>
+    /// Signs HTTP requests with AWS Signature Version 4, the request authentication scheme used by
+    /// AWS services such as Bedrock. Implemented directly so provider adapters do not take a
+    /// dependency on the AWS SDK for what is a pure request transformation.
+    /// </summary>
+    /// <remarks>
+    /// The signature is computed over a canonical form of the request
+    /// (https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html) and applied as
+    /// the <c>Authorization</c> header together with <c>x-amz-date</c> and, for temporary
+    /// credentials, <c>x-amz-security-token</c>. The headers included in the signature are
+    /// <c>host</c>, <c>content-type</c> (when the request carries one), <c>x-amz-date</c>, and
+    /// <c>x-amz-security-token</c> (when present) — the minimal set services require, kept small so
+    /// intermediaries that add headers cannot invalidate the signature.
+    /// </remarks>
+    public static class AwsSigV4Signer
+    {
+        private const string Algorithm = "AWS4-HMAC-SHA256";
+
+        /// <summary>
+        /// Signs the request in place for the given service and region.
+        /// </summary>
+        /// <param name="request">The request to sign. Must have an absolute <see cref="HttpRequestMessage.RequestUri"/>.</param>
+        /// <param name="payload">The exact request body bytes; use an empty array for bodyless requests.</param>
+        /// <param name="credentials">The AWS credentials to sign with.</param>
+        /// <param name="region">The AWS region forming the credential scope (for example <c>us-east-1</c>).</param>
+        /// <param name="service">The signing service name (for example <c>bedrock-runtime</c>).</param>
+        /// <param name="signingTime">The instant to stamp into <c>x-amz-date</c>; pass the current UTC time outside tests.</param>
+        public static void Sign(
+            HttpRequestMessage request,
+            byte[] payload,
+            AwsSigV4Credentials credentials,
+            string region,
+            string service,
+            DateTimeOffset signingTime)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            ArgumentNullException.ThrowIfNull(payload);
+            ArgumentNullException.ThrowIfNull(credentials);
+
+            var uri = request.RequestUri
+                ?? throw new ArgumentException("The request must have an absolute URI to be signed.", nameof(request));
+
+            var amzDate = signingTime.UtcDateTime.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
+            var dateStamp = signingTime.UtcDateTime.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+            // The Host header is set explicitly so the value signed here is exactly what goes on
+            // the wire rather than whatever HttpClient would derive at send time.
+            request.Headers.Host = uri.Authority;
+            request.Headers.Remove("x-amz-date");
+            request.Headers.Add("x-amz-date", amzDate);
+            request.Headers.Remove("x-amz-security-token");
+            if (!string.IsNullOrEmpty(credentials.SessionToken))
+            {
+                request.Headers.Add("x-amz-security-token", credentials.SessionToken);
+            }
+
+            var signedHeaders = new SortedDictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["host"] = uri.Authority,
+                ["x-amz-date"] = amzDate
+            };
+            var contentType = request.Content?.Headers.ContentType?.ToString();
+            if (!string.IsNullOrEmpty(contentType))
+            {
+                signedHeaders["content-type"] = contentType;
+            }
+            if (!string.IsNullOrEmpty(credentials.SessionToken))
+            {
+                signedHeaders["x-amz-security-token"] = credentials.SessionToken;
+            }
+
+            var canonicalHeaders = string.Concat(signedHeaders.Select(header => $"{header.Key}:{header.Value.Trim()}\n"));
+            var signedHeaderNames = string.Join(";", signedHeaders.Keys);
+            var payloadHash = ToHex(SHA256.HashData(payload));
+
+            var canonicalRequest = string.Join("\n",
+                request.Method.Method,
+                BuildCanonicalPath(uri),
+                BuildCanonicalQuery(uri),
+                canonicalHeaders,
+                signedHeaderNames,
+                payloadHash);
+
+            var credentialScope = $"{dateStamp}/{region}/{service}/aws4_request";
+            var stringToSign = string.Join("\n",
+                Algorithm,
+                amzDate,
+                credentialScope,
+                ToHex(SHA256.HashData(Encoding.UTF8.GetBytes(canonicalRequest))));
+
+            var signingKey = HmacSha256(
+                HmacSha256(
+                    HmacSha256(
+                        HmacSha256(Encoding.UTF8.GetBytes("AWS4" + credentials.SecretAccessKey), dateStamp),
+                        region),
+                    service),
+                "aws4_request");
+            var signature = ToHex(HmacSha256(signingKey, stringToSign));
+
+            request.Headers.TryAddWithoutValidation(
+                "Authorization",
+                $"{Algorithm} Credential={credentials.AccessKeyId}/{credentialScope}, "
+                + $"SignedHeaders={signedHeaderNames}, Signature={signature}");
+        }
+
+        /// <summary>
+        /// Builds the canonical URI path. SigV4 for services other than S3 expects each path segment
+        /// URI-encoded twice; <see cref="Uri.AbsolutePath"/> is the once-encoded wire form, so this
+        /// encodes it once more, keeping <c>/</c> and unreserved characters literal (the same
+        /// normalization botocore and the AWS SDKs apply).
+        /// </summary>
+        internal static string BuildCanonicalPath(Uri uri)
+        {
+            var path = uri.AbsolutePath;
+            if (string.IsNullOrEmpty(path))
+            {
+                return "/";
+            }
+
+            var builder = new StringBuilder(path.Length);
+            foreach (var b in Encoding.UTF8.GetBytes(path))
+            {
+                var c = (char)b;
+                if (c == '/' || IsUnreserved(c))
+                {
+                    builder.Append(c);
+                }
+                else
+                {
+                    builder.Append('%').Append(((int)b).ToString("X2", CultureInfo.InvariantCulture));
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Builds the canonical query string: parameters strictly percent-encoded and sorted by
+        /// encoded name, then encoded value.
+        /// </summary>
+        internal static string BuildCanonicalQuery(Uri uri)
+        {
+            var query = uri.Query;
+            if (string.IsNullOrEmpty(query) || query == "?")
+            {
+                return string.Empty;
+            }
+
+            var pairs = query.TrimStart('?')
+                .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Select(pair =>
+                {
+                    var separator = pair.IndexOf('=');
+                    var name = separator < 0 ? pair : pair[..separator];
+                    var value = separator < 0 ? string.Empty : pair[(separator + 1)..];
+                    return (Name: SigV4Encode(Uri.UnescapeDataString(name)),
+                            Value: SigV4Encode(Uri.UnescapeDataString(value)));
+                })
+                .OrderBy(pair => pair.Name, StringComparer.Ordinal)
+                .ThenBy(pair => pair.Value, StringComparer.Ordinal);
+
+            return string.Join("&", pairs.Select(pair => $"{pair.Name}={pair.Value}"));
+        }
+
+        private static string SigV4Encode(string value)
+        {
+            var builder = new StringBuilder(value.Length);
+            foreach (var b in Encoding.UTF8.GetBytes(value))
+            {
+                var c = (char)b;
+                if (IsUnreserved(c))
+                {
+                    builder.Append(c);
+                }
+                else
+                {
+                    builder.Append('%').Append(((int)b).ToString("X2", CultureInfo.InvariantCulture));
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsUnreserved(char c) =>
+            c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '.' or '_' or '~';
+
+        private static byte[] HmacSha256(byte[] key, string data) =>
+            HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(data));
+
+        private static string ToHex(byte[] bytes) =>
+            Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ClientCreatorRegistry.cs
@@ -8,6 +8,7 @@ using ConduitLLM.Providers.Groq;
 using ConduitLLM.Providers.MiniMax;
 using ConduitLLM.Providers.OpenAI;
 using ConduitLLM.Providers.Replicate;
+using ConduitLLM.Providers.Bedrock;
 using ConduitLLM.Providers.Cloudflare;
 using ConduitLLM.Providers.Meta;
 using ConduitLLM.Providers.OpenRouter;
@@ -81,7 +82,8 @@ namespace ConduitLLM.Providers.Configuration
             [ProviderType.Cloudflare] = CreateCloudflareClient,
             [ProviderType.OpenRouter] = CreateOpenRouterClient,
             [ProviderType.Meta] = CreateMetaClient,
-            [ProviderType.Azure] = CreateOpenAIClient
+            [ProviderType.Azure] = CreateOpenAIClient,
+            [ProviderType.Bedrock] = CreateBedrockClient
         };
 
         /// <summary>
@@ -314,6 +316,21 @@ namespace ConduitLLM.Providers.Configuration
                 logger,
                 context.HttpClientFactory,
                 context.ProviderOptionsJson);
+        }
+
+        private static ILLMClient CreateBedrockClient(
+            Provider provider,
+            ProviderKeyCredential keyCredential,
+            string modelId,
+            ClientCreationContext context)
+        {
+            var logger = context.LoggerFactory.CreateLogger<BedrockClient>();
+            return new BedrockClient(
+                provider,
+                keyCredential,
+                modelId,
+                logger,
+                context.HttpClientFactory);
         }
 
         private static ILLMClient CreateMetaClient(

--- a/Shared/ConduitLLM.Providers/Configuration/ProviderConfigurationRegistry.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ProviderConfigurationRegistry.cs
@@ -304,6 +304,57 @@ namespace ConduitLLM.Providers.Configuration
                 }
             },
 
+            // Amazon Bedrock is region-scoped: the runtime endpoint host embeds the region, and the
+            // region also forms the SigV4 credential scope. Authentication is either SigV4 (the key
+            // credential's ApiKey is the access key ID and the secret access key / session token are
+            // secret settings) or a Bedrock API key sent as a Bearer token when no secret access key
+            // is configured. BedrockClient signs per request, so the registered strategy only covers
+            // the Bearer mode.
+            [ProviderType.Bedrock] = new ProviderConfiguration
+            {
+                DefaultBaseUrl = DefaultUrl(ProviderType.Bedrock),
+                AuthenticationStrategy = BearerTokenStrategy.Instance,
+                ErrorMessages = new ProviderErrorMessages
+                {
+                    InvalidApiKey = "Invalid AWS credentials for Bedrock. Verify the access key ID and secret access key (or Bedrock API key) and that the key has bedrock permissions.",
+                    RateLimitExceeded = "Amazon Bedrock throttled the request. Please try again later or request a quota increase.",
+                    ModelNotFound = "Model not found. Bedrock model IDs look like 'anthropic.claude-sonnet-4-20250514-v1:0'; cross-region inference profiles are prefixed (e.g. 'us.anthropic...'). Verify the model is enabled in this region.",
+                    MissingApiKey = "An AWS access key ID or Bedrock API key is required for Amazon Bedrock"
+                },
+                Settings = new[]
+                {
+                    new ProviderSettingDefinition
+                    {
+                        Key = "region",
+                        Label = "AWS Region",
+                        HelpText = "The AWS region hosting the Bedrock models (for example us-east-1). Builds the endpoint https://bedrock-runtime.<region>.amazonaws.com and scopes request signing.",
+                        Placeholder = "e.g. us-east-1",
+                        Required = true,
+                        Binding = ProviderSettingBinding.UrlPathToken,
+                        BindingTarget = "region",
+                        ValidationRegex = "^[a-z]{2}(-[a-z]+)+-[0-9]+$"
+                    },
+                    new ProviderSettingDefinition
+                    {
+                        Key = "secret_access_key",
+                        Label = "Secret Access Key",
+                        HelpText = "The AWS secret access key paired with the access key ID entered as the API key. Leave blank when the API key field holds a Bedrock API key instead of an IAM access key.",
+                        Required = false,
+                        Secret = true,
+                        Binding = ProviderSettingBinding.AuthScope
+                    },
+                    new ProviderSettingDefinition
+                    {
+                        Key = "session_token",
+                        Label = "Session Token",
+                        HelpText = "The STS session token when using temporary credentials (access key IDs starting with ASIA). Leave blank for long-term credentials.",
+                        Required = false,
+                        Secret = true,
+                        Binding = ProviderSettingBinding.AuthScope
+                    }
+                }
+            },
+
             [ProviderType.Meta] = new ProviderConfiguration
             {
                 DefaultBaseUrl = DefaultUrl(ProviderType.Meta),

--- a/Shared/ConduitLLM.Providers/Configuration/ProviderSettingDefinition.cs
+++ b/Shared/ConduitLLM.Providers/Configuration/ProviderSettingDefinition.cs
@@ -12,20 +12,19 @@ namespace ConduitLLM.Providers.Configuration
         UrlPathToken = 0,
 
         /// <summary>
-        /// The value is sent as an HTTP request header (for example <c>OpenAI-Organization</c>).
-        /// Declared for future phases; header application is not wired in Phase 1.
+        /// The value is sent as an HTTP request header (for example <c>OpenAI-Organization</c>),
+        /// applied generically by <c>BaseLLMClient.ApplyHeaderSettings</c>.
         /// </summary>
         Header = 1,
 
         /// <summary>
         /// The value is sent as a query-string parameter (for example Azure's <c>api-version</c>).
-        /// Declared for future phases; query application is not wired in Phase 1.
         /// </summary>
         QueryParam = 2,
 
         /// <summary>
-        /// The value participates in request authentication/signing (for example an AWS region).
-        /// Declared for future phases; auth-scope application is not wired in Phase 1.
+        /// The value participates in request authentication/signing rather than being placed on the
+        /// request generically (for example AWS SigV4 secret material, consumed by the Bedrock client).
         /// </summary>
         AuthScope = 3,
     }
@@ -37,8 +36,8 @@ namespace ConduitLLM.Providers.Configuration
     /// <remarks>
     /// These declarations are the single source of truth consumed by request-time resolution,
     /// validation, and the WebAdmin provider form. Non-secret values are stored in
-    /// <c>Provider.Settings</c>; secret-valued settings are reserved for a later phase and must not
-    /// be placed in that non-encrypted bag.
+    /// <c>Provider.Settings</c>; secret-valued settings live encrypted on
+    /// <c>ProviderKeyCredential.SecretSettings</c> and must never be placed in that plaintext bag.
     /// </remarks>
     public record ProviderSettingDefinition
     {
@@ -77,8 +76,9 @@ namespace ConduitLLM.Providers.Configuration
         public bool Required { get; init; }
 
         /// <summary>
-        /// Whether the value is sensitive. Secret settings are reserved for a later phase and are not
-        /// stored in the non-encrypted <c>Provider.Settings</c> bag.
+        /// Whether the value is sensitive. Secret settings are stored encrypted on the key
+        /// credential (<c>ProviderKeyCredential.SecretSettings</c>), never in the plaintext
+        /// <c>Provider.Settings</c> bag, and their values are never returned by the API.
         /// </summary>
         public bool Secret { get; init; }
 

--- a/Shared/ConduitLLM.Providers/Http/ProviderHttpClientNames.cs
+++ b/Shared/ConduitLLM.Providers/Http/ProviderHttpClientNames.cs
@@ -44,6 +44,7 @@ public static class ProviderHttpClientNames
             [ProviderType.OpenRouter] = "OpenRouter",
             [ProviderType.Meta] = "meta",
             [ProviderType.Azure] = "Azure",
+            [ProviderType.Bedrock] = "bedrock",
         };
 
     /// <summary>

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Chat.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Chat.cs
@@ -1,0 +1,376 @@
+using System.Text.Json;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Providers.Helpers;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Bedrock
+{
+    /// <summary>
+    /// BedrockClient partial class containing chat completion via the Converse API.
+    /// </summary>
+    public partial class BedrockClient
+    {
+        /// <inheritdoc />
+        public override async Task<ChatCompletionResponse> CreateChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            ValidateRequest(request, "CreateChatCompletion");
+
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var httpClient = CreateHttpClient(apiKey);
+
+                var payload = SerializePayload(MapToConverseRequest(request));
+                var url = BuildModelUrl(request.Model ?? ProviderModelId, "converse");
+                using var httpRequest = BuildRequest(HttpMethod.Post, url, payload, RuntimeService, apiKey);
+
+                using var httpResponse = await httpClient.SendAsync(httpRequest, cancellationToken);
+                await ThrowOnErrorAsync(httpResponse, "chat completion", cancellationToken);
+
+                var body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                var converseResponse = JsonSerializer.Deserialize<BedrockConverseResponse>(body, DefaultJsonOptions)
+                    ?? throw new LLMCommunicationException("Bedrock returned an empty converse response.");
+
+                var response = MapToCoreResponse(converseResponse, request.Model ?? ProviderModelId);
+                RecordUsage(response.Usage, "CreateChatCompletion");
+                return response;
+            }, "CreateChatCompletion", cancellationToken);
+        }
+
+        /// <summary>
+        /// Maps the OpenAI-shaped request to a Converse request: system messages become system
+        /// blocks, tool results become <c>toolResult</c> blocks on a user message, assistant tool
+        /// calls become <c>toolUse</c> blocks, and consecutive same-role messages are merged because
+        /// Converse requires strictly alternating roles.
+        /// </summary>
+        internal BedrockConverseRequest MapToConverseRequest(ChatCompletionRequest request)
+        {
+            var system = new List<BedrockSystemBlock>();
+            var messages = new List<BedrockMessage>();
+
+            foreach (var message in request.Messages)
+            {
+                if (string.Equals(message.Role, MessageRole.System, StringComparison.OrdinalIgnoreCase))
+                {
+                    var text = ContentHelper.GetContentAsString(message.Content);
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        system.Add(new BedrockSystemBlock { Text = text });
+                    }
+                    continue;
+                }
+
+                var mapped = MapMessage(message);
+                if (mapped.Content.Count == 0)
+                {
+                    continue;
+                }
+
+                if (messages.Count > 0 && messages[^1].Role == mapped.Role)
+                {
+                    messages[^1].Content.AddRange(mapped.Content);
+                }
+                else
+                {
+                    messages.Add(mapped);
+                }
+            }
+
+            var converseRequest = new BedrockConverseRequest
+            {
+                Messages = messages,
+                System = system.Count > 0 ? system : null,
+                InferenceConfig = MapInferenceConfig(request),
+                ToolConfig = MapToolConfig(request)
+            };
+
+            if (request.TopK is { } topK)
+            {
+                converseRequest.AdditionalModelRequestFields = new Dictionary<string, JsonElement>
+                {
+                    ["top_k"] = JsonSerializer.SerializeToElement(topK)
+                };
+            }
+
+            if (request.ResponseFormat?.Type == "json_object")
+            {
+                Logger.LogDebug("Bedrock Converse has no JSON response mode; response_format is ignored.");
+            }
+
+            return converseRequest;
+        }
+
+        private BedrockMessage MapMessage(Message message)
+        {
+            if (string.Equals(message.Role, MessageRole.Tool, StringComparison.OrdinalIgnoreCase))
+            {
+                // Tool results ride on a user message in Converse.
+                return new BedrockMessage
+                {
+                    Role = "user",
+                    Content = new List<BedrockContentBlock>
+                    {
+                        new()
+                        {
+                            ToolResult = new BedrockToolResultBlock
+                            {
+                                ToolUseId = message.ToolCallId ?? string.Empty,
+                                Content = new List<BedrockContentBlock> { MapToolResultContent(message.Content) }
+                            }
+                        }
+                    }
+                };
+            }
+
+            var role = string.Equals(message.Role, MessageRole.Assistant, StringComparison.OrdinalIgnoreCase)
+                ? "assistant"
+                : "user";
+            var blocks = new List<BedrockContentBlock>();
+
+            var text = ContentHelper.GetContentAsString(message.Content);
+            if (!string.IsNullOrEmpty(text))
+            {
+                blocks.Add(new BedrockContentBlock { Text = text });
+            }
+
+            foreach (var image in ContentHelper.ExtractImageUrls(message.Content))
+            {
+                blocks.Add(MapImage(image));
+            }
+
+            if (message.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolCall in message.ToolCalls)
+                {
+                    blocks.Add(new BedrockContentBlock
+                    {
+                        ToolUse = new BedrockToolUseBlock
+                        {
+                            ToolUseId = toolCall.Id,
+                            Name = toolCall.Function.Name,
+                            Input = ParseJsonOrWrap(toolCall.Function.Arguments)
+                        }
+                    });
+                }
+            }
+
+            return new BedrockMessage { Role = role, Content = blocks };
+        }
+
+        private static BedrockContentBlock MapToolResultContent(object? content)
+        {
+            var text = ContentHelper.GetContentAsString(content);
+            try
+            {
+                using var document = JsonDocument.Parse(text);
+                if (document.RootElement.ValueKind is JsonValueKind.Object)
+                {
+                    return new BedrockContentBlock { Json = document.RootElement.Clone() };
+                }
+            }
+            catch (JsonException)
+            {
+                // Plain-text tool output.
+            }
+
+            return new BedrockContentBlock { Text = text };
+        }
+
+        private static BedrockContentBlock MapImage(ImageUrl image)
+        {
+            // Converse only accepts inline bytes. Data URLs carry them directly; remote URLs would
+            // require Conduit to fetch arbitrary content server-side, which this adapter does not do.
+            var url = image.Url;
+            if (!url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ValidationException(
+                    "Bedrock requires image content to be supplied inline as a data URL; remote image URLs are not supported.");
+            }
+
+            var separator = url.IndexOf(',');
+            if (separator < 0)
+            {
+                throw new ValidationException("Malformed data URL in image content.");
+            }
+
+            var header = url[..separator];
+            var format = header switch
+            {
+                _ when header.Contains("image/jpeg", StringComparison.OrdinalIgnoreCase) => "jpeg",
+                _ when header.Contains("image/gif", StringComparison.OrdinalIgnoreCase) => "gif",
+                _ when header.Contains("image/webp", StringComparison.OrdinalIgnoreCase) => "webp",
+                _ => "png"
+            };
+
+            return new BedrockContentBlock
+            {
+                Image = new BedrockImageBlock
+                {
+                    Format = format,
+                    Source = new BedrockImageSource { Bytes = url[(separator + 1)..] }
+                }
+            };
+        }
+
+        private static JsonElement ParseJsonOrWrap(string arguments)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(
+                    string.IsNullOrWhiteSpace(arguments) ? "{}" : arguments);
+                return document.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                using var fallback = JsonDocument.Parse(
+                    JsonSerializer.Serialize(new { raw = arguments }));
+                return fallback.RootElement.Clone();
+            }
+        }
+
+        private static BedrockInferenceConfig? MapInferenceConfig(ChatCompletionRequest request)
+        {
+            var config = new BedrockInferenceConfig
+            {
+                MaxTokens = request.MaxTokens ?? request.MaxCompletionTokens,
+                Temperature = request.Temperature,
+                TopP = request.TopP,
+                StopSequences = request.Stop is { Count: > 0 } ? request.Stop : null
+            };
+
+            return config.MaxTokens is null && config.Temperature is null
+                && config.TopP is null && config.StopSequences is null
+                ? null
+                : config;
+        }
+
+        private static BedrockToolConfig? MapToolConfig(ChatCompletionRequest request)
+        {
+            // OpenAI's tool_choice "none" means the model must not call tools; Converse cannot
+            // express that with tools present, so the tools are simply not sent.
+            if (request.Tools is not { Count: > 0 }
+                || request.ToolChoice?.GetSerializedValue() as string == "none")
+            {
+                return null;
+            }
+
+            var config = new BedrockToolConfig
+            {
+                Tools = request.Tools.Select(tool => new BedrockTool
+                {
+                    ToolSpec = new BedrockToolSpec
+                    {
+                        Name = tool.Function.Name,
+                        Description = tool.Function.Description,
+                        InputSchema = tool.Function.Parameters is { } parameters
+                            ? new BedrockToolInputSchema
+                            {
+                                Json = JsonSerializer.SerializeToElement(parameters)
+                            }
+                            : null
+                    }
+                }).ToList()
+            };
+
+            config.ToolChoice = MapToolChoice(request.ToolChoice);
+            return config;
+        }
+
+        private static BedrockToolChoice? MapToolChoice(ToolChoice? toolChoice)
+        {
+            if (toolChoice is null)
+            {
+                return null;
+            }
+
+            var serialized = JsonSerializer.SerializeToElement(toolChoice.GetSerializedValue());
+            if (serialized.ValueKind == JsonValueKind.String)
+            {
+                return serialized.GetString() switch
+                {
+                    "auto" => new BedrockToolChoice { Auto = new { } },
+                    "required" => new BedrockToolChoice { Any = new { } },
+                    _ => null
+                };
+            }
+
+            if (serialized.ValueKind == JsonValueKind.Object
+                && serialized.TryGetProperty("function", out var function)
+                && function.TryGetProperty("name", out var name)
+                && name.GetString() is { Length: > 0 } functionName)
+            {
+                return new BedrockToolChoice { Tool = new BedrockNamedToolChoice { Name = functionName } };
+            }
+
+            return null;
+        }
+
+        internal ChatCompletionResponse MapToCoreResponse(BedrockConverseResponse response, string modelId)
+        {
+            var contentBlocks = response.Output?.Message?.Content ?? new List<BedrockContentBlock>();
+            var text = string.Concat(contentBlocks
+                .Where(block => !string.IsNullOrEmpty(block.Text))
+                .Select(block => block.Text));
+
+            var toolCalls = contentBlocks
+                .Where(block => block.ToolUse != null)
+                .Select(block => new ToolCall
+                {
+                    Id = block.ToolUse!.ToolUseId,
+                    Function = new FunctionCall
+                    {
+                        Name = block.ToolUse.Name,
+                        Arguments = block.ToolUse.Input.ValueKind == JsonValueKind.Undefined
+                            ? "{}"
+                            : block.ToolUse.Input.GetRawText()
+                    }
+                })
+                .ToList();
+
+            return new ChatCompletionResponse
+            {
+                Id = $"bedrock-{Guid.NewGuid():N}",
+                Object = "chat.completion",
+                Created = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                Model = modelId,
+                Choices = new List<Choice>
+                {
+                    new()
+                    {
+                        Index = 0,
+                        FinishReason = MapStopReason(response.StopReason),
+                        Message = new Message
+                        {
+                            Role = MessageRole.Assistant,
+                            Content = text.Length > 0 ? text : null,
+                            ToolCalls = toolCalls.Count > 0 ? toolCalls : null
+                        }
+                    }
+                },
+                Usage = response.Usage is { } usage
+                    ? new Usage
+                    {
+                        PromptTokens = usage.InputTokens,
+                        CompletionTokens = usage.OutputTokens,
+                        TotalTokens = usage.TotalTokens
+                            ?? (usage.InputTokens ?? 0) + (usage.OutputTokens ?? 0)
+                    }
+                    : null
+            };
+        }
+
+        internal static string MapStopReason(string? stopReason) => stopReason switch
+        {
+            "end_turn" or "stop_sequence" => FinishReason.Stop,
+            "max_tokens" => FinishReason.Length,
+            "tool_use" => FinishReason.ToolCalls,
+            "content_filtered" or "guardrail_intervened" => FinishReason.ContentFilter,
+            _ => FinishReason.Stop
+        };
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Models.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Models.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Common.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Bedrock
+{
+    /// <summary>
+    /// BedrockClient partial class containing model discovery and authentication verification.
+    /// </summary>
+    /// <remarks>
+    /// Model discovery targets the control-plane <c>GET /foundation-models</c> endpoint on the
+    /// <c>bedrock.&lt;region&gt;</c> host (signing service <c>bedrock</c>, not
+    /// <c>bedrock-runtime</c>). This is also what backs the provider connection test: it is a real
+    /// authenticated request, so an invalid key, missing model access, or a wrong region produce
+    /// classifiable errors instead of an opaque failure.
+    /// </remarks>
+    public partial class BedrockClient
+    {
+        /// <inheritdoc />
+        public override async Task<List<ExtendedModelInfo>> GetModelsAsync(
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await ExecuteApiRequestAsync(async () =>
+            {
+                using var httpClient = CreateHttpClient(apiKey);
+                using var httpRequest = BuildRequest(
+                    HttpMethod.Get, BuildFoundationModelsUrl(), null, ControlPlaneService, apiKey);
+
+                Logger.LogDebug("Listing Bedrock foundation models at {Endpoint}", httpRequest.RequestUri);
+
+                using var httpResponse = await httpClient.SendAsync(httpRequest, cancellationToken);
+                await ThrowOnErrorAsync(httpResponse, "model discovery", cancellationToken);
+
+                var body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+                var parsed = JsonSerializer.Deserialize<BedrockListFoundationModelsResponse>(body, DefaultJsonOptions);
+
+                return parsed?.ModelSummaries?
+                    .Where(summary => !string.IsNullOrWhiteSpace(summary.ModelId))
+                    .Select(summary => ExtendedModelInfo
+                        .Create(summary.ModelId!, ProviderName, summary.ModelId!)
+                        .WithName(summary.ModelName ?? summary.ModelId!))
+                    .ToList()
+                    ?? new List<ExtendedModelInfo>();
+            }, "GetModels", cancellationToken);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The base implementation issues a bare GET with a Bearer header, which cannot carry a
+        /// SigV4 signature; verification is instead performed through the signed model-discovery
+        /// request.
+        /// </remarks>
+        public override async Task<Core.Interfaces.AuthenticationResult> VerifyAuthenticationAsync(
+            string? apiKey = null,
+            string? baseUrl = null,
+            CancellationToken cancellationToken = default)
+        {
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                var models = await GetModelsAsync(apiKey, cancellationToken);
+                return Core.Interfaces.AuthenticationResult.Success(
+                    $"Connected successfully to Amazon Bedrock in {_region} ({models.Count} foundation models visible)",
+                    (DateTime.UtcNow - startTime).TotalMilliseconds);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (LLMCommunicationException ex)
+            {
+                Logger.LogWarning(ex, "Bedrock authentication verification failed");
+                return Core.Interfaces.AuthenticationResult.Failure("Authentication failed", ex.Message);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error verifying Bedrock authentication");
+                return Core.Interfaces.AuthenticationResult.Failure(
+                    $"Authentication verification failed: {ex.Message}", ex.ToString());
+            }
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Streaming.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Streaming.cs
@@ -1,0 +1,232 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Providers.Streaming;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Bedrock
+{
+    /// <summary>
+    /// BedrockClient partial class containing streaming via ConverseStream.
+    /// </summary>
+    /// <remarks>
+    /// ConverseStream responds with the AWS binary event-stream framing rather than SSE; frames are
+    /// decoded by <see cref="AwsEventStreamReader"/> and mapped onto OpenAI-style chunks. Tool-call
+    /// indices are assigned in order of appearance because Bedrock's <c>contentBlockIndex</c> counts
+    /// every content block (text included) while OpenAI's <c>tool_calls[].index</c> counts only tool
+    /// calls.
+    /// </remarks>
+    public partial class BedrockClient
+    {
+        /// <inheritdoc />
+        public override async IAsyncEnumerable<ChatCompletionChunk> StreamChatCompletionAsync(
+            ChatCompletionRequest request,
+            string? apiKey = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ValidateRequest(request, "StreamChatCompletion");
+
+            using var logScope = BeginProviderLogScope("StreamChatCompletion");
+            var instrumentation = BeginStreamingScope("StreamChatCompletion");
+            HttpClient? httpClient = null;
+            HttpResponseMessage? response = null;
+            var modelId = request.Model ?? ProviderModelId;
+
+            try
+            {
+                try
+                {
+                    httpClient = CreateHttpClient(apiKey);
+                    var payload = SerializePayload(MapToConverseRequest(request));
+                    var url = BuildModelUrl(modelId, "converse-stream");
+                    var httpRequest = BuildRequest(HttpMethod.Post, url, payload, RuntimeService, apiKey);
+
+                    response = await httpClient.SendAsync(
+                        httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                    await ThrowOnErrorAsync(response, "streaming chat completion", cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    instrumentation.RecordFailure(nameof(OperationCanceledException));
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    instrumentation.RecordFailure(ex.GetType().Name);
+                    throw;
+                }
+
+                var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                var created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                var streamId = $"bedrock-{Guid.NewGuid():N}";
+                // Maps Bedrock content block index -> OpenAI tool call index.
+                var toolCallIndexByBlock = new Dictionary<int, int>();
+                var reportedUsage = false;
+
+                await foreach (var message in AwsEventStreamReader.ReadMessagesAsync(stream, cancellationToken))
+                {
+                    if (message.MessageType == "exception" || message.ExceptionType != null)
+                    {
+                        var error = ExtractErrorFromJson(message.PayloadText, message.PayloadText);
+                        instrumentation.RecordFailure(message.ExceptionType ?? "BedrockStreamException");
+                        throw new LLMCommunicationException(
+                            $"Bedrock streaming error ({message.ExceptionType ?? "exception"}): {error}");
+                    }
+
+                    var chunk = MapStreamEvent(message, streamId, created, modelId, toolCallIndexByBlock);
+                    if (chunk == null)
+                    {
+                        continue;
+                    }
+
+                    if (!reportedUsage && chunk.Usage != null)
+                    {
+                        RecordUsage(chunk.Usage, "StreamChatCompletion");
+                        reportedUsage = true;
+                    }
+
+                    instrumentation.RecordChunk();
+                    yield return chunk;
+                }
+            }
+            finally
+            {
+                response?.Dispose();
+                httpClient?.Dispose();
+                instrumentation.Dispose();
+            }
+        }
+
+        private ChatCompletionChunk? MapStreamEvent(
+            AwsEventStreamMessage message,
+            string streamId,
+            long created,
+            string modelId,
+            Dictionary<int, int> toolCallIndexByBlock)
+        {
+            switch (message.EventType)
+            {
+                case "messageStart":
+                    return CreateChunk(streamId, created, modelId,
+                        new DeltaContent { Role = MessageRole.Assistant });
+
+                case "contentBlockStart":
+                {
+                    var start = Deserialize<BedrockStreamContentBlockStart>(message);
+                    if (start?.Start?.ToolUse is not { } toolUse)
+                    {
+                        return null;
+                    }
+
+                    var toolIndex = toolCallIndexByBlock.Count;
+                    toolCallIndexByBlock[start.ContentBlockIndex] = toolIndex;
+                    return CreateChunk(streamId, created, modelId, new DeltaContent
+                    {
+                        ToolCalls = new List<ToolCallChunk>
+                        {
+                            new()
+                            {
+                                Index = toolIndex,
+                                Id = toolUse.ToolUseId,
+                                Type = "function",
+                                Function = new FunctionCallChunk { Name = toolUse.Name, Arguments = string.Empty }
+                            }
+                        }
+                    });
+                }
+
+                case "contentBlockDelta":
+                {
+                    var delta = Deserialize<BedrockStreamContentBlockDelta>(message);
+                    if (delta?.Delta?.Text is { Length: > 0 } text)
+                    {
+                        return CreateChunk(streamId, created, modelId, new DeltaContent { Content = text });
+                    }
+
+                    if (delta?.Delta?.ReasoningContent?.Text is { Length: > 0 } reasoning)
+                    {
+                        return CreateChunk(streamId, created, modelId, new DeltaContent { Reasoning = reasoning });
+                    }
+
+                    if (delta?.Delta?.ToolUse?.Input is { Length: > 0 } arguments)
+                    {
+                        var toolIndex = toolCallIndexByBlock.GetValueOrDefault(delta.ContentBlockIndex, 0);
+                        return CreateChunk(streamId, created, modelId, new DeltaContent
+                        {
+                            ToolCalls = new List<ToolCallChunk>
+                            {
+                                new()
+                                {
+                                    Index = toolIndex,
+                                    Function = new FunctionCallChunk { Arguments = arguments }
+                                }
+                            }
+                        });
+                    }
+
+                    return null;
+                }
+
+                case "messageStop":
+                {
+                    var stop = Deserialize<BedrockStreamMessageStop>(message);
+                    var chunk = CreateChunk(streamId, created, modelId, new DeltaContent());
+                    chunk.Choices[0].FinishReason = MapStopReason(stop?.StopReason);
+                    return chunk;
+                }
+
+                case "metadata":
+                {
+                    var metadata = Deserialize<BedrockStreamMetadata>(message);
+                    if (metadata?.Usage is not { } usage)
+                    {
+                        return null;
+                    }
+
+                    var chunk = CreateChunk(streamId, created, modelId, new DeltaContent());
+                    chunk.Usage = new Usage
+                    {
+                        PromptTokens = usage.InputTokens,
+                        CompletionTokens = usage.OutputTokens,
+                        TotalTokens = usage.TotalTokens
+                            ?? (usage.InputTokens ?? 0) + (usage.OutputTokens ?? 0)
+                    };
+                    return chunk;
+                }
+
+                case "contentBlockStop":
+                    return null;
+
+                default:
+                    Logger.LogDebug("Ignoring unrecognized Bedrock stream event type {EventType}", message.EventType);
+                    return null;
+            }
+        }
+
+        private T? Deserialize<T>(AwsEventStreamMessage message) where T : class
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<T>(message.Payload, DefaultJsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                Logger.LogWarning(ex, "Failed to parse Bedrock stream event {EventType}", message.EventType);
+                return null;
+            }
+        }
+
+        private static ChatCompletionChunk CreateChunk(string id, long created, string modelId, DeltaContent delta) =>
+            new()
+            {
+                Id = id,
+                Object = "chat.completion.chunk",
+                Created = created,
+                Model = modelId,
+                Choices = new List<StreamingChoice> { new() { Index = 0, Delta = delta } }
+            };
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.cs
@@ -1,0 +1,219 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Providers.Authentication;
+using ConduitLLM.Providers.Configuration;
+
+using Microsoft.Extensions.Logging;
+
+namespace ConduitLLM.Providers.Bedrock
+{
+    /// <summary>
+    /// Client for Amazon Bedrock via the model-agnostic Converse API.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Bedrock is the first consumer of the multi-secret credential mechanism from epic #1177:
+    /// the key credential's <c>ApiKey</c> holds either an IAM access key ID (paired with the
+    /// <c>secret_access_key</c> / optional <c>session_token</c> secret settings, requests signed
+    /// with SigV4) or a Bedrock API key (sent as a Bearer token when no secret access key is
+    /// configured). The AWS region is a provider-level structured setting that both builds the
+    /// endpoint host and scopes the signature.
+    /// </para>
+    /// <para>
+    /// Signing covers the exact request bytes, so this client builds and authenticates each
+    /// <see cref="HttpRequestMessage"/> itself rather than relying on client-level default headers.
+    /// </para>
+    /// </remarks>
+    public partial class BedrockClient : BaseLLMClient
+    {
+        internal const string RuntimeService = "bedrock-runtime";
+        internal const string ControlPlaneService = "bedrock";
+        private const string SecretAccessKeySetting = "secret_access_key";
+        private const string SessionTokenSetting = "session_token";
+
+        private readonly string _region;
+        private readonly string _runtimeBaseUrl;
+        private readonly string _controlPlaneBaseUrl;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BedrockClient"/> class.
+        /// </summary>
+        /// <param name="provider">The provider entity carrying the region setting and optional base URL override.</param>
+        /// <param name="keyCredential">The key credential; secret settings must already be revealed to plaintext.</param>
+        /// <param name="providerModelId">The Bedrock model ID or inference profile ID.</param>
+        /// <param name="logger">The logger for diagnostic information.</param>
+        /// <param name="httpClientFactory">The HTTP client factory.</param>
+        public BedrockClient(
+            Provider provider,
+            ProviderKeyCredential keyCredential,
+            string providerModelId,
+            ILogger<BedrockClient> logger,
+            IHttpClientFactory httpClientFactory)
+            : base(provider, keyCredential, providerModelId, logger, httpClientFactory, "bedrock")
+        {
+            _region = ProviderConfigurationRegistry.GetSettingValue(provider.ProviderType, provider.Settings, "region")
+                ?? throw new ConfigurationException(
+                    "Bedrock is missing required configuration: AWS Region. Provide the value in the provider settings.");
+
+            _runtimeBaseUrl = ProviderConfigurationRegistry.ResolveBaseUrl(provider);
+
+            // The control plane (model listing) lives on the sibling bedrock.<region> host. When an
+            // operator overrides the base URL (a proxy or PrivateLink endpoint), the runtime host is
+            // rewritten when it carries the bedrock-runtime marker; otherwise the override is used
+            // as-is and is expected to front both APIs.
+            _controlPlaneBaseUrl = _runtimeBaseUrl.Contains(RuntimeService, StringComparison.OrdinalIgnoreCase)
+                ? _runtimeBaseUrl.Replace(RuntimeService, ControlPlaneService, StringComparison.OrdinalIgnoreCase)
+                : _runtimeBaseUrl;
+        }
+
+        /// <summary>
+        /// Validates that the credential expresses one of the two supported authentication shapes.
+        /// </summary>
+        protected override void ValidateCredentials()
+        {
+            base.ValidateCredentials();
+
+            // An IAM access key ID without its secret can never authenticate; failing here names the
+            // missing field instead of letting AWS return an opaque 403 at request time.
+            if (!UsesSigV4 && LooksLikeAccessKeyId(PrimaryKeyCredential.ApiKey))
+            {
+                throw new ConfigurationException(
+                    "Bedrock is missing required configuration: Secret Access Key. The API key looks like an "
+                    + "IAM access key ID, which must be paired with its secret access key on the key credential. "
+                    + "Alternatively, use a Bedrock API key as the API key and leave the secret settings empty.");
+            }
+        }
+
+        private static bool LooksLikeAccessKeyId(string? apiKey) =>
+            apiKey != null && (apiKey.StartsWith("AKIA", StringComparison.Ordinal)
+                || apiKey.StartsWith("ASIA", StringComparison.Ordinal));
+
+        /// <summary>Whether requests are signed with SigV4 (a secret access key is configured).</summary>
+        private bool UsesSigV4 => !string.IsNullOrWhiteSpace(GetSecretSetting(SecretAccessKeySetting));
+
+        private string? GetSecretSetting(string key) =>
+            PrimaryKeyCredential.SecretSettings is { } secrets && secrets.TryGetValue(key, out var value)
+                && !string.IsNullOrWhiteSpace(value)
+                ? value
+                : null;
+
+        /// <summary>
+        /// Builds and authenticates a Bedrock request. SigV4 signs the exact payload bytes; Bearer
+        /// mode attaches the Bedrock API key. The optional per-call API key override replaces the
+        /// access key ID (SigV4) or the API key (Bearer) while keeping the configured secrets.
+        /// </summary>
+        internal HttpRequestMessage BuildRequest(
+            HttpMethod method,
+            string url,
+            byte[]? payload,
+            string service,
+            string? apiKeyOverride = null)
+        {
+            var request = new HttpRequestMessage(method, url);
+            if (payload != null)
+            {
+                var content = new ByteArrayContent(payload);
+                content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                request.Content = content;
+            }
+
+            var effectiveApiKey = !string.IsNullOrWhiteSpace(apiKeyOverride)
+                ? apiKeyOverride
+                : PrimaryKeyCredential.ApiKey!;
+
+            if (UsesSigV4)
+            {
+                AwsSigV4Signer.Sign(
+                    request,
+                    payload ?? Array.Empty<byte>(),
+                    new AwsSigV4Credentials(
+                        effectiveApiKey,
+                        GetSecretSetting(SecretAccessKeySetting)!,
+                        GetSecretSetting(SessionTokenSetting)),
+                    _region,
+                    service,
+                    DateTimeOffset.UtcNow);
+            }
+            else
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", effectiveApiKey);
+            }
+
+            return request;
+        }
+
+        /// <summary>
+        /// Serializes a Bedrock request body with the client's camelCase conventions.
+        /// </summary>
+        internal static byte[] SerializePayload<T>(T body) =>
+            JsonSerializer.SerializeToUtf8Bytes(body, DefaultJsonOptions);
+
+        /// <summary>
+        /// Authentication is applied per request (SigV4 covers the payload), so no client-level
+        /// authentication header is configured.
+        /// </summary>
+        protected override void ConfigureAuthentication(HttpClient client, string apiKey)
+        {
+            // Intentionally empty: BuildRequest attaches the Authorization header per request.
+        }
+
+        /// <summary>
+        /// Raises a communication error carrying Bedrock's error message and status code so the
+        /// shared classifier can produce an actionable connection-test result.
+        /// </summary>
+        private async Task ThrowOnErrorAsync(HttpResponseMessage response, string operation, CancellationToken cancellationToken)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var message = ExtractErrorFromJson(body, $"{(int)response.StatusCode} ({response.StatusCode})");
+            throw new LLMCommunicationException(
+                $"Bedrock {operation} failed: {message} [HTTP {(int)response.StatusCode}]",
+                response.StatusCode,
+                body);
+        }
+
+        /// <summary>The runtime endpoint for a model-scoped action such as <c>converse</c>.</summary>
+        internal string BuildModelUrl(string modelId, string action) =>
+            $"{_runtimeBaseUrl}/model/{Uri.EscapeDataString(modelId)}/{action}";
+
+        /// <summary>The control-plane endpoint for foundation-model discovery.</summary>
+        internal string BuildFoundationModelsUrl() => $"{_controlPlaneBaseUrl}/foundation-models";
+
+        /// <inheritdoc />
+        public override string GetHealthCheckUrl(string? baseUrl = null) =>
+            !string.IsNullOrWhiteSpace(baseUrl)
+                ? $"{baseUrl.TrimEnd('/')}/foundation-models"
+                : BuildFoundationModelsUrl();
+
+        /// <inheritdoc />
+        public override Task<EmbeddingResponse> CreateEmbeddingAsync(
+            EmbeddingRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException(
+                "The Bedrock adapter does not support embeddings; Bedrock embedding models use "
+                + "model-specific InvokeModel payloads rather than the Converse API.");
+        }
+
+        /// <inheritdoc />
+        public override Task<ImageGenerationResponse> CreateImageAsync(
+            ImageGenerationRequest request,
+            string? apiKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException(
+                "The Bedrock adapter does not support image generation; Bedrock image models use "
+                + "model-specific InvokeModel payloads rather than the Converse API.");
+        }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockModels.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockModels.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ConduitLLM.Providers.Bedrock
+{
+    /// <summary>
+    /// Wire models for the Amazon Bedrock Converse and control-plane REST APIs. Bedrock JSON is
+    /// camelCase; these serialize with the client's camelCase options and omit nulls.
+    /// </summary>
+    internal class BedrockConverseRequest
+    {
+        public List<BedrockMessage> Messages { get; set; } = new();
+        public List<BedrockSystemBlock>? System { get; set; }
+        public BedrockInferenceConfig? InferenceConfig { get; set; }
+        public BedrockToolConfig? ToolConfig { get; set; }
+
+        /// <summary>Model-native pass-through fields (for example Anthropic's <c>top_k</c>).</summary>
+        public Dictionary<string, JsonElement>? AdditionalModelRequestFields { get; set; }
+    }
+
+    internal class BedrockSystemBlock
+    {
+        public string? Text { get; set; }
+    }
+
+    internal class BedrockMessage
+    {
+        public string Role { get; set; } = "user";
+        public List<BedrockContentBlock> Content { get; set; } = new();
+    }
+
+    /// <summary>
+    /// A Converse content block. Exactly one member is set per block.
+    /// </summary>
+    internal class BedrockContentBlock
+    {
+        public string? Text { get; set; }
+        public BedrockImageBlock? Image { get; set; }
+        public BedrockToolUseBlock? ToolUse { get; set; }
+        public BedrockToolResultBlock? ToolResult { get; set; }
+        public JsonElement? Json { get; set; }
+    }
+
+    internal class BedrockImageBlock
+    {
+        public string Format { get; set; } = "png";
+        public BedrockImageSource Source { get; set; } = new();
+    }
+
+    internal class BedrockImageSource
+    {
+        /// <summary>Base64-encoded image data (the REST API carries bytes fields as base64 strings).</summary>
+        public string? Bytes { get; set; }
+    }
+
+    internal class BedrockToolUseBlock
+    {
+        public string ToolUseId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public JsonElement Input { get; set; }
+    }
+
+    internal class BedrockToolResultBlock
+    {
+        public string ToolUseId { get; set; } = string.Empty;
+        public List<BedrockContentBlock> Content { get; set; } = new();
+    }
+
+    internal class BedrockInferenceConfig
+    {
+        public int? MaxTokens { get; set; }
+        public double? Temperature { get; set; }
+        public double? TopP { get; set; }
+        public List<string>? StopSequences { get; set; }
+    }
+
+    internal class BedrockToolConfig
+    {
+        public List<BedrockTool> Tools { get; set; } = new();
+        public BedrockToolChoice? ToolChoice { get; set; }
+    }
+
+    internal class BedrockTool
+    {
+        public BedrockToolSpec ToolSpec { get; set; } = new();
+    }
+
+    internal class BedrockToolSpec
+    {
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public BedrockToolInputSchema? InputSchema { get; set; }
+    }
+
+    internal class BedrockToolInputSchema
+    {
+        public JsonElement Json { get; set; }
+    }
+
+    /// <summary>Exactly one member is set: <c>auto</c>, <c>any</c>, or a named <c>tool</c>.</summary>
+    internal class BedrockToolChoice
+    {
+        public object? Auto { get; set; }
+        public object? Any { get; set; }
+        public BedrockNamedToolChoice? Tool { get; set; }
+    }
+
+    internal class BedrockNamedToolChoice
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal class BedrockConverseResponse
+    {
+        public BedrockConverseOutput? Output { get; set; }
+        public string? StopReason { get; set; }
+        public BedrockUsage? Usage { get; set; }
+    }
+
+    internal class BedrockConverseOutput
+    {
+        public BedrockMessage? Message { get; set; }
+    }
+
+    internal class BedrockUsage
+    {
+        public int? InputTokens { get; set; }
+        public int? OutputTokens { get; set; }
+        public int? TotalTokens { get; set; }
+    }
+
+    // ---- ConverseStream event payloads ----
+
+    internal class BedrockStreamMessageStart
+    {
+        public string? Role { get; set; }
+    }
+
+    internal class BedrockStreamContentBlockStart
+    {
+        public int ContentBlockIndex { get; set; }
+        public BedrockStreamBlockStart? Start { get; set; }
+    }
+
+    internal class BedrockStreamBlockStart
+    {
+        public BedrockStreamToolUseStart? ToolUse { get; set; }
+    }
+
+    internal class BedrockStreamToolUseStart
+    {
+        public string? ToolUseId { get; set; }
+        public string? Name { get; set; }
+    }
+
+    internal class BedrockStreamContentBlockDelta
+    {
+        public int ContentBlockIndex { get; set; }
+        public BedrockStreamDelta? Delta { get; set; }
+    }
+
+    internal class BedrockStreamDelta
+    {
+        public string? Text { get; set; }
+        public BedrockStreamToolUseDelta? ToolUse { get; set; }
+        public BedrockStreamReasoningDelta? ReasoningContent { get; set; }
+    }
+
+    internal class BedrockStreamToolUseDelta
+    {
+        /// <summary>A fragment of the tool input JSON, streamed as text.</summary>
+        public string? Input { get; set; }
+    }
+
+    internal class BedrockStreamReasoningDelta
+    {
+        public string? Text { get; set; }
+    }
+
+    internal class BedrockStreamMessageStop
+    {
+        public string? StopReason { get; set; }
+    }
+
+    internal class BedrockStreamMetadata
+    {
+        public BedrockUsage? Usage { get; set; }
+    }
+
+    // ---- Control plane (ListFoundationModels) ----
+
+    internal class BedrockListFoundationModelsResponse
+    {
+        public List<BedrockFoundationModelSummary>? ModelSummaries { get; set; }
+    }
+
+    internal class BedrockFoundationModelSummary
+    {
+        public string? ModelId { get; set; }
+        public string? ModelName { get; set; }
+        public string? ProviderName { get; set; }
+        public List<string>? OutputModalities { get; set; }
+        public bool? ResponseStreamingSupported { get; set; }
+    }
+
+    /// <summary>Bedrock error envelope (<c>{"message": "..."}</c>).</summary>
+    internal class BedrockErrorResponse
+    {
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+    }
+}

--- a/Shared/ConduitLLM.Providers/Streaming/AwsEventStreamReader.cs
+++ b/Shared/ConduitLLM.Providers/Streaming/AwsEventStreamReader.cs
@@ -1,0 +1,234 @@
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace ConduitLLM.Providers.Streaming
+{
+    /// <summary>
+    /// A single decoded message from an AWS <c>application/vnd.amazon.eventstream</c> response.
+    /// </summary>
+    public sealed record AwsEventStreamMessage(
+        IReadOnlyDictionary<string, string> Headers,
+        byte[] Payload)
+    {
+        /// <summary>The <c>:message-type</c> header (<c>event</c> or <c>exception</c>), if present.</summary>
+        public string? MessageType => Headers.GetValueOrDefault(":message-type");
+
+        /// <summary>The <c>:event-type</c> header naming the event (for example <c>contentBlockDelta</c>).</summary>
+        public string? EventType => Headers.GetValueOrDefault(":event-type");
+
+        /// <summary>The <c>:exception-type</c> header naming the modeled exception, if this message is one.</summary>
+        public string? ExceptionType => Headers.GetValueOrDefault(":exception-type");
+
+        /// <summary>The payload decoded as UTF-8 text (event payloads are JSON documents).</summary>
+        public string PayloadText => Encoding.UTF8.GetString(Payload);
+    }
+
+    /// <summary>
+    /// Decodes the AWS event-stream binary framing (<c>application/vnd.amazon.eventstream</c>) used
+    /// by streaming Bedrock APIs such as <c>ConverseStream</c>. Unlike SSE there is no textual
+    /// delimiter: each message is a length-prefixed frame with CRC-protected prelude and body.
+    /// </summary>
+    /// <remarks>
+    /// Frame layout: 4-byte big-endian total length, 4-byte headers length, 4-byte CRC32 of those
+    /// 8 bytes, the headers block, the payload, and a trailing 4-byte CRC32 of everything before it.
+    /// Each header is a length-prefixed name, a value-type byte, and a type-dependent value.
+    /// Both CRCs are validated; a mismatch means the stream is corrupt and raises
+    /// <see cref="InvalidDataException"/> rather than yielding garbled events.
+    /// </remarks>
+    public static class AwsEventStreamReader
+    {
+        private const int PreludeLength = 12;
+        private const int MaxFrameLength = 16 * 1024 * 1024;
+
+        /// <summary>
+        /// Reads and decodes messages from the stream until it ends.
+        /// </summary>
+        /// <param name="stream">The raw response stream positioned at the first frame.</param>
+        /// <param name="cancellationToken">A token to cancel the read.</param>
+        /// <returns>The decoded messages in stream order.</returns>
+        /// <exception cref="InvalidDataException">Thrown when a frame is malformed or fails CRC validation.</exception>
+        public static async IAsyncEnumerable<AwsEventStreamMessage> ReadMessagesAsync(
+            Stream stream,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var prelude = new byte[PreludeLength];
+            while (true)
+            {
+                var read = await ReadBlockAsync(stream, prelude, cancellationToken);
+                if (read == 0)
+                {
+                    yield break;
+                }
+                if (read < PreludeLength)
+                {
+                    throw new InvalidDataException("AWS event stream ended mid-frame while reading the prelude.");
+                }
+
+                var totalLength = BinaryPrimitives.ReadUInt32BigEndian(prelude.AsSpan(0, 4));
+                var headersLength = BinaryPrimitives.ReadUInt32BigEndian(prelude.AsSpan(4, 4));
+                var preludeCrc = BinaryPrimitives.ReadUInt32BigEndian(prelude.AsSpan(8, 4));
+
+                if (Crc32.Compute(prelude.AsSpan(0, 8)) != preludeCrc)
+                {
+                    throw new InvalidDataException("AWS event stream prelude failed CRC validation.");
+                }
+                if (totalLength < PreludeLength + 4 || totalLength > MaxFrameLength
+                    || headersLength > totalLength - PreludeLength - 4)
+                {
+                    throw new InvalidDataException(
+                        $"AWS event stream frame has inconsistent lengths (total {totalLength}, headers {headersLength}).");
+                }
+
+                var remainder = new byte[totalLength - PreludeLength];
+                if (await ReadBlockAsync(stream, remainder, cancellationToken) < remainder.Length)
+                {
+                    throw new InvalidDataException("AWS event stream ended mid-frame while reading the body.");
+                }
+
+                var messageCrc = BinaryPrimitives.ReadUInt32BigEndian(remainder.AsSpan(remainder.Length - 4, 4));
+                var crc = Crc32.Append(Crc32.Compute(prelude), remainder.AsSpan(0, remainder.Length - 4));
+                if (crc != messageCrc)
+                {
+                    throw new InvalidDataException("AWS event stream message failed CRC validation.");
+                }
+
+                var headers = ParseHeaders(remainder.AsSpan(0, (int)headersLength));
+                var payload = remainder.AsSpan((int)headersLength, remainder.Length - (int)headersLength - 4).ToArray();
+                yield return new AwsEventStreamMessage(headers, payload);
+            }
+        }
+
+        private static async Task<int> ReadBlockAsync(Stream stream, byte[] buffer, CancellationToken cancellationToken)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(offset), cancellationToken);
+                if (read == 0)
+                {
+                    break;
+                }
+                offset += read;
+            }
+
+            return offset;
+        }
+
+        private static IReadOnlyDictionary<string, string> ParseHeaders(ReadOnlySpan<byte> block)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
+            var offset = 0;
+            while (offset < block.Length)
+            {
+                var nameLength = block[offset];
+                offset += 1;
+                RequireBytes(block, offset, nameLength);
+                var name = Encoding.UTF8.GetString(block.Slice(offset, nameLength));
+                offset += nameLength;
+
+                RequireBytes(block, offset, 1);
+                var valueType = block[offset];
+                offset += 1;
+
+                string value;
+                switch (valueType)
+                {
+                    case 0: // bool true
+                        value = "true";
+                        break;
+                    case 1: // bool false
+                        value = "false";
+                        break;
+                    case 2: // byte
+                        RequireBytes(block, offset, 1);
+                        value = ((sbyte)block[offset]).ToString();
+                        offset += 1;
+                        break;
+                    case 3: // int16
+                        RequireBytes(block, offset, 2);
+                        value = BinaryPrimitives.ReadInt16BigEndian(block.Slice(offset, 2)).ToString();
+                        offset += 2;
+                        break;
+                    case 4: // int32
+                        RequireBytes(block, offset, 4);
+                        value = BinaryPrimitives.ReadInt32BigEndian(block.Slice(offset, 4)).ToString();
+                        offset += 4;
+                        break;
+                    case 5: // int64
+                    case 8: // timestamp (millis since epoch)
+                        RequireBytes(block, offset, 8);
+                        value = BinaryPrimitives.ReadInt64BigEndian(block.Slice(offset, 8)).ToString();
+                        offset += 8;
+                        break;
+                    case 6: // byte array
+                    case 7: // string
+                        RequireBytes(block, offset, 2);
+                        var length = BinaryPrimitives.ReadUInt16BigEndian(block.Slice(offset, 2));
+                        offset += 2;
+                        RequireBytes(block, offset, length);
+                        value = valueType == 7
+                            ? Encoding.UTF8.GetString(block.Slice(offset, length))
+                            : Convert.ToBase64String(block.Slice(offset, length));
+                        offset += length;
+                        break;
+                    case 9: // uuid
+                        RequireBytes(block, offset, 16);
+                        value = Convert.ToHexString(block.Slice(offset, 16)).ToLowerInvariant();
+                        offset += 16;
+                        break;
+                    default:
+                        throw new InvalidDataException($"AWS event stream header '{name}' has unknown value type {valueType}.");
+                }
+
+                headers[name] = value;
+            }
+
+            return headers;
+        }
+
+        private static void RequireBytes(ReadOnlySpan<byte> block, int offset, int count)
+        {
+            if (offset + count > block.Length)
+            {
+                throw new InvalidDataException("AWS event stream header block is truncated.");
+            }
+        }
+
+        /// <summary>
+        /// CRC-32 (IEEE 802.3, reflected polynomial 0xEDB88320) as used by the AWS event-stream
+        /// framing. Implemented locally to avoid a package dependency for 20 lines of table lookup.
+        /// </summary>
+        internal static class Crc32
+        {
+            private static readonly uint[] Table = BuildTable();
+
+            private static uint[] BuildTable()
+            {
+                var table = new uint[256];
+                for (uint i = 0; i < 256; i++)
+                {
+                    var crc = i;
+                    for (var bit = 0; bit < 8; bit++)
+                    {
+                        crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320u : crc >> 1;
+                    }
+                    table[i] = crc;
+                }
+                return table;
+            }
+
+            public static uint Compute(ReadOnlySpan<byte> data) => Append(0, data);
+
+            public static uint Append(uint crc, ReadOnlySpan<byte> data)
+            {
+                var value = ~crc;
+                foreach (var b in data)
+                {
+                    value = (value >> 8) ^ Table[(value ^ b) & 0xFF];
+                }
+                return ~value;
+            }
+        }
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsEventStreamReaderTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsEventStreamReaderTests.cs
@@ -1,0 +1,148 @@
+using System.Buffers.Binary;
+using System.Text;
+
+using ConduitLLM.Providers.Streaming;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Providers.Bedrock;
+
+/// <summary>
+/// Tests for the AWS event-stream (<c>application/vnd.amazon.eventstream</c>) frame decoder used by
+/// Bedrock's ConverseStream.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "Providers")]
+public class AwsEventStreamReaderTests
+{
+    [Fact]
+    public void Crc32_Matches_The_Published_Check_Value()
+    {
+        // CRC-32/IEEE check value: crc32("123456789") == 0xCBF43926.
+        AwsEventStreamReader.Crc32.Compute("123456789"u8.ToArray())
+            .Should().Be(0xCBF43926u);
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Decodes_A_Frame_With_Headers_And_Payload()
+    {
+        var frame = BuildFrame(
+            new Dictionary<string, string>
+            {
+                [":message-type"] = "event",
+                [":event-type"] = "contentBlockDelta"
+            },
+            """{"contentBlockIndex":0,"delta":{"text":"Hello"}}""");
+
+        var messages = await ReadAllAsync(new MemoryStream(frame));
+
+        var message = messages.Should().ContainSingle().Subject;
+        message.MessageType.Should().Be("event");
+        message.EventType.Should().Be("contentBlockDelta");
+        message.PayloadText.Should().Contain("Hello");
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Decodes_Consecutive_Frames_In_Order()
+    {
+        var first = BuildFrame(new() { [":event-type"] = "messageStart" }, """{"role":"assistant"}""");
+        var second = BuildFrame(new() { [":event-type"] = "messageStop" }, """{"stopReason":"end_turn"}""");
+        var stream = new MemoryStream(first.Concat(second).ToArray());
+
+        var messages = await ReadAllAsync(stream);
+
+        messages.Select(m => m.EventType).Should().Equal("messageStart", "messageStop");
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Rejects_A_Corrupted_Message_Crc()
+    {
+        var frame = BuildFrame(new() { [":event-type"] = "messageStart" }, "{}");
+        frame[^1] ^= 0xFF;
+
+        var act = () => ReadAllAsync(new MemoryStream(frame));
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*CRC*");
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Rejects_A_Corrupted_Prelude()
+    {
+        var frame = BuildFrame(new() { [":event-type"] = "messageStart" }, "{}");
+        frame[9] ^= 0xFF; // inside the prelude CRC
+
+        var act = () => ReadAllAsync(new MemoryStream(frame));
+
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Rejects_A_Truncated_Frame()
+    {
+        var frame = BuildFrame(new() { [":event-type"] = "messageStart" }, """{"role":"assistant"}""");
+
+        var act = () => ReadAllAsync(new MemoryStream(frame[..^6]));
+
+        await act.Should().ThrowAsync<InvalidDataException>()
+            .WithMessage("*mid-frame*");
+    }
+
+    [Fact]
+    public async Task ReadMessagesAsync_Returns_Nothing_For_An_Empty_Stream()
+    {
+        var messages = await ReadAllAsync(new MemoryStream());
+
+        messages.Should().BeEmpty();
+    }
+
+    private static async Task<List<AwsEventStreamMessage>> ReadAllAsync(Stream stream)
+    {
+        var messages = new List<AwsEventStreamMessage>();
+        await foreach (var message in AwsEventStreamReader.ReadMessagesAsync(stream))
+        {
+            messages.Add(message);
+        }
+        return messages;
+    }
+
+    /// <summary>
+    /// Builds a spec-conformant event-stream frame: 12-byte prelude (total length, headers length,
+    /// prelude CRC), string-typed headers, payload, and the trailing message CRC.
+    /// </summary>
+    internal static byte[] BuildFrame(Dictionary<string, string> headers, string payload)
+    {
+        using var headerStream = new MemoryStream();
+        foreach (var (name, value) in headers)
+        {
+            var nameBytes = Encoding.UTF8.GetBytes(name);
+            var valueBytes = Encoding.UTF8.GetBytes(value);
+            headerStream.WriteByte((byte)nameBytes.Length);
+            headerStream.Write(nameBytes);
+            headerStream.WriteByte(7); // value type: string
+            Span<byte> length = stackalloc byte[2];
+            BinaryPrimitives.WriteUInt16BigEndian(length, (ushort)valueBytes.Length);
+            headerStream.Write(length);
+            headerStream.Write(valueBytes);
+        }
+
+        var headerBytes = headerStream.ToArray();
+        var payloadBytes = Encoding.UTF8.GetBytes(payload);
+        var totalLength = 12 + headerBytes.Length + payloadBytes.Length + 4;
+
+        var frame = new byte[totalLength];
+        BinaryPrimitives.WriteUInt32BigEndian(frame.AsSpan(0, 4), (uint)totalLength);
+        BinaryPrimitives.WriteUInt32BigEndian(frame.AsSpan(4, 4), (uint)headerBytes.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(
+            frame.AsSpan(8, 4), AwsEventStreamReader.Crc32.Compute(frame.AsSpan(0, 8)));
+        headerBytes.CopyTo(frame.AsSpan(12));
+        payloadBytes.CopyTo(frame.AsSpan(12 + headerBytes.Length));
+        BinaryPrimitives.WriteUInt32BigEndian(
+            frame.AsSpan(totalLength - 4, 4),
+            AwsEventStreamReader.Crc32.Compute(frame.AsSpan(0, totalLength - 4)));
+
+        return frame;
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsSigV4SignerTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsSigV4SignerTests.cs
@@ -1,0 +1,115 @@
+using System.Net.Http.Headers;
+
+using ConduitLLM.Providers.Authentication;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Providers.Bedrock;
+
+/// <summary>
+/// Tests for the AWS Signature Version 4 implementation used by the Bedrock adapter.
+/// The primary case reproduces the worked example from the AWS signing documentation
+/// (GET iam.amazonaws.com ListUsers with the AKIDEXAMPLE credentials), whose signature is a
+/// published known-good value.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "Providers")]
+public class AwsSigV4SignerTests
+{
+    private static readonly AwsSigV4Credentials DocCredentials = new(
+        "AKIDEXAMPLE",
+        "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+
+    private static readonly DateTimeOffset DocSigningTime =
+        new(2015, 8, 30, 12, 36, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Sign_Reproduces_The_AWS_Documentation_Example_Signature()
+    {
+        // GET https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08 with an empty body and
+        // a signed content-type header, per the SigV4 documentation walkthrough.
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08");
+        request.Content = new ByteArrayContent(Array.Empty<byte>());
+        request.Content.Headers.ContentType =
+            MediaTypeHeaderValue.Parse("application/x-www-form-urlencoded; charset=utf-8");
+
+        AwsSigV4Signer.Sign(request, Array.Empty<byte>(), DocCredentials, "us-east-1", "iam", DocSigningTime);
+
+        var authorization = request.Headers.GetValues("Authorization").Single();
+        authorization.Should().Be(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+            + "SignedHeaders=content-type;host;x-amz-date, "
+            + "Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7");
+        request.Headers.GetValues("x-amz-date").Single().Should().Be("20150830T123600Z");
+        request.Headers.Host.Should().Be("iam.amazonaws.com");
+    }
+
+    [Fact]
+    public void Sign_With_Session_Token_Adds_And_Signs_The_Security_Token_Header()
+    {
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/test/converse");
+        var credentials = DocCredentials with { SessionToken = "the-session-token" };
+
+        AwsSigV4Signer.Sign(request, Array.Empty<byte>(), credentials, "us-east-1", "bedrock-runtime", DocSigningTime);
+
+        request.Headers.GetValues("x-amz-security-token").Single().Should().Be("the-session-token");
+        request.Headers.GetValues("Authorization").Single()
+            .Should().Contain("SignedHeaders=host;x-amz-date;x-amz-security-token");
+    }
+
+    [Fact]
+    public void Sign_Is_Deterministic_For_Identical_Inputs()
+    {
+        HttpRequestMessage Build()
+        {
+            var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                "https://bedrock-runtime.eu-west-1.amazonaws.com/model/m/converse");
+            AwsSigV4Signer.Sign(
+                request,
+                "{\"messages\":[]}"u8.ToArray(),
+                DocCredentials,
+                "eu-west-1",
+                "bedrock-runtime",
+                DocSigningTime);
+            return request;
+        }
+
+        Build().Headers.GetValues("Authorization").Single()
+            .Should().Be(Build().Headers.GetValues("Authorization").Single());
+    }
+
+    [Fact]
+    public void BuildCanonicalPath_Double_Encodes_Percent_Encoded_Segments()
+    {
+        // Bedrock model IDs contain ':' which is %3A on the wire; SigV4 for non-S3 services
+        // canonicalizes the once-encoded path by encoding it again (%3A -> %253A).
+        var uri = new Uri("https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v1%3A0/converse");
+
+        AwsSigV4Signer.BuildCanonicalPath(uri)
+            .Should().Be("/model/anthropic.claude-v1%253A0/converse");
+    }
+
+    [Fact]
+    public void BuildCanonicalPath_Keeps_Unreserved_Characters_And_Slashes()
+    {
+        var uri = new Uri("https://bedrock.us-east-1.amazonaws.com/foundation-models");
+
+        AwsSigV4Signer.BuildCanonicalPath(uri).Should().Be("/foundation-models");
+    }
+
+    [Fact]
+    public void BuildCanonicalQuery_Sorts_Parameters_And_Percent_Encodes_Strictly()
+    {
+        var uri = new Uri("https://example.amazonaws.com/?zeta=z%20value&Action=ListUsers");
+
+        AwsSigV4Signer.BuildCanonicalQuery(uri)
+            .Should().Be("Action=ListUsers&zeta=z%20value");
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockClientTests.cs
@@ -1,0 +1,435 @@
+using System.Net;
+using System.Text;
+
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Providers.Bedrock;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+using Moq.Protected;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Providers.Bedrock;
+
+/// <summary>
+/// Tests for <see cref="BedrockClient"/>: credential-shape validation, per-request SigV4/Bearer
+/// authentication, Converse request/response mapping, streaming decode, and model discovery.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "Providers")]
+public class BedrockClientTests
+{
+    private const string Region = "us-east-1";
+    private const string ModelId = "anthropic.claude-sonnet-4-20250514-v1:0";
+
+    [Fact]
+    public void Constructor_Without_Region_Setting_Names_The_Missing_Field()
+    {
+        var act = () => CreateClient(CreateHandler(HttpStatusCode.OK, "{}"), settings: new());
+
+        act.Should().Throw<ConfigurationException>()
+            .WithMessage("*AWS Region*");
+    }
+
+    [Fact]
+    public void Constructor_With_Access_Key_Id_But_No_Secret_Names_The_Missing_Secret()
+    {
+        var act = () => CreateClient(
+            CreateHandler(HttpStatusCode.OK, "{}"),
+            apiKey: "AKIAIOSFODNN7EXAMPLE",
+            secretSettings: new());
+
+        act.Should().Throw<ConfigurationException>()
+            .WithMessage("*Secret Access Key*");
+    }
+
+    [Fact]
+    public void Constructor_With_Bedrock_Api_Key_And_No_Secrets_Is_Valid()
+    {
+        var act = () => CreateClient(
+            CreateHandler(HttpStatusCode.OK, "{}"),
+            apiKey: "bedrock-api-key-value",
+            secretSettings: new());
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task Chat_Posts_To_The_Converse_Endpoint_With_The_Model_Id_Escaped()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = CreateHandler(HttpStatusCode.OK, ConverseResponseJson("Hi"), req => captured = req);
+        var client = CreateClient(handler);
+
+        await client.CreateChatCompletionAsync(ChatRequest());
+
+        captured.Should().NotBeNull();
+        captured!.Method.Should().Be(HttpMethod.Post);
+        captured.RequestUri!.AbsoluteUri.Should().Be(
+            $"https://bedrock-runtime.{Region}.amazonaws.com/model/anthropic.claude-sonnet-4-20250514-v1%3A0/converse");
+    }
+
+    [Fact]
+    public async Task Chat_In_SigV4_Mode_Signs_The_Request()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = CreateHandler(HttpStatusCode.OK, ConverseResponseJson("Hi"), req => captured = req);
+        var client = CreateClient(
+            handler,
+            apiKey: "AKIAIOSFODNN7EXAMPLE",
+            secretSettings: new Dictionary<string, string>
+            {
+                ["secret_access_key"] = "secret",
+                ["session_token"] = "token"
+            });
+
+        await client.CreateChatCompletionAsync(ChatRequest());
+
+        var authorization = captured!.Headers.GetValues("Authorization").Single();
+        authorization.Should().StartWith("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/");
+        authorization.Should().Contain($"/{Region}/bedrock-runtime/aws4_request");
+        captured.Headers.Contains("x-amz-date").Should().BeTrue();
+        captured.Headers.GetValues("x-amz-security-token").Single().Should().Be("token");
+    }
+
+    [Fact]
+    public async Task Chat_In_Bearer_Mode_Sends_The_Api_Key_As_Bearer_Token()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = CreateHandler(HttpStatusCode.OK, ConverseResponseJson("Hi"), req => captured = req);
+        var client = CreateClient(handler, apiKey: "bedrock-api-key", secretSettings: null);
+
+        await client.CreateChatCompletionAsync(ChatRequest());
+
+        captured!.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        captured.Headers.Authorization.Parameter.Should().Be("bedrock-api-key");
+    }
+
+    [Fact]
+    public async Task Chat_Maps_Text_Usage_And_Stop_Reason()
+    {
+        var handler = CreateHandler(HttpStatusCode.OK, ConverseResponseJson("Hello there"));
+        var client = CreateClient(handler);
+
+        var response = await client.CreateChatCompletionAsync(ChatRequest());
+
+        response.Choices.Should().ContainSingle();
+        response.Choices[0].Message.Content.Should().Be("Hello there");
+        response.Choices[0].FinishReason.Should().Be("stop");
+        response.Usage!.PromptTokens.Should().Be(10);
+        response.Usage.CompletionTokens.Should().Be(20);
+        response.Usage.TotalTokens.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task Chat_Maps_Tool_Use_Blocks_To_Tool_Calls()
+    {
+        const string body = """
+        {
+          "output": { "message": { "role": "assistant", "content": [
+            { "toolUse": { "toolUseId": "tool-1", "name": "get_weather", "input": { "city": "Berlin" } } }
+          ] } },
+          "stopReason": "tool_use",
+          "usage": { "inputTokens": 5, "outputTokens": 7, "totalTokens": 12 }
+        }
+        """;
+        var client = CreateClient(CreateHandler(HttpStatusCode.OK, body));
+
+        var response = await client.CreateChatCompletionAsync(ChatRequest());
+
+        response.Choices[0].FinishReason.Should().Be("tool_calls");
+        var toolCall = response.Choices[0].Message.ToolCalls.Should().ContainSingle().Subject;
+        toolCall.Id.Should().Be("tool-1");
+        toolCall.Function.Name.Should().Be("get_weather");
+        toolCall.Function.Arguments.Should().Contain("Berlin");
+    }
+
+    [Fact]
+    public async Task Chat_Error_Surfaces_Bedrocks_Message_And_Status()
+    {
+        var handler = CreateHandler(
+            HttpStatusCode.Forbidden,
+            """{ "message": "The security token included in the request is invalid." }""");
+        var client = CreateClient(handler);
+
+        var act = () => client.CreateChatCompletionAsync(ChatRequest());
+
+        (await act.Should().ThrowAsync<LLMCommunicationException>())
+            .WithMessage("*security token*")
+            .WithMessage("*403*");
+    }
+
+    [Fact]
+    public void MapToConverseRequest_Extracts_System_Merges_Roles_And_Maps_Tool_Results()
+    {
+        var client = CreateClient(CreateHandler(HttpStatusCode.OK, "{}"));
+        var request = new ChatCompletionRequest
+        {
+            Model = ModelId,
+            Messages = new List<Message>
+            {
+                new() { Role = "system", Content = "Be terse." },
+                new() { Role = "user", Content = "What's the weather?" },
+                new()
+                {
+                    Role = "assistant",
+                    Content = null,
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new()
+                        {
+                            Id = "tool-1",
+                            Function = new FunctionCall { Name = "get_weather", Arguments = """{"city":"Berlin"}""" }
+                        }
+                    }
+                },
+                new() { Role = "tool", ToolCallId = "tool-1", Content = """{"temp_c": 21}""" },
+                new() { Role = "tool", ToolCallId = "tool-2", Content = "plain text result" }
+            }
+        };
+
+        var converse = client.MapToConverseRequest(request);
+
+        converse.System.Should().ContainSingle().Which.Text.Should().Be("Be terse.");
+        converse.Messages.Should().HaveCount(3, "the two consecutive tool results merge into one user message");
+        converse.Messages[0].Role.Should().Be("user");
+        converse.Messages[1].Role.Should().Be("assistant");
+        converse.Messages[1].Content.Should().ContainSingle(block => block.ToolUse != null);
+        converse.Messages[2].Role.Should().Be("user");
+        converse.Messages[2].Content.Should().HaveCount(2);
+        converse.Messages[2].Content[0].ToolResult!.ToolUseId.Should().Be("tool-1");
+        converse.Messages[2].Content[0].ToolResult!.Content[0].Json.Should().NotBeNull();
+        converse.Messages[2].Content[1].ToolResult!.Content[0].Text.Should().Be("plain text result");
+    }
+
+    [Fact]
+    public async Task GetModels_Queries_The_Control_Plane_Foundation_Models_Endpoint()
+    {
+        HttpRequestMessage? captured = null;
+        const string body = """
+        {
+          "modelSummaries": [
+            { "modelId": "anthropic.claude-sonnet-4-20250514-v1:0", "modelName": "Claude Sonnet 4", "providerName": "Anthropic" },
+            { "modelId": "amazon.nova-pro-v1:0", "modelName": "Nova Pro", "providerName": "Amazon" }
+          ]
+        }
+        """;
+        var client = CreateClient(CreateHandler(HttpStatusCode.OK, body, req => captured = req));
+
+        var models = await client.GetModelsAsync();
+
+        captured!.Method.Should().Be(HttpMethod.Get);
+        captured.RequestUri!.AbsoluteUri.Should().Be(
+            $"https://bedrock.{Region}.amazonaws.com/foundation-models");
+        models.Select(m => m.Id).Should().Contain(new[]
+        {
+            "anthropic.claude-sonnet-4-20250514-v1:0",
+            "amazon.nova-pro-v1:0"
+        });
+    }
+
+    [Fact]
+    public async Task VerifyAuthentication_Fails_With_The_Providers_Error_Message()
+    {
+        var handler = CreateHandler(
+            HttpStatusCode.Unauthorized,
+            """{ "message": "UnrecognizedClientException" }""");
+        var client = CreateClient(handler);
+
+        var result = await client.VerifyAuthenticationAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorDetails.Should().Contain("UnrecognizedClientException");
+    }
+
+    [Fact]
+    public async Task Streaming_Maps_Event_Stream_Frames_To_Chunks()
+    {
+        var frames = new[]
+        {
+            Frame("messageStart", """{"role":"assistant"}"""),
+            Frame("contentBlockDelta", """{"contentBlockIndex":0,"delta":{"text":"Hel"}}"""),
+            Frame("contentBlockDelta", """{"contentBlockIndex":0,"delta":{"text":"lo"}}"""),
+            Frame("messageStop", """{"stopReason":"end_turn"}"""),
+            Frame("metadata", """{"usage":{"inputTokens":3,"outputTokens":9,"totalTokens":12}}""")
+        };
+        var client = CreateClient(CreateStreamingHandler(frames));
+
+        var chunks = new List<ChatCompletionChunk>();
+        await foreach (var chunk in client.StreamChatCompletionAsync(ChatRequest()))
+        {
+            chunks.Add(chunk);
+        }
+
+        chunks.Should().HaveCount(5);
+        chunks[0].Choices[0].Delta.Role.Should().Be("assistant");
+        string.Concat(chunks.Select(c => c.Choices[0].Delta.Content)).Should().Be("Hello");
+        chunks[3].Choices[0].FinishReason.Should().Be("stop");
+        chunks[4].Usage!.TotalTokens.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Streaming_Assigns_Tool_Call_Indices_In_Order_Of_Appearance()
+    {
+        var frames = new[]
+        {
+            Frame("contentBlockStart", """{"contentBlockIndex":1,"start":{"toolUse":{"toolUseId":"t-1","name":"get_weather"}}}"""),
+            Frame("contentBlockDelta", """{"contentBlockIndex":1,"delta":{"toolUse":{"input":"{\"city\":"}}}"""),
+            Frame("contentBlockDelta", """{"contentBlockIndex":1,"delta":{"toolUse":{"input":"\"Berlin\"}"}}}"""),
+            Frame("messageStop", """{"stopReason":"tool_use"}""")
+        };
+        var client = CreateClient(CreateStreamingHandler(frames));
+
+        var chunks = new List<ChatCompletionChunk>();
+        await foreach (var chunk in client.StreamChatCompletionAsync(ChatRequest()))
+        {
+            chunks.Add(chunk);
+        }
+
+        chunks[0].Choices[0].Delta.ToolCalls![0].Id.Should().Be("t-1");
+        chunks[0].Choices[0].Delta.ToolCalls![0].Index.Should().Be(0);
+        chunks[0].Choices[0].Delta.ToolCalls![0].Function!.Name.Should().Be("get_weather");
+        var argumentFragments = chunks
+            .Where(c => c.Choices[0].Delta.ToolCalls?[0].Function?.Arguments is { Length: > 0 })
+            .Select(c => c.Choices[0].Delta.ToolCalls![0].Function!.Arguments);
+        string.Concat(argumentFragments).Should().Be("""{"city":"Berlin"}""");
+        chunks[^1].Choices[0].FinishReason.Should().Be("tool_calls");
+    }
+
+    [Fact]
+    public async Task Streaming_Exception_Event_Raises_A_Communication_Error()
+    {
+        var frame = FrameWithHeaders(
+            new Dictionary<string, string>
+            {
+                [":message-type"] = "exception",
+                [":exception-type"] = "throttlingException"
+            },
+            """{ "message": "Too many requests, please wait." }""");
+        var client = CreateClient(CreateStreamingHandler(new[] { frame }));
+
+        var act = async () =>
+        {
+            await foreach (var _ in client.StreamChatCompletionAsync(ChatRequest()))
+            {
+            }
+        };
+
+        (await act.Should().ThrowAsync<LLMCommunicationException>())
+            .WithMessage("*throttlingException*")
+            .WithMessage("*Too many requests*");
+    }
+
+    // ---- helpers ----
+
+    private static ChatCompletionRequest ChatRequest() => new()
+    {
+        Model = ModelId,
+        Messages = new List<Message> { new() { Role = "user", Content = "Hello" } }
+    };
+
+    private static string ConverseResponseJson(string text) => $$"""
+    {
+      "output": { "message": { "role": "assistant", "content": [ { "text": "{{text}}" } ] } },
+      "stopReason": "end_turn",
+      "usage": { "inputTokens": 10, "outputTokens": 20, "totalTokens": 30 }
+    }
+    """;
+
+    private static byte[] Frame(string eventType, string payload) =>
+        FrameWithHeaders(
+            new Dictionary<string, string>
+            {
+                [":message-type"] = "event",
+                [":event-type"] = eventType
+            },
+            payload);
+
+    private static byte[] FrameWithHeaders(Dictionary<string, string> headers, string payload) =>
+        AwsEventStreamReaderTests.BuildFrame(headers, payload);
+
+    private static Mock<HttpMessageHandler> CreateHandler(
+        HttpStatusCode statusCode,
+        string body,
+        Action<HttpRequestMessage>? onRequest = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => onRequest?.Invoke(req))
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        return handler;
+    }
+
+    private static Mock<HttpMessageHandler> CreateStreamingHandler(IEnumerable<byte[]> frames)
+    {
+        var bytes = frames.SelectMany(frame => frame).ToArray();
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ByteArrayContent(bytes)
+                {
+                    Headers = { { "Content-Type", "application/vnd.amazon.eventstream" } }
+                }
+            });
+        return handler;
+    }
+
+    private static BedrockClient CreateClient(
+        Mock<HttpMessageHandler> handler,
+        string apiKey = "AKIAIOSFODNN7EXAMPLE",
+        Dictionary<string, string>? settings = null,
+        Dictionary<string, string>? secretSettings = null)
+    {
+        var httpClient = new HttpClient(handler.Object);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var provider = new Provider
+        {
+            Id = 1,
+            ProviderType = ProviderType.Bedrock,
+            ProviderName = "bedrock-test",
+            Settings = settings ?? new Dictionary<string, string> { ["region"] = Region }
+        };
+
+        var key = new ProviderKeyCredential
+        {
+            Id = 1,
+            ProviderId = 1,
+            ApiKey = apiKey,
+            SecretSettings = secretSettings ?? (apiKey.StartsWith("AKIA") || apiKey.StartsWith("ASIA")
+                ? new Dictionary<string, string> { ["secret_access_key"] = "test-secret" }
+                : null),
+            IsPrimary = true,
+            IsEnabled = true
+        };
+
+        return new BedrockClient(
+            provider,
+            key,
+            ModelId,
+            NullLogger<BedrockClient>.Instance,
+            factory.Object);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockProviderSettingsTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockProviderSettingsTests.cs
@@ -1,0 +1,106 @@
+using System.Text.RegularExpressions;
+
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Core.Exceptions;
+using ConduitLLM.Providers.Configuration;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace ConduitLLM.Tests.Providers.Bedrock;
+
+/// <summary>
+/// Amazon Bedrock is the first provider to consume the multi-secret credential mechanism from
+/// epic #1177: the region is a provider-level structured setting that builds the endpoint and
+/// scopes SigV4 signing, and the secret access key / session token are secret-typed settings
+/// living encrypted on the key credential.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Component", "Providers")]
+public class BedrockProviderSettingsTests
+{
+    private static Provider BedrockProvider(Dictionary<string, string>? settings = null) => new()
+    {
+        ProviderType = ProviderType.Bedrock,
+        ProviderName = "bedrock",
+        Settings = settings
+    };
+
+    [Fact]
+    public void Bedrock_Should_Be_A_Configurable_Provider_Type_With_Registered_Adapter_Defaults()
+    {
+        ProviderTypeCatalog.IsConfigurable(ProviderType.Bedrock).Should().BeTrue();
+        ProviderConfigurationRegistry.TryGetConfiguration(ProviderType.Bedrock, out var config).Should().BeTrue();
+        ClientCreatorRegistry.IsSupported(ProviderType.Bedrock).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Bedrock_Should_Declare_Region_As_A_Required_Url_Token_Setting()
+    {
+        ProviderConfigurationRegistry.TryGetConfiguration(ProviderType.Bedrock, out var config).Should().BeTrue();
+
+        var region = config!.Settings.Should().ContainSingle(s => s.Key == "region").Subject;
+        region.Required.Should().BeTrue();
+        region.Secret.Should().BeFalse();
+        region.Binding.Should().Be(ProviderSettingBinding.UrlPathToken);
+        region.EffectiveBindingTarget.Should().Be("region");
+
+        Regex.IsMatch("us-east-1", region.ValidationRegex!).Should().BeTrue();
+        Regex.IsMatch("us-gov-west-1", region.ValidationRegex!).Should().BeTrue();
+        Regex.IsMatch("ap-southeast-2", region.ValidationRegex!).Should().BeTrue();
+        Regex.IsMatch("not a region", region.ValidationRegex!).Should().BeFalse();
+        Regex.IsMatch("useast1", region.ValidationRegex!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Bedrock_Should_Declare_Secret_Access_Key_And_Session_Token_As_Secret_Settings()
+    {
+        var secrets = ProviderConfigurationRegistry.GetSecretSettings(ProviderType.Bedrock);
+
+        secrets.Should().HaveCount(2);
+        secrets.Should().OnlyContain(s => s.Secret && s.Binding == ProviderSettingBinding.AuthScope);
+
+        // Both are optional at the declaration level: the Bearer (Bedrock API key) mode uses
+        // neither, and the client validates the SigV4 pairing itself with an actionable error.
+        secrets.Should().ContainSingle(s => s.Key == "secret_access_key").Which.Required.Should().BeFalse();
+        secrets.Should().ContainSingle(s => s.Key == "session_token").Which.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Secret_Settings_Must_Never_Appear_In_The_Plaintext_Settings_Schema()
+    {
+        var nonSecret = ProviderConfigurationRegistry.GetNonSecretSettings(ProviderType.Bedrock);
+
+        nonSecret.Should().ContainSingle().Which.Key.Should().Be("region");
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_Should_Substitute_The_Region_Into_The_Default_Endpoint()
+    {
+        var provider = BedrockProvider(new Dictionary<string, string> { ["region"] = "eu-central-1" });
+
+        ProviderConfigurationRegistry.ResolveBaseUrl(provider)
+            .Should().Be("https://bedrock-runtime.eu-central-1.amazonaws.com");
+    }
+
+    [Fact]
+    public void ResolveBaseUrl_Without_A_Region_Should_Raise_An_Actionable_Error()
+    {
+        var act = () => ProviderConfigurationRegistry.ResolveBaseUrl(BedrockProvider());
+
+        act.Should().Throw<ConfigurationException>()
+            .WithMessage("*AWS Region*");
+    }
+
+    [Fact]
+    public void An_Explicit_Base_Url_Override_Should_Still_Win()
+    {
+        var provider = BedrockProvider(new Dictionary<string, string> { ["region"] = "us-east-1" });
+        provider.BaseUrl = "https://bedrock-proxy.internal.example.com";
+
+        ProviderConfigurationRegistry.ResolveBaseUrl(provider)
+            .Should().Be("https://bedrock-proxy.internal.example.com");
+    }
+}

--- a/WebAdmin/src/constants/providers.ts
+++ b/WebAdmin/src/constants/providers.ts
@@ -18,6 +18,7 @@ export enum ProviderType {
   OpenRouter = 13,
   Meta = 14,
   Azure = 15,
+  Bedrock = 16,
 }
 
 /**
@@ -39,6 +40,7 @@ export const PROVIDER_TYPE_NAMES: Record<number, string> = {
   [ProviderType.OpenRouter]: 'OpenRouter',
   [ProviderType.Meta]: 'Meta AI',
   [ProviderType.Azure]: 'Azure OpenAI',
+  [ProviderType.Bedrock]: 'Amazon Bedrock',
 };
 
 /**

--- a/WebAdmin/src/generated/admin-api.ts
+++ b/WebAdmin/src/generated/admin-api.ts
@@ -6661,7 +6661,8 @@ export interface components {
       | "cloudflare"
       | "openRouter"
       | "meta"
-      | "azure";
+      | "azure"
+      | "bedrock";
     /** @description Request model for pruning old media. */
     PruneMediaRequest: {
       /**

--- a/WebAdmin/src/lib/admin-api/models/providerType.ts
+++ b/WebAdmin/src/lib/admin-api/models/providerType.ts
@@ -16,6 +16,7 @@ export const ProviderType = {
   OpenRouter: 'openRouter',
   Meta: 'meta',
   Azure: 'azure',
+  Bedrock: 'bedrock',
 } as const;
 
 export type ProviderType = (typeof ProviderType)[keyof typeof ProviderType];

--- a/WebAdmin/src/lib/admin-api/types/providers.ts
+++ b/WebAdmin/src/lib/admin-api/types/providers.ts
@@ -130,6 +130,17 @@ export const PROVIDER_REGISTRY: Partial<Record<ProviderType, ProviderMetadata>> 
     defaultMaxOutputTokens: 16384,
     description: 'Azure OpenAI Service (deployment-scoped OpenAI models)'
   },
+  [ProviderType.Bedrock]: {
+    value: ProviderType.Bedrock,
+    name: 'Bedrock',
+    label: 'Amazon Bedrock',
+    supportsSpeedScore: true,
+    supportsQualityScore: true,
+    supportsVariation: false,
+    defaultMaxInputTokens: 200000,
+    defaultMaxOutputTokens: 65536,
+    description: 'Amazon Bedrock (AWS-hosted foundation models via the Converse API)'
+  },
   [ProviderType.Ultravox]: {
     value: ProviderType.Ultravox,
     name: 'Ultravox',

--- a/WebAdmin/src/lib/gateway-api/types.ts
+++ b/WebAdmin/src/lib/gateway-api/types.ts
@@ -61,6 +61,8 @@ export enum ProviderType {
   Cloudflare,
   OpenRouter,
   Meta,
+  Azure,
+  Bedrock,
 }
 
 export interface TextContent {


### PR DESCRIPTION
## Summary

Epic #1177's remaining scope. PR #1240 shipped the multi-secret credential mechanism but deliberately deferred its consumer: a configurable Bedrock provider with no client would 500 on every request. This PR adds **Amazon Bedrock as a first-class `ProviderType`** on top of that mechanism, plus the AWS protocol plumbing it needs. Google Vertex (the other Phase 4 provider) is filed separately as #1250.

### Commits

1. **docs(providers)** — the provider-setting schema still said Header/QueryParam/AuthScope bindings and secret settings were "not wired / reserved for a later phase"; all shipped in #1185/#1186/#1187.
2. **feat(providers): AWS SigV4 + event-stream plumbing** — `AwsSigV4Signer` (request signing incl. the non-S3 canonical-path double-encoding rule, verified against the published AWS documentation example) and `AwsEventStreamReader` (`application/vnd.amazon.eventstream` frame decoder with CRC validation, since ConverseStream is binary-framed, not SSE). No AWS SDK dependency.
3. **feat(providers): Bedrock ProviderType end-to-end** — enum value 16, all five registries, structured settings, the Converse client, WebAdmin mirrors, regenerated `openapi-admin.json` + generated types.

### How the epic's mechanism is exercised

- **`region`** — required provider-level setting (URL token): builds `https://bedrock-runtime.<region>.amazonaws.com` *and* scopes SigV4 signing. Missing region → configuration error naming the field.
- **`secret_access_key` / `session_token`** — secret-typed settings on the key credential, encrypted at rest, revealed only at the client-factory seam.
- **Dual auth modes**: IAM access key ID (ApiKey) + secret access key → per-request SigV4; Bedrock API key alone → Bearer. An `AKIA`/`ASIA` key without its secret fails fast at construction naming the missing Secret Access Key.

### Adapter capabilities

- **Chat (Converse)**: system blocks, inline-data-URL images, tools/tool-choice, toolUse ↔ tool_calls mapping, tool results (JSON or text), consecutive same-role merging (Converse requires alternating roles), stop-reason + usage mapping.
- **Streaming (ConverseStream)**: binary frames → OpenAI chunks, incremental tool-call arguments (block indices remapped to tool-call indices), trailing usage metadata, modeled exceptions surfaced with the AWS exception type.
- **Test Connection / models**: signed `GET /foundation-models` on the `bedrock.<region>` control-plane host so bad key / wrong region / missing model access classify into actionable messages.
- Embeddings & image generation throw `NotSupportedException` (Bedrock serves those via model-specific InvokeModel payloads, not Converse).

### Also fixed along the way

- WebAdmin `gateway-api/types.ts` `ProviderType` enum had drifted — it was missing `Azure` (15); backfilled both Azure and Bedrock.

## Verification

- `dotnet build` full solution: clean
- `dotnet test Tests/ConduitLLM.Tests`: **3670 passed, 0 failed** (includes 35 new Bedrock tests: SigV4 doc vector, CRC32 check value, frame decode/corruption, auth modes, Converse mapping, streaming, model discovery)
- `tools/openapi`: `validate:openapi` clean; `openapi-admin.json` diff is exactly the enum addition
- WebAdmin: `npm run lint` 0 errors, `npm run type-check` clean

## Issues

Refs #1177. Closes #1187 (manual close after merge — dev PRs don't auto-close). Follow-up: #1250 (Vertex).