### PR TITLE
fix(admin): duplicate provider keys return 409 with a real duplicate check

### DIFF
--- a/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Keys.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Keys.cs
@@ -70,6 +70,23 @@ namespace ConduitLLM.Admin.Endpoints
                     $"{provider.ProviderType} requires: {string.Join(", ", missingSecrets)}.");
             }
 
+            // The (ProviderId, ApiKey) unique index compares ciphertext, and Data Protection
+            // produces different ciphertext for the same plaintext on every write — the database
+            // cannot catch semantic duplicates. Compare revealed values instead (#1261).
+            if (!string.IsNullOrEmpty(request.ApiKey))
+            {
+                var existingKeys = await RepositoryPaginationExtensions.GetAllViaPaginationAsync(
+                    _keyRepository.GetByProviderIdPaginatedAsync, providerId);
+                if (existingKeys.Any(k => TryRevealApiKey(k.ApiKey) == request.ApiKey))
+                {
+                    Logger.LogWarning("Duplicate API key attempted for provider {ProviderId} ({ProviderName})",
+                        providerId, LoggingSanitizer.S(provider.ProviderName));
+                    return AdminResults.Conflict(
+                        $"An API key with this value already exists for {provider.ProviderName}. Each API key must be unique per provider.",
+                        "duplicate_provider_key");
+                }
+            }
+
             var keyCredential = new ProviderKeyCredential
             {
                 ProviderId = providerId,
@@ -101,6 +118,23 @@ namespace ConduitLLM.Admin.Endpoints
             AdminOperationsMetricsService.RecordConfigurationChange("providerkey", "create");
 
             return Results.Created($"/v1/admin/providers/{providerId}/keys/{createdKeyId}", ToKeyDto(keyCredential));
+        }
+
+        /// <summary>
+        /// Reveals a stored API key for duplicate comparison. An unreadable row (rotated or
+        /// lost Data Protection key ring) must not block creating a new key, so it compares
+        /// as no-match instead of throwing.
+        /// </summary>
+        private string? TryRevealApiKey(string? storedApiKey)
+        {
+            try
+            {
+                return _secretProtector.Reveal(storedApiKey);
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Providers.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/ProviderCredentialsEndpoints.Providers.cs
@@ -82,7 +82,7 @@ namespace ConduitLLM.Admin.Endpoints
             group.MapGet("/{providerId:int}/keys/{keyId:int}", ([FromServices] ProviderCredentialsEndpoints endpoints, int providerId, int keyId) => endpoints.GetProviderKeyCredential(providerId, keyId))
                 .WithName("ProviderCredentials_GetKey").Produces<ProviderKeyCredentialDto>().Produces(StatusCodes.Status404NotFound);
             group.MapPost("/{providerId:int}/keys", ([FromServices] ProviderCredentialsEndpoints endpoints, int providerId, CreateKeyRequest request) => endpoints.CreateProviderKeyCredential(providerId, request))
-                .WithName("ProviderCredentials_CreateKey").Produces<ProviderKeyCredentialDto>(StatusCodes.Status201Created).Produces(StatusCodes.Status400BadRequest).Produces(StatusCodes.Status404NotFound);
+                .WithName("ProviderCredentials_CreateKey").Produces<ProviderKeyCredentialDto>(StatusCodes.Status201Created).Produces(StatusCodes.Status400BadRequest).Produces(StatusCodes.Status404NotFound).Produces(StatusCodes.Status409Conflict);
             group.MapPatch("/{providerId:int}/keys/{keyId:int}", ([FromServices] ProviderCredentialsEndpoints endpoints, int providerId, int keyId, JsonMergePatch<UpdateKeyRequest> patch) => endpoints.UpdateProviderKeyCredential(providerId, keyId, patch.Value))
                 .AcceptsJsonMergePatch<UpdateKeyRequest>()
                 .WithName("ProviderCredentials_UpdateKey").Produces<ProviderKeyCredentialDto>().Produces(StatusCodes.Status400BadRequest).Produces(StatusCodes.Status404NotFound);

--- a/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
+++ b/Shared/ConduitLLM.Core/Exceptions/ExceptionToResponseMapper.cs
@@ -103,6 +103,15 @@ public static class ExceptionToResponseMapper
                 => new(400, "Invalid parameter value", "invalid_parameter", LogLevel.Warning,
                     "Argument error", false, "invalid_request_error", argEx.ParamName),
 
+            // Both derive from InvalidOperationException, so these arms must precede its arms.
+            ConduitLLM.Configuration.Exceptions.DuplicateProviderKeyException dupKeyEx
+                => new(409, dupKeyEx.Message, "duplicate_provider_key", LogLevel.Warning,
+                    "Duplicate provider key", true, "invalid_request_error"),
+
+            ConduitLLM.Configuration.Exceptions.IdempotencyConflictException idemEx
+                => new(409, idemEx.Message, "conflict", LogLevel.Warning,
+                    "Idempotency conflict", true, "invalid_request_error"),
+
             InvalidOperationException invalidOp when IsDependencyResolutionFailure(invalidOp)
                 => new(500, "A server dependency could not be resolved", "dependency_resolution_error", LogLevel.Error,
                     "Dependency resolution error", false, "server_error"),

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderKeySecretSettingsEndpointTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderKeySecretSettingsEndpointTests.cs
@@ -60,6 +60,9 @@ public class ProviderKeySecretSettingsEndpointTests
             .Setup(repository => repository.CreateAsync(It.IsAny<ProviderKeyCredential>(), It.IsAny<CancellationToken>()))
             .Callback<ProviderKeyCredential, CancellationToken>((key, _) => persisted = key)
             .ReturnsAsync(9);
+        _keyRepository
+            .Setup(repository => repository.GetByProviderIdPaginatedAsync(1, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ProviderKeyCredential>(), 0));
 
         var result = await CreateEndpoints().CreateProviderKeyCredential(1, new CreateKeyRequest
         {
@@ -84,6 +87,80 @@ public class ProviderKeySecretSettingsEndpointTests
         dto.ApiKey.Should().Be("***test");
         dto.ConfiguredSecretSettings.Should().Equal("secret_access_key");
         System.Text.Json.JsonSerializer.Serialize(dto).Should().NotContain(SecretValue);
+    }
+
+    [Fact]
+    public async Task CreateKey_Should_Return409_When_ApiKey_Already_Exists_Encrypted()
+    {
+        _providerRepository
+            .Setup(repository => repository.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Provider { Id = 1, ProviderType = ProviderType.OpenAI, ProviderName = "openai" });
+        // Data Protection ciphertext differs on every Protect call, so this only matches if the
+        // endpoint compares revealed values, not stored ones.
+        _keyRepository
+            .Setup(repository => repository.GetByProviderIdPaginatedAsync(1, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ProviderKeyCredential>
+            {
+                new() { Id = 5, ProviderId = 1, ApiKey = _protector.Protect("sk-test") }
+            }, 1));
+
+        var result = await CreateEndpoints().CreateProviderKeyCredential(1, new CreateKeyRequest
+        {
+            ApiKey = "sk-test",
+            KeyName = "duplicate"
+        });
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        _keyRepository.Verify(
+            repository => repository.CreateAsync(It.IsAny<ProviderKeyCredential>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateKey_Should_Return409_When_ApiKey_Matches_Legacy_Plaintext_Row()
+    {
+        _providerRepository
+            .Setup(repository => repository.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Provider { Id = 1, ProviderType = ProviderType.OpenAI, ProviderName = "openai" });
+        _keyRepository
+            .Setup(repository => repository.GetByProviderIdPaginatedAsync(1, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ProviderKeyCredential>
+            {
+                new() { Id = 5, ProviderId = 1, ApiKey = "sk-test" }
+            }, 1));
+
+        var result = await CreateEndpoints().CreateProviderKeyCredential(1, new CreateKeyRequest
+        {
+            ApiKey = "sk-test",
+            KeyName = "duplicate"
+        });
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    [Fact]
+    public async Task CreateKey_Should_Succeed_When_ApiKey_Differs_From_Existing_Keys()
+    {
+        _providerRepository
+            .Setup(repository => repository.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Provider { Id = 1, ProviderType = ProviderType.OpenAI, ProviderName = "openai" });
+        _keyRepository
+            .Setup(repository => repository.GetByProviderIdPaginatedAsync(1, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<ProviderKeyCredential>
+            {
+                new() { Id = 5, ProviderId = 1, ApiKey = _protector.Protect("sk-other") }
+            }, 1));
+        _keyRepository
+            .Setup(repository => repository.CreateAsync(It.IsAny<ProviderKeyCredential>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(9);
+
+        var result = await CreateEndpoints().CreateProviderKeyCredential(1, new CreateKeyRequest
+        {
+            ApiKey = "sk-test",
+            KeyName = "unique"
+        });
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status201Created);
     }
 
     [Fact]

--- a/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
@@ -59,6 +59,37 @@ public class ExceptionToResponseMapperTests
     }
 
     [Fact]
+    public void Map_DuplicateProviderKeyException_Returns409()
+    {
+        // Derives from InvalidOperationException; must not fall into the generic 400 arm (#1261).
+        var provider = new ConduitLLM.Configuration.Entities.Provider
+        {
+            Id = 1,
+            ProviderType = ConduitLLM.Configuration.ProviderType.OpenAI,
+            ProviderName = "openai"
+        };
+        var exception = new ConduitLLM.Configuration.Exceptions.DuplicateProviderKeyException(provider, 1);
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(409);
+        result.ErrorCode.Should().Be("duplicate_provider_key");
+        result.IncludeExceptionMessageInLog.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Map_IdempotencyConflictException_Returns409()
+    {
+        var exception = new ConduitLLM.Configuration.Exceptions.IdempotencyConflictException(
+            "A conflicting request with the same idempotency key is in progress");
+
+        var result = ExceptionToResponseMapper.Map(exception);
+
+        result.StatusCode.Should().Be(409);
+        result.ErrorCode.Should().Be("conflict");
+    }
+
+    [Fact]
     public void Map_InvalidOperationException_Returns400WithInvalidOperation()
     {
         // Arrange


### PR DESCRIPTION
Implements #1261 from the dedup-audit backlog.

## The bug was worse than filed
The issue described duplicates hitting the DB unique index and surfacing as 500. Investigating, the reality post-encryption is worse: the `(ProviderId, ApiKey)` unique index compares **ciphertext**, and Data Protection produces different ciphertext for the same plaintext on every write — so the database cannot catch semantic duplicates at all. Since encryption-at-rest landed, duplicate API keys have been **silently accepted**; only legacy plaintext rows could collide (and those surfaced as 500 `internal_error`).

## Changes
- `POST /v1/admin/providers/{id}/keys` now compares the requested key against **revealed** stored values and returns **409 `duplicate_provider_key`** with the friendly message. Rows that can no longer be decrypted (rotated/lost key ring) compare as no-match rather than blocking creation.
- `ExceptionToResponseMapper`: `DuplicateProviderKeyException` → 409 `duplicate_provider_key`, `IdempotencyConflictException` → 409 `conflict` — both previously fell into the generic `InvalidOperationException` → 400 arm with a redacted message. Arms are ordered before the base-type arm.
- 409 added to the endpoint's OpenAPI `Produces` contract.
- Deliberately did **not** re-route through `ProviderService.AddKeyCredentialAsync` — the endpoint publishes its own events; re-routing would double-publish (see #1261).

## WebAdmin impact
Checked: the key-create UI catches errors generically and surfaces the server's problem-details message via `notify.error`, so the 409 message reaches the operator with no client change.

## Tests
- 3 new endpoint tests: 409 for an encrypted duplicate (proves the compare is on revealed values), 409 for a legacy-plaintext duplicate, 201 for a distinct key
- 2 new mapper tests pinning the 409 arms ahead of the InvalidOperationException 400 arm
- Full suite: 3,570 passed, 0 failed

Note: close #1261 manually on merge (dev PRs don't auto-close).

https://claude.ai/code/session_01Hn4pnKjamxf3NPX5bVsvnU