### PR TITLE
fix(gateway): single query-string credential policy for virtual-key extraction

### DIFF
--- a/Services/ConduitLLM.Gateway/Authentication/VirtualKeyAuthenticationHandler.cs
+++ b/Services/ConduitLLM.Gateway/Authentication/VirtualKeyAuthenticationHandler.cs
@@ -218,46 +218,10 @@ namespace ConduitLLM.Gateway.Authentication
         }
 
         /// <summary>
-        /// Extracts the Virtual Key from the request headers
+        /// Extracts the Virtual Key from the request
         /// </summary>
-        private string? ExtractVirtualKey(Microsoft.AspNetCore.Http.HttpContext context)
-        {
-            // For SignalR connections, check query string first
-            if (context.Request.Path.StartsWithSegments("/hubs"))
-            {
-                // Check for access_token in query string (standard for SignalR)
-                if (context.Request.Query.TryGetValue("access_token", out var accessToken))
-                {
-                    return accessToken.ToString();
-                }
-                
-                // Also check for api_key in query string
-                if (context.Request.Query.TryGetValue("api_key", out var apiKey))
-                {
-                    return apiKey.ToString();
-                }
-            }
-
-            // Try Authorization header first (Bearer token)
-            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(authHeader))
-            {
-                var token = SpanHelper.ExtractBearerToken(authHeader);
-                if (!string.IsNullOrEmpty(token))
-                {
-                    return token;
-                }
-            }
-
-            // Try X-API-Key header
-            var apiKeyHeader = context.Request.Headers["X-API-Key"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(apiKeyHeader))
-            {
-                return apiKeyHeader.Trim();
-            }
-
-            return null;
-        }
+        private static string? ExtractVirtualKey(Microsoft.AspNetCore.Http.HttpContext context) =>
+            VirtualKeyExtractor.Extract(context);
 
         /// <summary>
         /// Sanitizes a key for logging by showing only first few characters

--- a/Services/ConduitLLM.Gateway/Authentication/VirtualKeyExtractor.cs
+++ b/Services/ConduitLLM.Gateway/Authentication/VirtualKeyExtractor.cs
@@ -1,0 +1,57 @@
+using ConduitLLM.Core.Utilities;
+
+namespace ConduitLLM.Gateway.Authentication
+{
+    /// <summary>
+    /// The single policy for extracting a virtual key credential from an HTTP request.
+    /// </summary>
+    internal static class VirtualKeyExtractor
+    {
+        /// <summary>
+        /// Extracts the virtual key from the request, or null when none is present.
+        /// Query-string credentials (<c>access_token</c>, <c>api_key</c>) are accepted only on
+        /// SignalR hub paths: browsers cannot set headers on WebSocket handshakes, which is the
+        /// sole legitimate use. Query strings land in access logs and referrers, so header
+        /// credentials are required everywhere else.
+        /// </summary>
+        public static string? Extract(HttpContext? context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+
+            if (context.Request.Path.StartsWithSegments("/hubs"))
+            {
+                // access_token is SignalR's standard query parameter; api_key is a legacy alias.
+                if (context.Request.Query.TryGetValue("access_token", out var accessToken))
+                {
+                    return accessToken.ToString();
+                }
+
+                if (context.Request.Query.TryGetValue("api_key", out var apiKey))
+                {
+                    return apiKey.ToString();
+                }
+            }
+
+            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(authHeader))
+            {
+                var token = SpanHelper.ExtractBearerToken(authHeader);
+                if (!string.IsNullOrEmpty(token))
+                {
+                    return token;
+                }
+            }
+
+            var apiKeyHeader = context.Request.Headers["X-API-Key"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(apiKeyHeader))
+            {
+                return apiKeyHeader.Trim();
+            }
+
+            return null;
+        }
+    }
+}

