### PR TITLE
test: migrate to AwesomeAssertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />
     <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />

--- a/Tests/ConduitLLM.FaultInjectionTests/BillingFaultFixture.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/BillingFaultFixture.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Options;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Configuration.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.FaultInjectionTests/ConduitLLM.FaultInjectionTests.csproj
+++ b/Tests/ConduitLLM.FaultInjectionTests/ConduitLLM.FaultInjectionTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Testcontainers.Redis" />

--- a/Tests/ConduitLLM.FaultInjectionTests/MediaCancellationFaultTests.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/MediaCancellationFaultTests.cs
@@ -11,7 +11,7 @@ using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Core.Validation;
 using ConduitLLM.Gateway.EventHandlers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/Tests/ConduitLLM.FaultInjectionTests/SpendPersistenceFaultTests.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/SpendPersistenceFaultTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Gateway.Middleware;
 using ConduitLLM.Gateway.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 

--- a/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
+++ b/Tests/ConduitLLM.FaultInjectionTests/StreamingAbortFaultTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Endpoints;
 using ConduitLLM.Gateway.Middleware;
 using ConduitLLM.Gateway.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/Tests/ConduitLLM.IntegrationTests/ConduitLLM.IntegrationTests.csproj
+++ b/Tests/ConduitLLM.IntegrationTests/ConduitLLM.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="YamlDotNet" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/Tests/ConduitLLM.IntegrationTests/Core/ProviderIntegrationTestBase.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/ProviderIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Core/TestHelpers.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Core/TestHelpers.cs
@@ -1,6 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using StackExchange.Redis;

--- a/Tests/ConduitLLM.IntegrationTests/Infrastructure/CriticalPathTestBase.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Infrastructure/CriticalPathTestBase.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Infrastructure/SignalRIntegrationTestBase.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Infrastructure/SignalRIntegrationTestBase.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.IntegrationTests.Infrastructure;
@@ -117,7 +117,7 @@ public abstract class SignalRIntegrationTestBase : IAsyncLifetime
     }
 
     /// <summary>
