### PR TITLE
fix: provider-error status unification + three wire-contract corrections

### DIFF
--- a/Services/ConduitLLM.Admin/DTOs/BillingAuditDtos.cs
+++ b/Services/ConduitLLM.Admin/DTOs/BillingAuditDtos.cs
@@ -146,40 +146,15 @@ namespace ConduitLLM.Admin.DTOs
         public bool IsEstimated { get; set; }
 
         /// <summary>
-        /// Usage details (parsed from JSON)
+        /// Usage details (parsed from JSON). Typed as the core Usage model — the same type
+        /// that wrote UsageJson — so no fields are lost in the audit round-trip.
         /// </summary>
-        public UsageDto? Usage { get; set; }
+        public ConduitLLM.Core.Models.Usage? Usage { get; set; }
 
         /// <summary>
         /// Additional metadata
         /// </summary>
         public Dictionary<string, object>? Metadata { get; set; }
-    }
-
-    /// <summary>
-    /// DTO for usage data
-    /// </summary>
-    public class UsageDto
-    {
-        /// <summary>
-        /// Prompt/input tokens
-        /// </summary>
-        public int? PromptTokens { get; set; }
-
-        /// <summary>
-        /// Completion/output tokens
-        /// </summary>
-        public int? CompletionTokens { get; set; }
-
-        /// <summary>
-        /// Total tokens
-        /// </summary>
-        public int? TotalTokens { get; set; }
-
-        /// <summary>
-        /// Image count for image generation
-        /// </summary>
-        public int? ImageCount { get; set; }
     }
 
     /// <summary>