--- a/Services/ConduitLLM.Gateway/Authentication/VirtualKeyHubFilter.cs
+++ b/Services/ConduitLLM.Gateway/Authentication/VirtualKeyHubFilter.cs
@@ -140,42 +140,8 @@ namespace ConduitLLM.Gateway.Authentication
         /// <summary>
         /// Extracts the Virtual Key from the request
         /// </summary>
-        private string? ExtractVirtualKey(Microsoft.AspNetCore.Http.HttpContext? httpContext)
-        {
-            if (httpContext == null) return null;
-
-            // Check query string first (for SignalR JavaScript clients)
-            if (httpContext.Request.Query.TryGetValue("access_token", out var queryToken))
-            {
-                return queryToken.ToString();
-            }
-            
-            // Also check for api_key in query string
-            if (httpContext.Request.Query.TryGetValue("api_key", out var queryKey))
-            {
-                return queryKey.ToString();
-            }
-
-            // Try Authorization header (for .NET clients)
-            var authHeader = httpContext.Request.Headers["Authorization"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(authHeader))
-            {
-                var token = SpanHelper.ExtractBearerToken(authHeader);
-                if (!string.IsNullOrEmpty(token))
-                {
-                    return token;
-                }
-            }
-
-            // Try X-API-Key header
-            var apiKeyHeader = httpContext.Request.Headers["X-API-Key"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(apiKeyHeader))
-            {
-                return apiKeyHeader.Trim();
-            }
-
-            return null;
-        }
+        private static string? ExtractVirtualKey(Microsoft.AspNetCore.Http.HttpContext? httpContext) =>
+            VirtualKeyExtractor.Extract(httpContext);
 
         /// <summary>
         /// Gets the client IP address from the request

--- a/Services/ConduitLLM.Gateway/Authentication/VirtualKeySignalRAuthenticationHandler.cs
+++ b/Services/ConduitLLM.Gateway/Authentication/VirtualKeySignalRAuthenticationHandler.cs
@@ -98,40 +98,8 @@ namespace ConduitLLM.Gateway.Authentication
         /// <summary>
         /// Extracts the Virtual Key from the request
         /// </summary>
-        private string? ExtractVirtualKey(HttpContext context)
-        {
-            // Check query string first (for SignalR JavaScript clients)
-            if (context.Request.Query.TryGetValue("access_token", out var queryToken))
-            {
-                return queryToken.ToString();
-            }
-            
-            // Also check for api_key in query string
-            if (context.Request.Query.TryGetValue("api_key", out var queryKey))
-            {
-                return queryKey.ToString();
-            }
-
-            // Try Authorization header (for .NET clients)
-            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(authHeader))
-            {
-                var token = SpanHelper.ExtractBearerToken(authHeader);
-                if (!string.IsNullOrEmpty(token))
-                {
-                    return token;
-                }
-            }
-
-            // Try X-API-Key header
-            var apiKeyHeader = context.Request.Headers["X-API-Key"].FirstOrDefault();
-            if (!string.IsNullOrEmpty(apiKeyHeader))
-            {
-                return apiKeyHeader.Trim();
-            }
-
-            return null;
-        }
+        private static string? ExtractVirtualKey(HttpContext context) =>
+            VirtualKeyExtractor.Extract(context);
 
         /// <summary>
         /// Gets the client IP address from the request