-    /// Asserts connection state with FluentAssertions.
+    /// Asserts connection state with AwesomeAssertions.
     /// </summary>
     protected static void AssertConnectionState(HubConnection connection, HubConnectionState expectedState)
     {

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CerebrasEndToEndTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CerebrasEndToEndTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/AuthenticationIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/AuthenticationIntegrationTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/CachingIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/CachingIntegrationTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/ProviderFailoverIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/ProviderFailoverIntegrationTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/RequestPipelineIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/CriticalPath/RequestPipelineIntegrationTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/GroqEndToEndTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/GroqEndToEndTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/PostgresDistributedLockServiceTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/PostgresDistributedLockServiceTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration;
 using ConduitLLM.Core.Services;
 using ConduitLLM.IntegrationTests.Infrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/ProviderBillingIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/ProviderBillingIntegrationTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SambaNovaEndToEndTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SambaNovaEndToEndTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRConnectionLifecycleTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRConnectionLifecycleTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.SignalR.Client;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using ConduitLLM.IntegrationTests.Infrastructure;
 using System.Collections.Concurrent;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRGroupManagementTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRGroupManagementTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.SignalR.Client;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using ConduitLLM.IntegrationTests.Infrastructure;
 using System.Collections.Concurrent;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMessagePackIntegrationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMessagePackIntegrationTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using System;
 using System.Threading.Tasks;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMessageQueueRecoveryTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMessageQueueRecoveryTests.cs
@@ -6,7 +6,7 @@ using ConduitLLM.Gateway.Models;
 using ConduitLLM.Gateway.Services;
 using ConduitLLM.IntegrationTests.Infrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMultiClientTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRMultiClientTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.SignalR.Client;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using ConduitLLM.IntegrationTests.Infrastructure;
 using System.Collections.Concurrent;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRProtocolNegotiationTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRProtocolNegotiationTests.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using System;
 using System.Threading.Tasks;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/SignalRRedisBackplaneTests.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/SignalRRedisBackplaneTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.SignalR.Client;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 using ConduitLLM.IntegrationTests.Infrastructure;
 using System.Collections.Concurrent;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithReasoningTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithReasoningTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Text;

--- a/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithToolCallsTest.cs
+++ b/Tests/ConduitLLM.IntegrationTests/Tests/StreamingWithToolCallsTest.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Text;

--- a/Tests/ConduitLLM.Tests/Admin/Contracts/BoundaryDtoTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Contracts/BoundaryDtoTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Core.Models.Pricing;
 using ConduitLLM.Functions.Entities;
 using ConduitLLM.Functions.Utilities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Contracts;
 

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/AdminResultsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/AdminResultsTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Endpoints;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringAggregationTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringAggregationTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Admin.Interfaces;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Endpoints;
 

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringDependencyTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringDependencyTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Interfaces;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringHistoryTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringHistoryTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringIncidentTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/HealthMonitoringIncidentTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/JsonMergePatchTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/JsonMergePatchTests.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 using ConduitLLM.Admin.Endpoints;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/MediaPrunePolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/MediaPrunePolicyTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Endpoints;
 

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderConnectionTestEndpointTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderConnectionTestEndpointTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderKeySecretSettingsEndpointTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderKeySecretSettingsEndpointTests.cs
@@ -7,7 +7,7 @@ using ConduitLLM.Configuration.Security;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;

--- a/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderSettingsSchemaEndpointTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Endpoints/ProviderSettingsSchemaEndpointTests.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Providers;
 using ConduitLLM.Providers.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/Tests/ConduitLLM.Tests/Admin/EventHandlers/GatewayHeartbeatHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/EventHandlers/GatewayHeartbeatHandlerTests.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Core.Constants;
 using ConduitLLM.Core.Events;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/Admin/Extensions/MediaLifecycleExtensionsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Extensions/MediaLifecycleExtensionsTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Extensions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Options;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/Tests/ConduitLLM.Tests/Admin/Integration/ModelAuthorEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Integration/ModelAuthorEndpointsTests.cs
@@ -14,7 +14,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Converters;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/Tests/ConduitLLM.Tests/Admin/Models/ModelAuthors/ModelAuthorDtoTests.Serialization.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/ModelAuthors/ModelAuthorDtoTests.Serialization.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Admin.Models.ModelAuthors;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.ModelAuthors
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Mapping.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Mapping.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Models.ModelSeries;
 using ConduitLLM.Configuration.Entities;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.ModelSeries
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Serialization.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Serialization.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Admin.Models.ModelSeries;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.ModelSeries
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Validation.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/ModelSeries/ModelSeriesDtoTests.Validation.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Admin.Models.ModelSeries;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.ModelSeries
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Mapping.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Mapping.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Admin.Models.Models;
 using ConduitLLM.Configuration.Entities;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.Models
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Serialization.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Serialization.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using ConduitLLM.Admin.Models.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.Models
 {

--- a/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Validation.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Models/Models/ModelDtoTests.Validation.cs
@@ -1,5 +1,5 @@
 using ConduitLLM.Admin.Models.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Models.Models
 {

--- a/Tests/ConduitLLM.Tests/Admin/OpenApi/DefaultErrorResponsesOperationTransformerTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/OpenApi/DefaultErrorResponsesOperationTransformerTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 using ConduitLLM.Admin.OpenApi;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminGlobalSettingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminGlobalSettingServiceTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Configuration.Messaging;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminHeartbeatPublisherTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminHeartbeatPublisherTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 using ConduitLLM.Core.Constants;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminIpFilterServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminIpFilterServiceTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Options;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using ConduitLLM.Configuration.Messaging;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminMediaServiceSoftDeleteTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminMediaServiceSoftDeleteTests.cs
@@ -7,7 +7,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Options;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceRoundTripTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceRoundTripTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Core.Events;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Create.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Create.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Delete.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Delete.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.EdgeCases.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.EdgeCases.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Get.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Get.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Configuration.Entities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.ImportExport.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.ImportExport.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Events;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 
 namespace ConduitLLM.Tests.Admin.Services;

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Update.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminModelCostServiceTests.Update.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/AdminNotificationServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/AdminNotificationServiceTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Admin.Services;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/ApiKeyTestResultServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ApiKeyTestResultServiceTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.DTOs;
 using ConduitLLM.Core.Exceptions;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Services;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupApprovalServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupApprovalServiceTests.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Options;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupServiceTests.cs
@@ -13,7 +13,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupStatusServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaCleanupStatusServiceTests.cs
@@ -9,7 +9,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Options;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaDeletionEngineTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaDeletionEngineTests.cs
@@ -9,7 +9,7 @@ using ConduitLLM.Configuration.Options;
 using ConduitLLM.Core.Events;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaReconciliationServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaReconciliationServiceTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Configuration.Options;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/MediaStorageConfigurationGuardTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/MediaStorageConfigurationGuardTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/ModelCostCanaryHostedServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ModelCostCanaryHostedServiceTests.cs
@@ -7,7 +7,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Admin/Services/ModelProviderTypeAssociationCostTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ModelProviderTypeAssociationCostTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Services;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Admin/Services/OpenRouterDriftDetectionServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/OpenRouterDriftDetectionServiceTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Configuration.Enums;
 using ConduitLLM.Configuration.Options;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;

--- a/Tests/ConduitLLM.Tests/Admin/Services/RefundServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/RefundServiceTests.cs
@@ -6,7 +6,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatEvaluatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatEvaluatorTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Admin.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Admin.Services;
 

--- a/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatStoreTests.cs
+++ b/Tests/ConduitLLM.Tests/Admin/Services/ServiceHeartbeatStoreTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Admin.Interfaces;
 using ConduitLLM.Admin.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj
+++ b/Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Moq.Contrib.HttpClient" />
     <PackageReference Include="bunit" />
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="AutoFixture.Xunit2" />
     <PackageReference Include="AutoFixture.AutoMoq" />

--- a/Tests/ConduitLLM.Tests/Configuration/Events/ProviderKeyCredentialEventsTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Events/ProviderKeyCredentialEventsTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using ConduitLLM.Configuration.Events;
 using ConduitLLM.Core.Events;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Configuration.Events;
 

--- a/Tests/ConduitLLM.Tests/Configuration/Repositories/MediaRecordAggregateStatsTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Repositories/MediaRecordAggregateStatsTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Configuration/Repositories/MediaRecordSoftDeleteTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Repositories/MediaRecordSoftDeleteTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Tests.TestInfrastructure;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ConduitLLM.Tests.Configuration.Repositories;

--- a/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyRepositoryExampleTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyRepositoryExampleTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyRepositoryTests.GetTopEnabled.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Repositories/VirtualKeyRepositoryTests.GetTopEnabled.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Repositories;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Configuration/Services/GlobalSettingsCacheServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Services/GlobalSettingsCacheServiceTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Configuration.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Configuration/SimpleSupportsChatTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/SimpleSupportsChatTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Configuration.Entities;
 
 namespace ConduitLLM.Tests.Configuration

--- a/Tests/ConduitLLM.Tests/Core/Configuration/VideoGenerationRetryConfigurationTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Configuration/VideoGenerationRetryConfigurationTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Configuration;
 

--- a/Tests/ConduitLLM.Tests/Core/Consumers/GlobalSettingCacheInvalidationHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Consumers/GlobalSettingCacheInvalidationHandlerTests.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Consumers;
 using ConduitLLM.Core.Events;
 using ConduitLLM.Tests.Messaging;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;

--- a/Tests/ConduitLLM.Tests/Core/Converters/UtcDateTimeConverterTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Converters/UtcDateTimeConverterTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using ConduitLLM.Core.Converters;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.Tests.Core.Converters;

--- a/Tests/ConduitLLM.Tests/Core/Decorators/ContextAwareLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Decorators/ContextAwareLLMClientTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Core.Decorators;
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;

--- a/Tests/ConduitLLM.Tests/Core/Decorators/PromptCachingLLMClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Decorators/PromptCachingLLMClientTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Decorators;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Diagnostics/BuildMetadataTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Diagnostics/BuildMetadataTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Diagnostics;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Diagnostics;
 

--- a/Tests/ConduitLLM.Tests/Core/Events/ConnectionLimitExceededTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Events/ConnectionLimitExceededTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Core.Events;
 
 namespace ConduitLLM.Tests.Core.Events

--- a/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Exceptions/ExceptionToResponseMapperTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Exceptions;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Functions.Exceptions;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Core/Extensions/LoggingSanitizerTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Extensions/LoggingSanitizerTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Configuration.Utilities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Core/Extensions/PrometheusMetricsEndpointExtensionsTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Extensions/PrometheusMetricsEndpointExtensionsTests.cs
@@ -7,7 +7,7 @@ using ConduitLLM.Core.Extensions;
 using ConduitLLM.Gateway.Middleware;
 using ConduitLLM.Gateway.Metrics;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/Tests/ConduitLLM.Tests/Core/Models/OpenAIRequestContractTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/OpenAIRequestContractTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Models;
 

--- a/Tests/ConduitLLM.Tests/Core/Models/ReasoningConfigTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/ReasoningConfigTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Core/Models/ResponseFormatTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/ResponseFormatTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Core/Models/UsageSerializationTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Models/UsageSerializationTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Models;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.BulkOperations.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.BulkOperations.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Cancellation.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Cancellation.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Concurrency.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Concurrency.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Services
 {

--- a/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Core.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Core.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Registration.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CancellableTaskRegistryTests.Registration.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CorrelationContextServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CorrelationContextServiceTests.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceAdditionalTests.ConcurrentAndThreadSafety.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceAdditionalTests.ConcurrentAndThreadSafety.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestHelpers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using ConduitLLM.Configuration.Entities;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.AdvancedFeatures.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.AdvancedFeatures.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestHelpers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using ConduitLLM.Configuration.Entities;

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Audio.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Audio.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.BasicCalculations.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.BasicCalculations.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestHelpers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using ConduitLLM.Configuration.Entities;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Core.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.Core.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ErrorHandling.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ErrorHandling.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Tests.TestHelpers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using ConduitLLM.Configuration.Entities;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.IdBasedLookup.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.IdBasedLookup.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ProviderReportedCost.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBasicTests.ProviderReportedCost.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBatchTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceBatchTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using Xunit.Abstractions;
 using ConduitLLM.Configuration.Entities;

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceCachedTokenTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceCachedTokenTests.cs
@@ -1,5 +1,5 @@
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using Xunit.Abstractions;
 using ConduitLLM.Configuration.Entities;

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.Basic.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.Basic.cs
@@ -1,5 +1,5 @@
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using ConduitLLM.Configuration.Entities;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.OriginalCharge.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.OriginalCharge.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.ProviderCost.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceRefundTests.ProviderCost.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceSearchAndInferenceTests.SearchUnits.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/CostCalculationServiceSearchAndInferenceTests.SearchUnits.cs
@@ -1,5 +1,5 @@
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Moq;
 using ConduitLLM.Configuration.Entities;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/InMemoryMediaDeletionBudgetServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/InMemoryMediaDeletionBudgetServiceTests.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;

--- a/Tests/ConduitLLM.Tests/Core/Services/MediaQuotaServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/MediaQuotaServiceTests.cs
@@ -6,7 +6,7 @@ using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Tests.TestInfrastructure;
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/PerformanceMetricsServiceTests.StreamingTracker.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/PerformanceMetricsServiceTests.StreamingTracker.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/PostgresDistributedLockServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/PostgresDistributedLockServiceTests.cs
@@ -1,5 +1,5 @@
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Services;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/PromptCacheInjectionServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/PromptCacheInjectionServiceTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Services;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/PromptCachingV3PolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/PromptCachingV3PolicyTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Services;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/RedisMediaDeletionBudgetFailureModeTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/RedisMediaDeletionBudgetFailureModeTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Configuration.Options;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Core/Services/RedisMediaDeletionBudgetServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/RedisMediaDeletionBudgetServiceTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using StackExchange.Redis;

--- a/Tests/ConduitLLM.Tests/Core/Services/S3MediaStorageServiceTests.BasicOperations.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/S3MediaStorageServiceTests.BasicOperations.cs
@@ -6,7 +6,7 @@ using Amazon.S3.Model;
 
 using ConduitLLM.Core.Models;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Core/Services/WebhookCircuitBreakerTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Services/WebhookCircuitBreakerTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Core/Utilities/IpAddressHelperTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Utilities/IpAddressHelperTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 
 using ConduitLLM.Core.Utilities;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 
 namespace ConduitLLM.Tests.Core.Utilities

--- a/Tests/ConduitLLM.Tests/Core/Utilities/IpFilterEvaluatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Utilities/IpFilterEvaluatorTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Constants;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Utilities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Utilities
 {

--- a/Tests/ConduitLLM.Tests/Core/Utilities/VideoUtilsResolutionTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Utilities/VideoUtilsResolutionTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Core.Utilities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Utilities
 {

--- a/Tests/ConduitLLM.Tests/Core/Validation/UsageValidatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Core/Validation/UsageValidatorTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Validation;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Core.Validation;
 

--- a/Tests/ConduitLLM.Tests/Functions/Utilities/JsonElementConverterTests.cs
+++ b/Tests/ConduitLLM.Tests/Functions/Utilities/JsonElementConverterTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Functions.Utilities;
 
 namespace ConduitLLM.Tests.Functions.Utilities

--- a/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyExtractorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Authentication/VirtualKeyExtractorTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Gateway.Authentication;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ChatEndpointErrorStatusTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ChatEndpointErrorStatusTests.cs
@@ -12,7 +12,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Gateway.Options;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayHttpContextExtensionsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayHttpContextExtensionsTests.cs
@@ -2,7 +2,7 @@ using System.Security.Claims;
 
 using ConduitLLM.Gateway.Endpoints;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayInternalOperationsEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/GatewayInternalOperationsEndpointsTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Gateway.Endpoints;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/MediaEndpointsSoftDeleteTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/MediaEndpointsSoftDeleteTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Gateway.Endpoints;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/MigratedGatewayEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/MigratedGatewayEndpointsTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Gateway.Endpoints;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ModelsEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ModelsEndpointsTests.cs
@@ -9,7 +9,7 @@ using ConduitLLM.Gateway.DTOs;
 using ConduitLLM.Gateway.Endpoints;
 using ConduitLLM.Gateway.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Endpoints/ResponsesEndpointsTests.cs
@@ -11,7 +11,7 @@ using ConduitLLM.Gateway.Endpoints;
 using ConduitLLM.Gateway.Options;
 using ConduitLLM.Gateway.UsageTracking;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/Gateway/EventHandlers/SpendUpdateProcessorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/EventHandlers/SpendUpdateProcessorTests.cs
@@ -6,7 +6,7 @@ using ConduitLLM.Core.Events;
 using ConduitLLM.Gateway.EventHandlers;
 using ConduitLLM.Tests.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Metrics/GatewayRateLimitMetricsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Metrics/GatewayRateLimitMetricsTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Gateway.Metrics;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Prometheus;
 

--- a/Tests/ConduitLLM.Tests/Gateway/Middleware/VirtualKeyRateLimitMiddlewareTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Middleware/VirtualKeyRateLimitMiddlewareTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Middleware;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/OpenAICompatibility/OpenAIHttpCompatibilityTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/OpenAICompatibility/OpenAIHttpCompatibilityTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/ConcurrencyRateLimitServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/ConcurrencyRateLimitServiceTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Constants;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/ModelRateLimitTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/ModelRateLimitTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Constants;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RateLimitFailurePolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RateLimitFailurePolicyTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Middleware;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/RequestTokenEstimatorTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Gateway/RateLimiting/TokenRateLimitServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/RateLimiting/TokenRateLimitServiceTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Constants;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.RateLimiting;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/Services/PerKeyIpFilterServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/Services/PerKeyIpFilterServiceTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Gateway.Interfaces;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Gateway/SignalR/MessagePackCompressionTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/SignalR/MessagePackCompressionTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using FluentAssertions;
+using AwesomeAssertions;
 using System.Buffers;
 using System.Text;
 using System.Text.Json;

--- a/Tests/ConduitLLM.Tests/Gateway/SignalR/MessagePackProtocolTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/SignalR/MessagePackProtocolTests.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Gateway.SignalR
 {

--- a/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRConnectionMonitorTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRConnectionMonitorTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Options;
 using ConduitLLM.Configuration.Services;
 using ConduitLLM.Gateway.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;

--- a/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRMessageQueueSerializationTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRMessageQueueSerializationTests.cs
@@ -4,7 +4,7 @@ using ConduitLLM.Core.Models.SignalR;
 using ConduitLLM.Gateway.Models;
 using ConduitLLM.Gateway.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Gateway.SignalR;
 

--- a/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRProtocolMetricsTests.cs
+++ b/Tests/ConduitLLM.Tests/Gateway/SignalR/SignalRProtocolMetricsTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Diagnostics.Metrics;
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Messaging/EndpointPolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/EndpointPolicyTests.cs
@@ -2,7 +2,7 @@ using System;
 
 using ConduitLLM.Configuration.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Messaging/EventBusBackendContractTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/EventBusBackendContractTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Tests/ConduitLLM.Tests/Messaging/MessagingBackendResolverTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/MessagingBackendResolverTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Configuration.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineBridgePilotTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineBridgePilotTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineBusHealthCheckTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineBusHealthCheckTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineEndpointPolicyTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineEndpointPolicyTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineEventBusTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineEventBusTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineHandlerBridgeTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineHandlerBridgeTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Messaging/WolverineInMemoryTransportTests.cs
+++ b/Tests/ConduitLLM.Tests/Messaging/WolverineInMemoryTransportTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/ConduitLLM.Tests/OpenApi/AuthoritativeContractTests.cs
+++ b/Tests/ConduitLLM.Tests/OpenApi/AuthoritativeContractTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 using AdminOperationIdValidator = ConduitLLM.Admin.OpenApi.OperationIdValidationDocumentTransformer;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.OpenApi;
 

--- a/Tests/ConduitLLM.Tests/OpenApi/UnusedSchemaPruningDocumentTransformerTests.cs
+++ b/Tests/ConduitLLM.Tests/OpenApi/UnusedSchemaPruningDocumentTransformerTests.cs
@@ -2,7 +2,7 @@ using System.Net.Http;
 
 using ConduitLLM.Gateway.OpenApi;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.OpenApi;
 

--- a/Tests/ConduitLLM.Tests/Providers/AzureProviderSettingsTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/AzureProviderSettingsTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Providers.Authentication;
 using ConduitLLM.Providers.Configuration;
 using ConduitLLM.Providers.OpenAI;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Providers/BalancedRouteScorerTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/BalancedRouteScorerTests.cs
@@ -3,7 +3,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsEventStreamReaderTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsEventStreamReaderTests.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 using ConduitLLM.Providers.Streaming;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsSigV4SignerTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/AwsSigV4SignerTests.cs
@@ -2,7 +2,7 @@ using System.Net.Http.Headers;
 
 using ConduitLLM.Providers.Authentication;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockClientTests.cs
@@ -8,7 +8,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.Bedrock;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockProviderSettingsTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Bedrock/BedrockProviderSettingsTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Providers.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Providers/ErrorClassificationTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ErrorClassificationTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.Tests.Providers

--- a/Tests/ConduitLLM.Tests/Providers/Helpers/AsyncJobPollerTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Helpers/AsyncJobPollerTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Metrics;
 using ConduitLLM.Providers.Helpers;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Providers/Helpers/ContentHelperTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Helpers/ContentHelperTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.Helpers;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.Tests.Providers.Helpers;

--- a/Tests/ConduitLLM.Tests/Providers/OpenAI/OpenAIErrorParsingTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenAI/OpenAIErrorParsingTests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using ConduitLLM.Core.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.Tests.Providers.OpenAI

--- a/Tests/ConduitLLM.Tests/Providers/OpenAICompatibleMappingTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenAICompatibleMappingTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.OpenAICompatible;
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace ConduitLLM.Tests.Providers;

--- a/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/OpenRouterClientTests.cs
@@ -10,7 +10,7 @@ using ConduitLLM.Core.Models.Audio;
 using ConduitLLM.Core.Models.Rerank;
 using ConduitLLM.Providers.OpenRouter;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 using Moq.Protected;

--- a/Tests/ConduitLLM.Tests/Providers/ProviderDefaultsRegistryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ProviderDefaultsRegistryTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Providers;
 using ConduitLLM.Providers.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using Moq;

--- a/Tests/ConduitLLM.Tests/Providers/ProviderSecretSettingsTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/ProviderSecretSettingsTests.cs
@@ -2,7 +2,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Security;
 using ConduitLLM.Providers.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Providers/RouteCircuitRegistryTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/RouteCircuitRegistryTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Providers;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Providers;
 

--- a/Tests/ConduitLLM.Tests/Providers/Vertex/GoogleServiceAccountTokenProviderTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Vertex/GoogleServiceAccountTokenProviderTests.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 using ConduitLLM.Providers.Vertex;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Moq;
 

--- a/Tests/ConduitLLM.Tests/Providers/Vertex/VertexClientTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Vertex/VertexClientTests.cs
@@ -10,7 +10,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.Vertex;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Tests/ConduitLLM.Tests/Providers/Vertex/VertexProviderSettingsTests.cs
+++ b/Tests/ConduitLLM.Tests/Providers/Vertex/VertexProviderSettingsTests.cs
@@ -5,7 +5,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Providers.Configuration;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/Tests/ConduitLLM.Tests/Security/Authorization/HealthKeyAuthorizationHandlerTests.cs
+++ b/Tests/ConduitLLM.Tests/Security/Authorization/HealthKeyAuthorizationHandlerTests.cs
@@ -3,7 +3,7 @@ using System.Security.Claims;
 
 using ConduitLLM.Security.Authorization;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/Tests/ConduitLLM.Tests/Security/FixedWindowCounterTests.cs
+++ b/Tests/ConduitLLM.Tests/Security/FixedWindowCounterTests.cs
@@ -1,7 +1,7 @@
 using ConduitLLM.Security.Services;
 using ConduitLLM.Tests.Core.Services;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.Blacklist.cs
+++ b/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.Blacklist.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Security
 {

--- a/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.IsAllowed.cs
+++ b/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.IsAllowed.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Security
 {

--- a/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.OtherTests.cs
+++ b/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.OtherTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;

--- a/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.Whitelist.cs
+++ b/Tests/ConduitLLM.Tests/Security/IpFilteringServiceTests.Whitelist.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace ConduitLLM.Tests.Security
 {

--- a/Tests/ConduitLLM.Tests/Security/Middleware/HealthEndpointAuthorizationMiddlewareTests.cs
+++ b/Tests/ConduitLLM.Tests/Security/Middleware/HealthEndpointAuthorizationMiddlewareTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using ConduitLLM.Security.Authorization;
 using ConduitLLM.Security.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/Tests/ConduitLLM.Tests/Security/SecurityMiddlewareBaseTests.cs
+++ b/Tests/ConduitLLM.Tests/Security/SecurityMiddlewareBaseTests.cs
@@ -1,6 +1,6 @@
 using ConduitLLM.Security.Middleware;
 using ConduitLLM.Security.Models;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/Tests/ConduitLLM.Tests/Services/PricingRulesEngineTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/PricingRulesEngineTests.cs
@@ -6,7 +6,7 @@ using ConduitLLM.Configuration.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Models.Pricing;
 using ConduitLLM.Core.Services;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;

--- a/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Services/ProviderErrorTrackingServiceTests.cs
@@ -10,7 +10,7 @@ using ConduitLLM.Core.Services;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Tests.Builders;
 using ConduitLLM.Configuration.Messaging;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/Tests/ConduitLLM.Tests/Utilities/ParameterConverterTests.cs
+++ b/Tests/ConduitLLM.Tests/Utilities/ParameterConverterTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using ConduitLLM.Providers.Utilities;
 
 namespace ConduitLLM.Tests.Utilities


### PR DESCRIPTION
## Summary

- replace FluentAssertions 8.10.0 with Apache-2.0 AwesomeAssertions 9.5.0
- update assertion namespaces across unit, integration, and fault-injection tests
- preserve the existing assertion API and test behavior

## Verification

- `dotnet restore Conduit.slnx`
- `dotnet build Conduit.slnx --no-restore --configuration Release` (0 errors)
- repository CI-filtered solution test command passed
- billing invariants: 123 passed, 1 skipped, 0 failed
- billing fault injection: 4 passed, 0 failed
- SignalR integration: 43 passed; 3 queue-recovery tests failed identically on this branch and unmodified `origin/dev` (same actual values and source lines), confirming they are pre-existing rather than migration regressions

The regular CI workflow only runs for PRs targeting `master`; the `dev`-targeted workflows are path-filtered and do not match this test-only dependency change.

Closes #1064