--- a/Services/ConduitLLM.Admin/Endpoints/BillingAuditEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/BillingAuditEndpoints.cs
@@ -310,7 +310,10 @@ namespace ConduitLLM.Admin.Endpoints
             {
                 try
                 {
-                    var usage = JsonSerializer.Deserialize<UsageDto>(entity.UsageJson);
+                    // Usage must round-trip through the same type that serialized UsageJson
+                    // (Core.Models.Usage, snake_case attributes) — a PascalCase DTO matched
+                    // no properties and returned empty usage on every audit event (#1260).
+                    var usage = JsonSerializer.Deserialize<ConduitLLM.Core.Models.Usage>(entity.UsageJson);
                     dto.Usage = usage;
                 }
                 catch (JsonException)

--- a/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/ChatEndpoints.cs
@@ -189,49 +189,18 @@ namespace ConduitLLM.Gateway.Endpoints
 
         internal static ProviderCommunicationError MapProviderCommunicationError(HttpStatusCode? upstreamStatus)
         {
-            return upstreamStatus switch
+            // The status table is shared with OpenAIErrorMiddleware via ExceptionToResponseMapper,
+            // so chat and non-chat routes report identical statuses for the same provider failure.
+            var mapping = ConduitLLM.Core.Exceptions.ExceptionToResponseMapper
+                .MapProviderCommunicationStatus(upstreamStatus, string.Empty);
+            var metricOutcome = mapping.ErrorCode switch
             {
-                HttpStatusCode.TooManyRequests => new(
-                    StatusCodes.Status429TooManyRequests,
-                    "rate_limit_exceeded",
-                    "rate_limit_error",
-                    "rate_limited"),
-                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new(
-                    StatusCodes.Status502BadGateway,
-                    "provider_authentication_error",
-                    "server_error",
-                    "provider_error"),
-                HttpStatusCode.RequestTimeout => new(
-                    StatusCodes.Status503ServiceUnavailable,
-                    "provider_timeout",
-                    "server_error",
-                    "provider_unavailable"),
-                HttpStatusCode.BadGateway => new(
-                    StatusCodes.Status502BadGateway,
-                    "provider_bad_gateway",
-                    "server_error",
-                    "provider_unavailable"),
-                HttpStatusCode.ServiceUnavailable => new(
-                    StatusCodes.Status503ServiceUnavailable,
-                    "provider_unavailable",
-                    "server_error",
-                    "provider_unavailable"),
-                HttpStatusCode.GatewayTimeout => new(
-                    StatusCodes.Status504GatewayTimeout,
-                    "provider_timeout",
-                    "server_error",
-                    "provider_unavailable"),
-                { } status when (int)status >= 400 && (int)status < 500 => new(
-                    (int)status,
-                    "provider_request_error",
-                    "invalid_request_error",
-                    "provider_rejected"),
-                _ => new(
-                    StatusCodes.Status502BadGateway,
-                    "provider_communication_error",
-                    "server_error",
-                    "provider_error")
+                "rate_limit_exceeded" => "rate_limited",
+                "provider_timeout" or "provider_unavailable" or "provider_bad_gateway" => "provider_unavailable",
+                "provider_request_error" => "provider_rejected",
+                _ => "provider_error"
             };
+            return new(mapping.StatusCode, mapping.ErrorCode, mapping.OpenAIErrorType, metricOutcome);
         }
 
         internal readonly record struct ProviderCommunicationError(

--- a/Services/ConduitLLM.Gateway/Endpoints/VideosEndpoints.cs
+++ b/Services/ConduitLLM.Gateway/Endpoints/VideosEndpoints.cs
@@ -165,8 +165,8 @@ namespace ConduitLLM.Gateway.Endpoints
             {
                 TaskId = taskId,
                 Status = TaskStateConstants.Pending,
-                CreatedAt = DateTimeOffset.UtcNow,
-                EstimatedCompletionTime = DateTimeOffset.UtcNow.AddSeconds(60),
+                CreatedAt = DateTime.UtcNow,
+                EstimatedCompletionTime = DateTime.UtcNow.AddSeconds(60),
                 CheckStatusUrl = $"/v1/conduit/videos/generations/tasks/{taskId}"
             };
             accounting.RecordMetadata(JsonSerializer.Serialize(new
@@ -293,8 +293,8 @@ namespace ConduitLLM.Gateway.Endpoints
                 TaskId = taskId,
                 Status = updatedStatus != null ? TaskStateConstants.FromTaskState(updatedStatus.State) : TaskStateConstants.Pending,
                 Progress = updatedStatus?.Progress ?? 0,
-                CreatedAt = updatedStatus?.CreatedAt ?? DateTimeOffset.UtcNow,
-                UpdatedAt = updatedStatus?.UpdatedAt ?? DateTimeOffset.UtcNow,
+                CreatedAt = updatedStatus?.CreatedAt ?? DateTime.UtcNow,
+                UpdatedAt = updatedStatus?.UpdatedAt ?? DateTime.UtcNow,
                 Error = $"Retry {updatedStatus?.RetryCount ?? 0}/{updatedStatus?.MaxRetries ?? 3} scheduled"
             };
 
@@ -469,8 +469,11 @@ namespace ConduitLLM.Gateway.Endpoints
     {
         public string TaskId { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
-        public DateTimeOffset CreatedAt { get; set; }
-        public DateTimeOffset? EstimatedCompletionTime { get; set; }
+        // DateTime (not DateTimeOffset) so GatewayJsonOptions' UtcDateTimeConverter normalizes
+        // these to Z-suffixed UTC like the image endpoints; task-store timestamps arrive with
+        // DateTimeKind.Unspecified and must not pick up the host's local offset (#1258).
+        public DateTime CreatedAt { get; set; }
+        public DateTime? EstimatedCompletionTime { get; set; }
         public string CheckStatusUrl { get; set; } = string.Empty;
     }
 
@@ -482,9 +485,9 @@ namespace ConduitLLM.Gateway.Endpoints
         public string TaskId { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
         public int? Progress { get; set; }
-        public DateTimeOffset CreatedAt { get; set; }
-        public DateTimeOffset UpdatedAt { get; set; }
-        public DateTimeOffset? CompletedAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public DateTime? CompletedAt { get; set; }
         public string? Error { get; set; }
         public string? ResultRaw { get; set; }
         public VideoGenerationResponse? Result { get; set; }

--- a/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
+++ b/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
@@ -154,23 +154,45 @@ public static class ExceptionToResponseMapper
     /// <summary>
     /// Maps an LLMCommunicationException, deriving status code and error type from the provider's response.
     /// </summary>
-    private static ExceptionMappingResult MapLLMCommunicationException(LLMCommunicationException commEx)
-    {
-        if (commEx.StatusCode.HasValue)
-        {
-            var statusCode = (int)commEx.StatusCode.Value;
-            var isServerError = statusCode >= 500;
-            return new(
-                statusCode,
-                commEx.Message,
-                "provider_communication_error",
-                isServerError ? LogLevel.Error : LogLevel.Warning,
-                "Provider communication error",
-                true,
-                isServerError ? "server_error" : "invalid_request_error");
-        }
+    private static ExceptionMappingResult MapLLMCommunicationException(LLMCommunicationException commEx) =>
+        MapProviderCommunicationStatus(commEx.StatusCode, commEx.Message);
 
-        return new(500, commEx.Message, "provider_communication_error", LogLevel.Error,
-            "Provider communication error", true, "server_error");
+    /// <summary>
+    /// Maps an upstream provider HTTP status to the client-visible response. Provider-side faults
+    /// (auth failures, timeouts, 5xx) surface as gateway errors (502/503/504) so OpenAI-compatible
+    /// clients do not mistake a provider credential failure for their own key being invalid (#1191);
+    /// other provider 4xx statuses are forwarded as request errors.
+    /// </summary>
+    public static ExceptionMappingResult MapProviderCommunicationStatus(
+        System.Net.HttpStatusCode? upstreamStatus,
+        string message)
+    {
+        return upstreamStatus switch
+        {
+            System.Net.HttpStatusCode.TooManyRequests
+                => new(429, message, "rate_limit_exceeded", LogLevel.Warning,
+                    "Provider rate limited", true, "rate_limit_error"),
+            System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden
+                => new(502, message, "provider_authentication_error", LogLevel.Error,
+                    "Provider authentication error", true, "server_error"),
+            System.Net.HttpStatusCode.RequestTimeout
+                => new(503, message, "provider_timeout", LogLevel.Error,
+                    "Provider timeout", true, "server_error"),
+            System.Net.HttpStatusCode.BadGateway
+                => new(502, message, "provider_bad_gateway", LogLevel.Error,
+                    "Provider bad gateway", true, "server_error"),
+            System.Net.HttpStatusCode.ServiceUnavailable
+                => new(503, message, "provider_unavailable", LogLevel.Error,
+                    "Provider unavailable", true, "server_error"),
+            System.Net.HttpStatusCode.GatewayTimeout
+                => new(504, message, "provider_timeout", LogLevel.Error,
+                    "Provider gateway timeout", true, "server_error"),
+            { } status when (int)status >= 400 && (int)status < 500
+                => new((int)status, message, "provider_request_error", LogLevel.Warning,
+                    "Provider rejected request", true, "invalid_request_error"),
+            _
+                => new(502, message, "provider_communication_error", LogLevel.Error,
+                    "Provider communication error", true, "server_error")
+        };
     }
 }

--- a/Shared/ConduitLLM.Core/Models/ImageGenerationResponse.cs
+++ b/Shared/ConduitLLM.Core/Models/ImageGenerationResponse.cs
@@ -70,5 +70,13 @@ namespace ConduitLLM.Core.Models
         /// </summary>
         [JsonPropertyName("b64_json")]
         public string? B64Json { get; set; }
+
+        /// <summary>
+        /// The prompt the provider actually used, when it rewrites the user's prompt
+        /// (e.g. DALL·E 3). Null when the provider does not revise prompts.
+        /// </summary>
+        [JsonPropertyName("revised_prompt")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? RevisedPrompt { get; set; }
     }
 }

--- a/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Images.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenAICompatible/OpenAICompatibleClient.Images.cs
@@ -121,8 +121,8 @@ namespace ConduitLLM.Providers.OpenAICompatible
                     Data = response.Data?.Select(d => new CoreModels.ImageData
                     {
                         Url = d.Url,
-                        B64Json = d.B64Json
-                        // Note: Core.Models.ImageData doesn't have RevisedPrompt property
+                        B64Json = d.B64Json,
+                        RevisedPrompt = d.RevisedPrompt
                     }).ToList() ?? new List<CoreModels.ImageData>()
                 };
             }, "CreateImage", cancellationToken);

--- a/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
@@ -363,9 +363,39 @@ public class ExceptionToResponseMapperTests
 
         // Assert
         result.StatusCode.Should().Be(502);
-        result.ErrorCode.Should().Be("provider_communication_error");
+        result.ErrorCode.Should().Be("provider_bad_gateway");
         result.ResponseMessage.Should().Be("Provider returned error");
         result.IncludeExceptionMessageInLog.Should().BeTrue();
+        result.OpenAIErrorType.Should().Be("server_error");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public void Map_LLMCommunicationException_WithProviderAuthFailure_Returns502(HttpStatusCode upstreamStatus)
+    {
+        // A provider credential rejection must not surface as a client 401/403 — an
+        // OpenAI-compatible SDK would read that as "your gateway key is invalid" (#1257).
+        var exception = new LLMCommunicationException("Provider rejected credentials",
+            upstreamStatus, "auth failure");
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(502);
+        result.ErrorCode.Should().Be("provider_authentication_error");
+        result.OpenAIErrorType.Should().Be("server_error");
+    }
+
+    [Fact]
+    public void Map_LLMCommunicationException_WithProviderTimeout_Returns503()
+    {
+        var exception = new LLMCommunicationException("Provider timed out",
+            HttpStatusCode.RequestTimeout, "timeout");
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(503);
+        result.ErrorCode.Should().Be("provider_timeout");
         result.OpenAIErrorType.Should().Be("server_error");
     }
 
@@ -386,7 +416,7 @@ public class ExceptionToResponseMapperTests
     }
 
     [Fact]