--- a/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyExtractorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyExtractorTests.cs
@@ -1,0 +1,82 @@
+using ConduitLLM.Gateway.Authentication;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ConduitLLM.Tests.Gateway.Authentication;
+
+/// <summary>
+/// Pins the credential-extraction policy: query-string credentials are accepted only on
+/// SignalR hub paths, header credentials everywhere (#1263).
+/// </summary>
+[Trait("Category", "Unit")]
+public class VirtualKeyExtractorTests
+{
+    private static DefaultHttpContext Context(string path, string? queryString = null)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        if (queryString != null)
+        {
+            context.Request.QueryString = new QueryString(queryString);
+        }
+        return context;
+    }
+
+    [Theory]
+    [InlineData("access_token")]
+    [InlineData("api_key")]
+    public void Extract_QueryStringCredential_OnHubPath_IsAccepted(string parameter)
+    {
+        var context = Context("/hubs/tasks", $"?{parameter}=condt_key");
+
+        VirtualKeyExtractor.Extract(context).Should().Be("condt_key");
+    }
+
+    [Theory]
+    [InlineData("/v1/chat/completions")]
+    [InlineData("/v1/embeddings")]
+    [InlineData("/v1/conduit/media/file")]
+    public void Extract_QueryStringCredential_OffHubPath_IsRejected(string path)
+    {
+        // Query strings land in access logs and referrers; only the SignalR WebSocket
+        // handshake (which cannot set headers from a browser) may use them.
+        var context = Context(path, "?access_token=condt_key&api_key=condt_key");
+
+        VirtualKeyExtractor.Extract(context).Should().BeNull();
+    }
+
+    [Fact]
+    public void Extract_BearerHeader_IsAccepted_OnAnyPath()
+    {
+        var context = Context("/v1/chat/completions");
+        context.Request.Headers.Authorization = "Bearer condt_key";
+
+        VirtualKeyExtractor.Extract(context).Should().Be("condt_key");
+    }
+
+    [Fact]
+    public void Extract_ApiKeyHeader_IsAccepted_AndTrimmed()
+    {
+        var context = Context("/v1/embeddings");
+        context.Request.Headers["X-API-Key"] = " condt_key ";
+
+        VirtualKeyExtractor.Extract(context).Should().Be("condt_key");
+    }
+
+    [Fact]
+    public void Extract_OnHubPath_QueryStringWins_OverHeaders()
+    {
+        var context = Context("/hubs/tasks", "?access_token=from_query");
+        context.Request.Headers.Authorization = "Bearer from_header";
+
+        VirtualKeyExtractor.Extract(context).Should().Be("from_query");
+    }
+
+    [Fact]
+    public void Extract_NullContext_ReturnsNull()
+    {
+        VirtualKeyExtractor.Extract(null).Should().BeNull();
+    }
+}


### PR DESCRIPTION
Implements #1263 from the dedup-audit backlog.

## Problem
`ExtractVirtualKey` existed three times in Gateway auth with a drifted security guard: only `VirtualKeyAuthenticationHandler` gated `?access_token=` / `?api_key=` extraction behind hub paths — `VirtualKeyHubFilter` and `VirtualKeySignalRAuthenticationHandler` accepted query-string credentials unconditionally. Query strings land in access logs and referrers, so this was a latent credential exposure if either component were ever wired to a non-hub path.

## Policy (now explicit and enforced in one place)
Query-string credentials are accepted **only under `/hubs`** — the SignalR WebSocket handshake cannot set headers from a browser, which is the sole legitimate use. Bearer and `X-API-Key` headers work everywhere. All Gateway hubs map under `/hubs` (verified against `Program.Endpoints.cs`), so no legitimate traffic changes behavior.

`VirtualKeyExtractor.Extract(HttpContext?)` is the single implementation; the three former copies are one-line delegations. The extractor enforces the path gate itself rather than taking an `allowQueryString` flag, so no caller can reopen the hole.

## Tests
- New `VirtualKeyExtractorTests` pin the policy: query-string accepted on hub paths, **rejected on non-hub paths**, headers accepted everywhere, hub-path query-string precedence, trim behavior, null context.
- Existing `VirtualKeyAuthenticationHandlerTests` (including the hub-path `access_token` case) pass unchanged.
- Full suite: 3,533 passed, 0 real failures — the 18 reported failures are all `Xunit.SkipException: Redis is not available` in `RedisMediaDeletionBudgetServiceTests` (the local test Redis went down between runs; unrelated to this change).

Note: close #1263 manually on merge (dev PRs don't auto-close).

https://claude.ai/code/session_01Hn4pnKjamxf3NPX5bVsvnU