### PR TITLE
ci: fix Validate-migrations check — restore manifest-pinned dotnet-ef instead of global install

### DIFF
--- a/.github/workflows/migration-validation.yml
+++ b/.github/workflows/migration-validation.yml
@@ -49,8 +49,12 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install dotnet-ef
-        run: dotnet tool install --global dotnet-ef
+      # The repo has a tool manifest (.config/dotnet-tools.json) pinning dotnet-ef;
+      # newer SDKs resolve the local manifest first, so a global install is shadowed
+      # and `dotnet ef` fails with "Run dotnet tool restore" until the manifest is
+      # restored. Restore the pinned tools instead of installing globally.
+      - name: Restore dotnet tools
+        run: dotnet tool restore
 
       # The validation script invokes dotnet-ef with --no-build
       - name: Build Configuration project


### PR DESCRIPTION
The Validate migrations workflow has failed on every dev run since the GitHub runner image update (~2026-07-26 23:49Z): the repo's tool manifest (`.config/dotnet-tools.json`) pins `dotnet-ef`, and the newer SDK resolves the local manifest first — so the workflow's `dotnet tool install --global dotnet-ef` is shadowed and `dotnet ef --version` exits non-zero with "Run \"dotnet tool restore\" to make the \"dotnet-ef\" command available." (surfaced by the diagnostic line added in PR #1318).

Fix: `dotnet tool restore` in place of the global install — restores the pinned tool set (dotnet-ef + reportgenerator), matching how local dev already runs the pinned version. Verified locally: after restore, `dotnet ef --version` succeeds.

Note: the manifest pins dotnet-ef 9.0.8 against the EF Core 10 runtime — that's the combination local dev already validates with (tools older than runtime emit a warning, not an error); bumping the pin to 10.x can be a follow-up if the warning bothers anyone.

Fixes #1346. Unblocks the red check on PR #1318 (and every other PR).