### PR TITLE
refactor(config): delete dead 2023 hardcoded pricing from RequestLogService

### DIFF
--- a/Shared/ConduitLLM.Configuration/Interfaces/IRequestLogService.cs
+++ b/Shared/ConduitLLM.Configuration/Interfaces/IRequestLogService.cs
@@ -22,23 +22,6 @@ namespace ConduitLLM.Configuration.Interfaces
         Task<int?> GetVirtualKeyIdFromKeyValueAsync(string keyValue);
 
         /// <summary>
-        /// Estimates token counts for request and response
-        /// </summary>
-        /// <param name="requestContent">The request content</param>
-        /// <param name="responseContent">The response content</param>
-        /// <returns>Tuple of (inputTokens, outputTokens)</returns>
-        (int InputTokens, int OutputTokens) EstimateTokens(string requestContent, string responseContent);
-
-        /// <summary>
-        /// Calculates the cost of a request based on model and token counts
-        /// </summary>
-        /// <param name="modelName">Name of the model used</param>
-        /// <param name="inputTokens">Number of input tokens</param>
-        /// <param name="outputTokens">Number of output tokens</param>
-        /// <returns>The calculated cost</returns>
-        decimal CalculateCost(string modelName, int inputTokens, int outputTokens);
-
-        /// <summary>
         /// Gets usage statistics for a virtual key for a specified time period
         /// </summary>
         /// <param name="virtualKeyId">The virtual key ID</param>

--- a/Shared/ConduitLLM.Configuration/Services/RequestLogService.cs
+++ b/Shared/ConduitLLM.Configuration/Services/RequestLogService.cs
@@ -137,55 +137,6 @@ public class RequestLogService : BatchAuditServiceBase<RequestLog>, IRequestLogS
     #region Query Methods
 
     /// <inheritdoc/>
-    public decimal CalculateCost(string modelName, int inputTokens, int outputTokens)
-    {
-        // This is a simplified implementation - in a real system,
-        // you'd likely have a more sophisticated pricing model
-        decimal inputRate = 0;
-        decimal outputRate = 0;
-
-        // Set rates based on model
-        switch (modelName.ToLowerInvariant())
-        {
-            case string name when name.Contains("gpt-4"):
-                inputRate = 0.00001m;  // $0.01 per 1K tokens
-                outputRate = 0.00003m;  // $0.03 per 1K tokens
-                break;
-            case string name when name.Contains("gpt-3.5"):
-                inputRate = 0.0000015m;  // $0.0015 per 1K tokens
-                outputRate = 0.000002m;  // $0.002 per 1K tokens
-                break;
-            default:
-                inputRate = 0.000001m;  // Default rate
-                outputRate = 0.000002m;  // Default rate
-                break;
-        }
-
-        decimal inputCost = inputTokens * inputRate;
-        decimal outputCost = outputTokens * outputRate;
-
-        return inputCost + outputCost;
-    }
-
-    /// <inheritdoc/>
-    public (int InputTokens, int OutputTokens) EstimateTokens(string requestContent, string responseContent)
-    {
-        // This is a simplified implementation - in a real system,
-        // you'd likely use a tokenizer like GPT-2/3 BPE
-
-        // Rough estimate: ~4 characters per token for English text
-        int inputTokens = !string.IsNullOrEmpty(requestContent)
-            ? (int)Math.Ceiling(requestContent.Length / 4.0)
-            : 0;
-
-        int outputTokens = !string.IsNullOrEmpty(responseContent)
-            ? (int)Math.Ceiling(responseContent.Length / 4.0)
-            : 0;
-
-        return (inputTokens, outputTokens);
-    }
-
-    /// <inheritdoc/>
     public async Task<int?> GetVirtualKeyIdFromKeyValueAsync(string keyValue)
     {
         using var scope = ServiceProvider.CreateScope();


### PR DESCRIPTION
Implements #1273 from the dedup-audit backlog.

The caller check the issue asked for came back clean: `IRequestLogService` is consumed only through `LogRequestAsync` (Gateway's `UsageTrackingMiddleware` computes real costs via the ModelCost pipeline and passes them in). `CalculateCost` and `EstimateTokens` had **zero callers** — dead interface members carrying 2023 rates whose `Contains("gpt-4")` arm matched gpt-4o/gpt-4.1, mispriced by an order of magnitude had anyone ever wired them up. Both deleted from the interface and implementation.

Solution builds clean with the members gone (the compiler confirms no callers existed).

Note: close #1273 manually on merge.

https://claude.ai/code/session_01Hn4pnKjamxf3NPX5bVsvnU