-    public void Map_LLMCommunicationException_WithoutStatusCode_Returns500()
+    public void Map_LLMCommunicationException_WithoutStatusCode_Returns502()
     {
         // Arrange
         var exception = new LLMCommunicationException("Unknown provider error");
@@ -394,8 +424,8 @@ public class ExceptionToResponseMapperTests
         // Act
         var result = ExceptionToResponseMapper.Map(exception);
 
-        // Assert
-        result.StatusCode.Should().Be(500);
+        // Assert: unknown provider failure is an upstream fault, not a Conduit fault.
+        result.StatusCode.Should().Be(502);
         result.ErrorCode.Should().Be("provider_communication_error");
         result.OpenAIErrorType.Should().Be("server_error");
         result.LogLevel.Should().Be(LogLevel.Error);

--- a/Tests/ConduitLLM.Tests/Middleware/OpenAIErrorMiddlewareTests.cs
+++ b/Tests/ConduitLLM.Tests/Middleware/OpenAIErrorMiddlewareTests.cs
@@ -200,11 +200,11 @@ namespace ConduitLLM.Tests.Middleware
             Assert.NotNull(errorResponse);
             Assert.Equal("Provider error", errorResponse.Error.Message);
             Assert.Equal("server_error", errorResponse.Error.Type);
-            Assert.Equal("provider_communication_error", errorResponse.Error.Code);
+            Assert.Equal("provider_bad_gateway", errorResponse.Error.Code);
         }
 
         [Fact]
