### PR TITLE
fix(admin): AdminResults error bodies carry the same request id as the x-request-id header

### DIFF
--- a/Services/ConduitLLM.Admin/Endpoints/AdminResults.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/AdminResults.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 using ConduitLLM.Admin.DTOs;
 
 namespace ConduitLLM.Admin.Endpoints;
@@ -36,19 +34,58 @@ public static class AdminResults
         string? code = null,
         IReadOnlyDictionary<string, string[]>? errors = null,
         string? traceId = null) =>
-        Results.Json(
-            new AdminProblemDetails
-            {
-                Type = $"https://httpstatuses.com/{status}",
-                Title = TitleFor(status),
-                Status = status,
-                Detail = detail,
-                Code = code,
-                TraceId = traceId ?? Activity.Current?.TraceId.ToString() ?? Guid.NewGuid().ToString("N"),
-                Errors = errors
-            },
-            statusCode: status,
-            contentType: "application/problem+json");
+        new AdminProblemResult(status, detail, code, errors, traceId);
+
+    /// <summary>
+    /// Writes an <see cref="AdminProblemDetails"/> body whose TraceId matches the
+    /// x-request-id response header. Both come from HttpContext.TraceIdentifier — the
+    /// correlation ID set by CorrelationIdMiddleware, and the same source
+    /// ExceptionHandlingMiddlewareBase uses — so explicit error returns and
+    /// exception-mapped errors carry identical identifiers (#1262).
+    /// </summary>
+    private sealed class AdminProblemResult : IResult, IStatusCodeHttpResult
+    {
+        private readonly int _status;
+        private readonly string _detail;
+        private readonly string? _code;
+        private readonly IReadOnlyDictionary<string, string[]>? _errors;
+        private readonly string? _traceId;
+
+        public AdminProblemResult(
+            int status,
+            string detail,
+            string? code,
+            IReadOnlyDictionary<string, string[]>? errors,
+            string? traceId)
+        {
+            _status = status;
+            _detail = detail;
+            _code = code;
+            _errors = errors;
+            _traceId = traceId;
+        }
+
+        public int? StatusCode => _status;
+
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            var traceId = _traceId ?? httpContext.TraceIdentifier;
+            httpContext.Response.Headers["x-request-id"] = traceId;
+            return Results.Json(
+                new AdminProblemDetails
+                {
+                    Type = $"https://httpstatuses.com/{_status}",
+                    Title = TitleFor(_status),
+                    Status = _status,
+                    Detail = _detail,
+                    Code = _code,
+                    TraceId = traceId,
+                    Errors = _errors
+                },
+                statusCode: _status,
+                contentType: "application/problem+json").ExecuteAsync(httpContext);
+        }
+    }
 
     private static string TitleFor(int status) => status switch
     {

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/AdminResultsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/AdminResultsTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Admin.Endpoints;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ConduitLLM.Tests.Admin.Endpoints;
+
+/// <summary>
+/// Pins the #1262 contract fix: explicit AdminResults error returns carry the documented
+/// x-request-id header, and the body TraceId matches it (both from HttpContext.TraceIdentifier,
+/// the same source the exception middleware uses).
+/// </summary>
+[Trait("Category", "Unit")]
+public class AdminResultsTests
+{
+    private static async Task<(DefaultHttpContext Context, AdminProblemDetails Body)> ExecuteAsync(IResult result)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider(),
+            TraceIdentifier = "test-correlation-id"
+        };
+        using var bodyStream = new MemoryStream();
+        context.Response.Body = bodyStream;
+
+        await result.ExecuteAsync(context);
+
+        bodyStream.Position = 0;
+        var body = await JsonSerializer.DeserializeAsync<AdminProblemDetails>(
+            bodyStream, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        return (context, body!);
+    }
+
+    [Fact]
+    public async Task Problem_SetsRequestIdHeader_MatchingBodyTraceId()
+    {
+        var (context, body) = await ExecuteAsync(AdminResults.NotFound("Thing not found"));
+
+        context.Response.Headers["x-request-id"].ToString().Should().Be("test-correlation-id");
+        body.TraceId.Should().Be("test-correlation-id");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        context.Response.ContentType.Should().StartWith("application/problem+json");
+    }
+
+    [Fact]
+    public async Task Problem_ExplicitTraceId_WinsAndStaysConsistent()
+    {
+        var (context, body) = await ExecuteAsync(
+            AdminResults.Problem(StatusCodes.Status409Conflict, "Conflict", "conflict", traceId: "explicit-id"));
+
+        context.Response.Headers["x-request-id"].ToString().Should().Be("explicit-id");
+        body.TraceId.Should().Be("explicit-id");
+    }
+
+    [Fact]
+    public void Problem_ReportsStatusCode_ForEndpointMetadata()
+    {
+        var result = AdminResults.Conflict("duplicate");
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+}


### PR DESCRIPTION
Implements the safe half of #1262 from the dedup-audit backlog.

## What investigation found
The issue claimed `AdminResults.*` responses omit the documented `x-request-id` header. Not quite: `CorrelationIdMiddleware` (wired in Admin) already stamps the header on **every** response via `OnStarting`. The real defect is the body: `AdminProblemDetails.TraceId` — documented as *'Request identifier returned in the x-request-id response header'* — was generated independently (`Activity.Current?.TraceId ?? Guid.NewGuid()`), so **body and header never matched** on explicit error returns. Exception-mapped errors were consistent (both use `HttpContext.TraceIdentifier`, which the correlation middleware sets to the correlation ID); explicit returns were not.

## Change
`AdminResults.Problem` is now a small custom `IResult` (still implementing `IStatusCodeHttpResult` for endpoint metadata/tests) that:
- takes `TraceId` from `HttpContext.TraceIdentifier` — the same source the exception middleware and the response header use, so an operator can correlate any Admin error body with logs and the header, regardless of which path produced it
- sets `x-request-id` explicitly, so the documented guarantee no longer depends on the correlation middleware's `IncludeInResponse` configuration

No wire-shape change: same `application/problem+json` body, same fields — only the `TraceId` value now agrees with the header.

## Tests
New `AdminResultsTests` pin header/body agreement, explicit-traceId override consistency, and the preserved `IStatusCodeHttpResult` behavior. Full suite: 3,540 passed; the 18 reported failures are the known Redis-unavailable `RedisMediaDeletionBudgetServiceTests` environmental set (local test Redis still down).

**Leaves #1262 open**: the error-code vocabulary unification (middleware `invalid_operation`/… vs `AdminResults` `bad_request`/… vs framework `validation_error`) is a WebAdmin-visible contract change and still needs coordination.

https://claude.ai/code/session_01Hn4pnKjamxf3NPX5bVsvnU