-        public async Task LLMCommunicationException_WithoutStatusCode_Returns500()
+        public async Task LLMCommunicationException_WithoutStatusCode_Returns502()
         {
             // Arrange
             var exception = new LLMCommunicationException("Unknown provider error");
@@ -214,8 +214,8 @@ namespace ConduitLLM.Tests.Middleware
             // Act
             await _middleware.InvokeAsync(_httpContext);
 
-            // Assert
-            Assert.Equal(500, _httpContext.Response.StatusCode);
+            // Assert: an unattributed provider failure is an upstream fault (502), not a Conduit 500.
+            Assert.Equal(502, _httpContext.Response.StatusCode);
 
             var errorResponse = GetErrorResponse(_httpContext);
 


### PR DESCRIPTION
Implements the first two decision items from the dedup-audit backlog: #1257, #1258, #1259, #1260.

## Provider failures map to gateway errors on every route (#1257)
The shared `ExceptionToResponseMapper` forwarded upstream provider statuses verbatim, so a provider credential rejection surfaced on `/v1/embeddings`, `/v1/images/*`, `/v1/audio/*`, etc. as a client **401** — OpenAI SDKs read that as "your key is invalid" and stop retrying. Chat has had the correct translation since #1191; that table is now the single shared one in `ExceptionToResponseMapper.MapProviderCommunicationStatus`:

- provider 401/403 → 502 `provider_authentication_error`
- provider 408 → 503 `provider_timeout`; 502/503/504 keep their gateway-fault statuses
- unlisted 5xx / no status → 502 `provider_communication_error` (was 500)
- other provider 4xx forwarded as `provider_request_error`

Chat behavior is unchanged (its tests pass untouched); it now derives its metric outcome from the shared mapping. Non-chat routes change observable status codes — that is the point. Stale mapper/middleware tests updated; new tests pin the provider-auth-→502 and timeout→503 arms.

## Video task timestamps no longer pick up the host's local offset (#1258)
The video DTOs' `DateTimeOffset` properties bypassed `UtcDateTimeConverter`, and the implicit `DateTime`→`DateTimeOffset` conversion treated Kind-less task-store timestamps as local time. Video task responses now serialize Z-suffixed UTC exactly like the image endpoints.

## `revised_prompt` surfaces in image responses (#1259)
The provider wire model parsed it; `Core.Models.ImageData` dropped it. Added as an OpenAI-compatible additive field, omitted when null.

## Billing-audit usage was always empty (#1260)
Worse than the audit stated: `UsageJson` is written from `Core.Models.Usage` (snake_case attributes) but was deserialized into an attribute-less PascalCase DTO — **zero properties matched**, so every audit event returned empty usage. The endpoint now round-trips the core `Usage` model, restoring all fields including cached/reasoning/video usage. No WebAdmin consumers of this shape exist.

## Verification
- `dotnet build`: clean
- `dotnet test`: 3,565 passed, 0 failed (includes 3 new mapper tests)

Note: PRs to dev don't auto-close issues (default branch is master) — close #1257–#1260 manually on merge.

https://claude.ai/code/session_01Hn4pnKjamxf3NPX5bVsvnU