### PR TITLE
Harden JSON, media RDG, and release migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,11 @@
 # Core Database Configuration
 # ===========================================
 DATABASE_URL=postgresql://conduit:conduitpass@postgres:5432/conduitdb
-# Migration startup behavior: Apply (default; migrate inline under advisory lock),
-# Wait (never migrate; gate /health/ready until an external `migrate` run catches
-# the schema up), or Skip (tests only).
-# See docs/configuration.md#deploy-time-configuration-the-environment
-#CONDUIT_MIGRATION_MODE=Apply
+# Normal services never mutate the schema. Wait is the default and gates
+# /health/ready until the explicit `migrate` command catches the schema up.
+# Skip bypasses the check and is for tests/break-glass use only. Apply was removed.
+# See docs/operations/deployment/migration-deployment-strategy.md
+#CONDUIT_MIGRATION_MODE=Wait
 #CONDUIT_MIGRATION_LOCK_TIMEOUT_SECONDS=300
 #CONDUIT_MIGRATION_WAIT_TIMEOUT_SECONDS=0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
           TEST_REDIS_CONNECTION: localhost:6379
           DATABASE_URL: postgresql://conduit:conduitpass@localhost:5432/conduitdb
 
+      - name: Admin media request-delegate generation guard
+        shell: pwsh
+        run: ./scripts/test/verify-admin-media-rdg.ps1 -NoRestore
+
       # Wolverine build-ahead codegen check (#961): compiles the handler chain for EVERY
       # registered event type up front via JasperFx's `codegen preview`, so codegen /
       # service-location incompatibilities (the class of defect behind W2 in the #929 S1

--- a/.github/workflows/migration-validation.yml
+++ b/.github/workflows/migration-validation.yml
@@ -5,13 +5,17 @@ on:
     branches: [master, dev]
     paths:
       - 'Shared/ConduitLLM.Configuration/**'
+      - 'Tests/ConduitLLM.Tests/Configuration/Data/**'
       - 'scripts/migrations/**'
+      - '.github/workflows/release.yml'
       - '.github/workflows/migration-validation.yml'
   pull_request:
     branches: [master, dev]
     paths:
       - 'Shared/ConduitLLM.Configuration/**'
+      - 'Tests/ConduitLLM.Tests/Configuration/Data/**'
       - 'scripts/migrations/**'
+      - '.github/workflows/release.yml'
       - '.github/workflows/migration-validation.yml'
 
 env:
@@ -63,6 +67,13 @@ jobs:
       - name: Validate migrations
         shell: pwsh
         run: ./scripts/migrations/validate-migrations.ps1 -CheckPending
+
+      - name: Exercise release migration gate
+        run: >-
+          dotnet test Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj
+          --configuration Release
+          --filter FullyQualifiedName~ReleaseMigrationCommandTests
+          --no-restore
 
       - name: Generate idempotent migration script
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Release
+  metadata:
+    name: Release metadata
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
-    
+      contents: read
+
     outputs:
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.version.outputs.channel }}
@@ -33,8 +32,6 @@ jobs:
       - name: Extract version and channel
         id: version
         # A tag is a pre-release iff its name contains a hyphen (SemVer rule).
-        # This single decision drives the GitHub Release flag and the Docker
-        # floating tag so both channels stay consistent.
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -48,20 +45,10 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ steps.version.outputs.prerelease }}
-          # Only stable releases become the repo's "Latest" (and appear in
-          # /releases/latest); betas never move the badge.
-          make_latest: ${{ steps.version.outputs.channel == 'latest' }}
-
   docker:
-    name: Docker - ${{ matrix.service }}
+    name: Build candidate - ${{ matrix.service }}
     runs-on: ubuntu-latest
-    needs: release
+    needs: metadata
     permissions:
       contents: read
       packages: write
@@ -91,21 +78,98 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push candidate
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
           push: true
-          # Immutable version pin + the floating channel tag (:latest for stable,
-          # :beta for pre-releases). A pre-release never overwrites :latest.
-          tags: |
-            ${{ env.REGISTRY }}/nickna/conduit-${{ matrix.service }}:${{ needs.release.outputs.version }}
-            ${{ env.REGISTRY }}/nickna/conduit-${{ matrix.service }}:${{ needs.release.outputs.channel }}
+          # Candidate tags are not consumed by deployments. Official version/channel
+          # tags are promoted only after the production migration succeeds.
+          tags: ${{ env.REGISTRY }}/nickna/conduit-${{ matrix.service }}:${{ needs.metadata.outputs.version }}-candidate
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
           build-args: |
-            VERSION=${{ needs.release.outputs.version }}
-            COMMIT_SHA=${{ needs.release.outputs.commit_sha }}
-            BUILD_TIMESTAMP=${{ needs.release.outputs.build_timestamp }}
+            VERSION=${{ needs.metadata.outputs.version }}
+            COMMIT_SHA=${{ needs.metadata.outputs.commit_sha }}
+            BUILD_TIMESTAMP=${{ needs.metadata.outputs.build_timestamp }}
+
+  migrate:
+    name: Production migration gate
+    runs-on: ubuntu-latest
+    needs: [metadata, docker]
+    environment: production
+    permissions:
+      contents: read
+      packages: read
+    env:
+      DATABASE_URL: ${{ secrets.CONDUIT_RELEASE_DATABASE_URL }}
+
+    steps:
+      - name: Require release database secret
+        run: test -n "$DATABASE_URL"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply database migrations
+        # A non-zero migrator exit code stops the workflow before any official image
+        # tag or GitHub Release is updated. Re-running the job is idempotent.
+        run: |
+          docker run --rm \
+            --env DATABASE_URL \
+            --env CONDUIT_MIGRATION_LOCK_TIMEOUT_SECONDS=600 \
+            --env ConduitLLM__Messaging__Wolverine__AutoProvision=false \
+            "${{ env.REGISTRY }}/nickna/conduit-admin:${{ needs.metadata.outputs.version }}-candidate" \
+            migrate
+
+  promote:
+    name: Promote release images
+    runs-on: ubuntu-latest
+    needs: [metadata, migrate]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote candidate tags
+        run: |
+          for SERVICE in webadmin http admin; do
+            SOURCE="${{ env.REGISTRY }}/nickna/conduit-${SERVICE}:${{ needs.metadata.outputs.version }}-candidate"
+            docker buildx imagetools create \
+              --tag "${{ env.REGISTRY }}/nickna/conduit-${SERVICE}:${{ needs.metadata.outputs.version }}" \
+              --tag "${{ env.REGISTRY }}/nickna/conduit-${SERVICE}:${{ needs.metadata.outputs.channel }}" \
+              "$SOURCE"
+          done
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [metadata, promote]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ needs.metadata.outputs.prerelease }}
+          # Only stable releases become the repo's "Latest"; betas never move it.
+          make_latest: ${{ needs.metadata.outputs.channel == 'latest' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,9 +333,10 @@ if (isMetricsData(event.data)) {
 - **Expand/contract policy**: migrations must be backward-compatible with the previous
   release's code; destructive steps (drop/rename) ship one release later, after no
   deployed code references the old shape
-- Runtime application is governed by `CONDUIT_MIGRATION_MODE` (Apply/Wait/Skip) and the
-  `migrate` CLI verb — see
-  [`docs/configuration.md`](docs/configuration.md#deploy-time-configuration-the-environment)
+- Normal services never apply schema changes. The explicit `migrate` CLI verb is
+  the release gate; runtime `CONDUIT_MIGRATION_MODE` supports `Wait` (default) or
+  `Skip` — see
+  [`migration-deployment-strategy.md`](docs/operations/deployment/migration-deployment-strategy.md)
 - Repository interfaces and implementations live in
   `Shared/ConduitLLM.Configuration/Interfaces/` and
   `Shared/ConduitLLM.Configuration/Repositories/`; follow the neighboring patterns

--- a/Conduit.slnx
+++ b/Conduit.slnx
@@ -15,6 +15,7 @@
     <Project Path="Tests/ConduitLLM.BillingInvariantTests/ConduitLLM.BillingInvariantTests.csproj" />
     <Project Path="Tests/ConduitLLM.FaultInjectionTests/ConduitLLM.FaultInjectionTests.csproj" />
     <Project Path="Tests/ConduitLLM.IntegrationTests/ConduitLLM.IntegrationTests.csproj" />
+    <Project Path="Tests/ConduitLLM.SerializationTests/ConduitLLM.SerializationTests.csproj" />
     <Project Path="Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ single origin.
    ```bash
    docker compose up -d
    ```
+   Compose runs the one-shot `migrate` service first. Gateway and Admin start only
+   after it exits successfully; neither API changes the schema during startup.
 
 4. **Access ConduitLLM**
    - **Gateway API**: `http://localhost:5000` (interactive docs at `/scalar/v1`)

--- a/Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj
+++ b/Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Compile Minimal API request delegates at build time. Treat an endpoint
+         falling back to runtime generation as a build regression. -->
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <WarningsAsErrors>$(WarningsAsErrors);RDG012</WarningsAsErrors>
     <!-- 1591: missing XML doc; NU1510: intentional direct security references. -->
     <NoWarn>$(NoWarn);1591;NU1510</NoWarn>
     <!-- Build-time OpenAPI document export (opt-in): the committed openapi-admin.json is the

--- a/Services/ConduitLLM.Admin/Endpoints/MediaEndpoints.cs
+++ b/Services/ConduitLLM.Admin/Endpoints/MediaEndpoints.cs
@@ -437,7 +437,9 @@ public static class MediaEndpoints
     private static string GetAdminActor(HttpContext context) =>
         context.User.Identity?.Name ?? $"master-key:{context.TraceIdentifier}";
 
-    private sealed class MediaEndpointLog;
+    // RDG emits service-resolution code outside this containing type. Keep the
+    // category non-public while making it accessible to assembly-generated code.
+    internal sealed class MediaEndpointLog;
 
     private static async Task<IResult> ExecuteManualCleanupAsync(
         string cleanupType,

--- a/Services/ConduitLLM.Admin/Extensions/ConfigurationExtensions.cs
+++ b/Services/ConduitLLM.Admin/Extensions/ConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Configuration.Extensions;
+using ConduitLLM.Configuration.ModelCatalogs;
 using ConduitLLM.Core.Extensions;
 
 namespace ConduitLLM.Admin.Extensions
@@ -23,8 +24,13 @@ namespace ConduitLLM.Admin.Extensions
             // Add caching services
             services.AddCachingServices(configuration);
 
-            // Add database migration services (CONDUIT_MIGRATION_MODE handling)
+            // Add read-only database migration readiness handling.
             services.AddDatabaseMigration();
+
+            // The Admin import endpoint can explicitly merge the embedded catalog at
+            // runtime. This is application behavior, not schema migration.
+            services.AddSingleton<BundledModelCatalog>();
+            services.AddScoped<IBundledModelCatalogImporter, BundledModelCatalogImporter>();
 
             // Customer error mode (CONDUIT_CUSTOMER_MODE) — Admin reports it on System Info;
             // its own error middleware stays operator-facing and does not use the translator.

--- a/Services/ConduitLLM.Admin/Program.Messaging.cs
+++ b/Services/ConduitLLM.Admin/Program.Messaging.cs
@@ -1,5 +1,6 @@
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
+using ConduitLLM.Core.Serialization;
 
 namespace ConduitLLM.Admin;
 
@@ -35,6 +36,17 @@ public partial class Program
 
         builder.Host.AddConduitWolverine(builder.Configuration, wolverineConnectionString, "conduit-admin", opts =>
         {
+            opts.UseSystemTextJsonForSerialization(options =>
+            {
+                options.TypeInfoResolverChain.Insert(0, CoreMessagingJsonContext.Default);
+                if (options.TypeInfoResolverChain.All(static resolver =>
+                        resolver is not System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver))
+                {
+                    options.TypeInfoResolverChain.Add(
+                        new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+                }
+            });
+
             ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
 
             // Gateway liveness heartbeat bridge (#1067). Registered unconditionally (like the

--- a/Services/ConduitLLM.Admin/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Admin/Program.Monitoring.cs
@@ -18,8 +18,8 @@ public partial class Program
         var healthChecksBuilder = builder.Services.AddHealthChecks();
 
         // Gate /health/ready on the schema being current. Tag must be "ready" —
-        // that's what the readiness endpoint filters on. Only Wait mode can fail
-        // this check; Apply/Skip set the state before the server binds.
+        // that's what the readiness endpoint filters on. Wait mode holds readiness
+        // down until the explicit migrator catches the schema up; Skip bypasses it.
         healthChecksBuilder.AddCheck<ConduitLLM.Configuration.HealthChecks.PendingMigrationsReadinessCheck>(
             "pending_migrations",
             failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -1,10 +1,13 @@
 using ConduitLLM.Admin.Endpoints;
 using ConduitLLM.Admin.DTOs;
 using ConduitLLM.Admin.Extensions;
+using ConduitLLM.Admin.Serialization;
 using ConduitLLM.Configuration.Data;
 using ConduitLLM.Configuration.Extensions;
+using ConduitLLM.Configuration.Serialization;
 using ConduitLLM.Core.Converters;
 using ConduitLLM.Core.Extensions;
+using ConduitLLM.Core.Serialization;
 using ConduitLLM.Security.Extensions;
 using ConduitLLM.Security.Middleware;
 
@@ -281,6 +284,16 @@ public partial class Program
 
     private static void ConfigureAdminJson(JsonSerializerOptions options)
     {
+        options.TypeInfoResolverChain.Insert(0, AdminHttpJsonContext.Default);
+        options.TypeInfoResolverChain.Insert(1, ConfigurationHttpJsonContext.Default);
+        options.TypeInfoResolverChain.Insert(2, CoreHttpJsonContext.Default);
+        if (options.TypeInfoResolverChain.All(static resolver =>
+                resolver is not System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver))
+        {
+            options.TypeInfoResolverChain.Add(
+                new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+        }
+
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
         options.PropertyNameCaseInsensitive = true;

--- a/Services/ConduitLLM.Admin/Program.cs
+++ b/Services/ConduitLLM.Admin/Program.cs
@@ -190,10 +190,8 @@ public partial class Program
             }
         }
 
-        // Run database migration startup handling (CONDUIT_MIGRATION_MODE); Apply mode
-        // also seeds default data under the migration lock.
-        await app.RunDatabaseMigrationAsync();
-
+        // Normal startup never mutates the database. MigrationWaitService gates
+        // readiness until the explicit "migrate" release step has completed.
         // Resolve the real client IP via trusted proxies. Must run before any IP-reading middleware:
         // HTTPS redirection honors X-Forwarded-Proto, and the /metrics gate reads the client IP.
         // No-op unless CONDUIT_TRUSTED_PROXY_ENABLED=true.

--- a/Services/ConduitLLM.Admin/Serialization/AdminHttpJsonContext.cs
+++ b/Services/ConduitLLM.Admin/Serialization/AdminHttpJsonContext.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Configuration.DTOs;
+
+namespace ConduitLLM.Admin.Serialization;
+
+/// <summary>
+/// Source-generated metadata for representative Admin error, list, and operational contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(AdminProblemDetails))]
+[JsonSerializable(typeof(PagedResult<MetricKeyCountDto>))]
+[JsonSerializable(typeof(BatchSpendingStatusResponse))]
+[JsonSerializable(typeof(BatchSpendingInformationResponse))]
+public partial class AdminHttpJsonContext : JsonSerializerContext;

--- a/Services/ConduitLLM.Gateway/Options/GatewayJsonOptions.cs
+++ b/Services/ConduitLLM.Gateway/Options/GatewayJsonOptions.cs
@@ -1,7 +1,10 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+using ConduitLLM.Configuration.Serialization;
 using ConduitLLM.Core.Converters;
+using ConduitLLM.Core.Serialization;
+using ConduitLLM.Gateway.Serialization;
 
 namespace ConduitLLM.Gateway.Options;
 
@@ -12,6 +15,16 @@ public static class GatewayJsonOptions
 {
     public static void Configure(JsonSerializerOptions options)
     {
+        options.TypeInfoResolverChain.Insert(0, GatewayHttpJsonContext.Default);
+        options.TypeInfoResolverChain.Insert(1, CoreHttpJsonContext.Default);
+        options.TypeInfoResolverChain.Insert(2, ConfigurationHttpJsonContext.Default);
+        if (options.TypeInfoResolverChain.All(static resolver =>
+                resolver is not System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver))
+        {
+            options.TypeInfoResolverChain.Add(
+                new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+        }
+
         options.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.Converters.Add(

--- a/Services/ConduitLLM.Gateway/Program.Messaging.cs
+++ b/Services/ConduitLLM.Gateway/Program.Messaging.cs
@@ -1,6 +1,7 @@
 using ConduitLLM.Configuration.Messaging;
 using ConduitLLM.Configuration.Messaging.Wolverine;
 using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Serialization;
 using ConduitLLM.Core.Services;
 
 public partial class Program
@@ -53,6 +54,17 @@ public partial class Program
 
         builder.Host.AddConduitWolverine(builder.Configuration, connectionString, "conduit-gateway", opts =>
         {
+            opts.UseSystemTextJsonForSerialization(options =>
+            {
+                options.TypeInfoResolverChain.Insert(0, CoreMessagingJsonContext.Default);
+                if (options.TypeInfoResolverChain.All(static resolver =>
+                        resolver is not System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver))
+                {
+                    options.TypeInfoResolverChain.Add(
+                        new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+                }
+            });
+
             ConduitLLM.Gateway.Extensions.CacheInvalidationMessagingExtensions.AddGatewayCacheInvalidationBridges(opts);
             ConduitLLM.Core.Extensions.SharedCacheInvalidationMessagingExtensions.AddSharedCacheInvalidationBridges(opts);
             ConduitLLM.Gateway.Extensions.MediaGenerationMessagingExtensions.AddMediaGenerationBridges(opts);

--- a/Services/ConduitLLM.Gateway/Program.Middleware.cs
+++ b/Services/ConduitLLM.Gateway/Program.Middleware.cs
@@ -25,9 +25,8 @@ public partial class Program
             }
         }
 
-        // Run database migrations
-        await app.RunDatabaseMigrationAsync();
-
+        // Normal startup never mutates the database. MigrationWaitService gates
+        // readiness until the explicit "migrate" release step has completed.
         // Resolve the real client IP via trusted proxies (must run before ANY middleware that reads
         // the client IP — correlation, auth, security). No-op unless CONDUIT_TRUSTED_PROXY_ENABLED=true.
         app.UseTrustedProxyForwardedHeaders();

--- a/Services/ConduitLLM.Gateway/Program.Monitoring.cs
+++ b/Services/ConduitLLM.Gateway/Program.Monitoring.cs
@@ -22,8 +22,8 @@ public partial class Program
             var healthChecksBuilder = builder.Services.AddHealthChecks();
 
             // Gate /health/ready on the schema being current. Tag must be "ready" —
-            // that's what the readiness endpoint filters on. Only Wait mode can fail
-            // this check; Apply/Skip set the state before the server binds.
+            // that's what the readiness endpoint filters on. Wait mode holds readiness
+            // down until the explicit migrator catches the schema up; Skip bypasses it.
             healthChecksBuilder.AddCheck<ConduitLLM.Configuration.HealthChecks.PendingMigrationsReadinessCheck>(
                 "pending_migrations",
                 failureStatus: Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy,

--- a/Services/ConduitLLM.Gateway/Properties/AssemblyInfo.cs
+++ b/Services/ConduitLLM.Gateway/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ConduitLLM.Tests")]
+[assembly: InternalsVisibleTo("ConduitLLM.SerializationTests")]
 [assembly: InternalsVisibleTo("ConduitLLM.Integration.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // For Moq

--- a/Services/ConduitLLM.Gateway/Serialization/GatewayHttpJsonContext.cs
+++ b/Services/ConduitLLM.Gateway/Serialization/GatewayHttpJsonContext.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Gateway.DTOs;
+
+namespace ConduitLLM.Gateway.Serialization;
+
+/// <summary>
+/// Source-generated metadata for Gateway-owned HTTP response contracts.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ModelListResponse))]
+[JsonSerializable(typeof(ModelMetadataResponse))]
+[JsonSerializable(typeof(DiscoveryCapabilitiesResponse))]
+[JsonSerializable(typeof(ModelParametersResponse))]
+[JsonSerializable(typeof(TaskCancellationResponse))]
+[JsonSerializable(typeof(FileMetadataResponse))]
+[JsonSerializable(typeof(DownloadUrlResponse))]
+[JsonSerializable(typeof(MediaUploadResponse))]
+public partial class GatewayHttpJsonContext : JsonSerializerContext;

--- a/Services/ConduitLLM.Gateway/Serialization/GatewayRedisJsonContext.cs
+++ b/Services/ConduitLLM.Gateway/Serialization/GatewayRedisJsonContext.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Gateway.Services;
+
+namespace ConduitLLM.Gateway.Serialization;
+
+/// <summary>
+/// Source-generated metadata for persisted Gateway cache entries and Redis invalidations.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(VirtualKey))]
+[JsonSerializable(typeof(ModelCost))]
+[JsonSerializable(typeof(RedisVirtualKeyCache.VirtualKeyBatchInvalidation))]
+[JsonSerializable(typeof(RedisModelCostCache.ModelCostBatchInvalidation))]
+internal partial class GatewayRedisJsonContext : JsonSerializerContext;

--- a/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.Helpers.cs
+++ b/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.Helpers.cs
@@ -91,7 +91,7 @@ namespace ConduitLLM.Gateway.Services
         {
             try
             {
-                var batchMessage = JsonSerializer.Deserialize<ModelCostBatchInvalidation>(message!.ToString());
+                var batchMessage = DeserializeBatchInvalidation(message!.ToString());
                 if (batchMessage?.CostIds != null)
                 {
                     var requests = batchMessage.CostIds.Select(id => new InvalidationRequest

--- a/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.Invalidation.cs
+++ b/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.Invalidation.cs
@@ -32,7 +32,7 @@ namespace ConduitLLM.Gateway.Services
                             var jsonString = (string?)value;
                             if (jsonString != null)
                             {
-                                var cost = JsonSerializer.Deserialize<ModelCost>(jsonString, JsonOptions);
+                                var cost = DeserializeModelCost(jsonString);
                                 if (cost?.Id == modelCostId)
                                 {
                                     await Database.KeyDeleteAsync(key);
@@ -153,7 +153,7 @@ namespace ConduitLLM.Gateway.Services
                                     var jsonString = (string?)value;
                                     if (jsonString != null)
                                     {
-                                        var cost = JsonSerializer.Deserialize<ModelCost>(jsonString, JsonOptions);
+                                        var cost = DeserializeModelCost(jsonString);
                                         if (cost?.Id == id)
                                         {
                                             keysToDelete.Add(key.ToString()!);
@@ -196,7 +196,7 @@ namespace ConduitLLM.Gateway.Services
 
                 await _subscriber.PublishAsync(
                     RedisChannel.Literal(CacheKeys.ModelCost.BatchInvalidationChannel),
-                    JsonSerializer.Serialize(batchMessage));
+                    SerializeBatchInvalidation(batchMessage));
 
                 stopwatch.Stop();
 
@@ -230,7 +230,7 @@ namespace ConduitLLM.Gateway.Services
         /// <summary>
         /// Message for batch invalidation pub/sub
         /// </summary>
-        private class ModelCostBatchInvalidation
+        internal sealed class ModelCostBatchInvalidation
         {
             public string[] CostIds { get; set; } = Array.Empty<string>();
             public DateTime Timestamp { get; set; }

--- a/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.cs
+++ b/Services/ConduitLLM.Gateway/Services/RedisModelCostCache.cs
@@ -5,6 +5,7 @@ using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Metrics;
+using ConduitLLM.Gateway.Serialization;
 
 namespace ConduitLLM.Gateway.Services
 {
@@ -20,6 +21,22 @@ namespace ConduitLLM.Gateway.Services
 
         // Custom counter for pattern match lookups (beyond standard hits/misses/invalidations)
         private long _bufferedPatternMatches;
+
+        private static ModelCost? DeserializeModelCost(string json) =>
+            JsonSerializer.Deserialize(json, GatewayRedisJsonContext.Default.ModelCost);
+
+        private static string SerializeModelCost(ModelCost value) =>
+            JsonSerializer.Serialize(value, GatewayRedisJsonContext.Default.ModelCost);
+
+        private static ModelCostBatchInvalidation? DeserializeBatchInvalidation(string json) =>
+            JsonSerializer.Deserialize(
+                json,
+                GatewayRedisJsonContext.Default.ModelCostBatchInvalidation);
+
+        private static string SerializeBatchInvalidation(ModelCostBatchInvalidation value) =>
+            JsonSerializer.Serialize(
+                value,
+                GatewayRedisJsonContext.Default.ModelCostBatchInvalidation);
 
         public RedisModelCostCache(
             IConnectionMultiplexer redis,
@@ -53,7 +70,7 @@ namespace ConduitLLM.Gateway.Services
                     var jsonString = (string?)cachedValue;
                     if (jsonString is not null)
                     {
-                        var cost = JsonSerializer.Deserialize<ModelCost>(jsonString, JsonOptions);
+                        var cost = DeserializeModelCost(jsonString);
 
                         if (cost != null)
                         {
@@ -82,7 +99,7 @@ namespace ConduitLLM.Gateway.Services
                             var jsonStr = (string?)cached;
                             if (jsonStr is not null)
                             {
-                                return JsonSerializer.Deserialize<ModelCost>(jsonStr, JsonOptions);
+                                return DeserializeModelCost(jsonStr);
                             }
                         }
                         return null;
@@ -125,7 +142,7 @@ namespace ConduitLLM.Gateway.Services
                     var jsonString = (string?)cachedValue;
                     if (jsonString is not null)
                     {
-                        var cost = JsonSerializer.Deserialize<ModelCost>(jsonString, JsonOptions);
+                        var cost = DeserializeModelCost(jsonString);
                         if (cost != null)
                         {
                             Logger.LogDebug("Model cost cache hit for exact model ID: {ModelId}", modelId);
@@ -153,7 +170,7 @@ namespace ConduitLLM.Gateway.Services
                             var jsonStr = (string?)cached;
                             if (jsonStr is not null)
                             {
-                                return JsonSerializer.Deserialize<ModelCost>(jsonStr, JsonOptions);
+                                return DeserializeModelCost(jsonStr);
                             }
                         }
                         return null;
@@ -163,7 +180,7 @@ namespace ConduitLLM.Gateway.Services
                 if (dbCost != null)
                 {
                     // Cache the result with the exact model ID for faster future lookups
-                    var serialized = JsonSerializer.Serialize(dbCost, JsonOptions);
+                    var serialized = SerializeModelCost(dbCost);
                     await Database.StringSetAsync(exactKey, serialized, DefaultExpiry);
                     Interlocked.Increment(ref _bufferedPatternMatches);
 

--- a/Services/ConduitLLM.Gateway/Services/RedisVirtualKeyCache.cs
+++ b/Services/ConduitLLM.Gateway/Services/RedisVirtualKeyCache.cs
@@ -7,6 +7,7 @@ using ConduitLLM.Core.Interfaces;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Services;
 using ConduitLLM.Gateway.Metrics;
+using ConduitLLM.Gateway.Serialization;
 
 namespace ConduitLLM.Gateway.Services
 {
@@ -55,7 +56,9 @@ namespace ConduitLLM.Gateway.Services
             try
             {
                 // Try Redis first - this is ~50x faster than database
-                var virtualKey = await TryGetCacheEntryAsync<VirtualKey>(cacheKey);
+                var virtualKey = await TryGetCacheEntryAsync(
+                    cacheKey,
+                    GatewayRedisJsonContext.Default.VirtualKey);
 
                 if (virtualKey != null)
                 {
@@ -108,7 +111,11 @@ namespace ConduitLLM.Gateway.Services
             {
                 var expiry = CalculateExpiry(virtualKey);
 
-                await SetCacheEntryAsync(cacheKey, virtualKey, expiry);
+                await SetCacheEntryAsync(
+                    cacheKey,
+                    virtualKey,
+                    GatewayRedisJsonContext.Default.VirtualKey,
+                    expiry);
 
                 Logger.LogDebug("Cached Virtual Key: {KeyHash}, expires in {ExpiryMinutes} minutes",
                     keyHash, expiry.TotalMinutes);
@@ -252,7 +259,9 @@ namespace ConduitLLM.Gateway.Services
         {
             try
             {
-                var batchMessage = JsonSerializer.Deserialize<VirtualKeyBatchInvalidation>(message!.ToString());
+                var batchMessage = JsonSerializer.Deserialize(
+                    message!.ToString(),
+                    GatewayRedisJsonContext.Default.VirtualKeyBatchInvalidation);
                 if (batchMessage?.KeyHashes != null)
                 {
                     var batch = Database.CreateBatch();
@@ -330,7 +339,9 @@ namespace ConduitLLM.Gateway.Services
 
                 await _subscriber.PublishAsync(
                     RedisChannel.Literal(CacheKeys.VirtualKey.BatchInvalidationChannel),
-                    JsonSerializer.Serialize(batchMessage));
+                    JsonSerializer.Serialize(
+                        batchMessage,
+                        GatewayRedisJsonContext.Default.VirtualKeyBatchInvalidation));
 
                 stopwatch.Stop();
 
@@ -387,7 +398,7 @@ namespace ConduitLLM.Gateway.Services
 
         #endregion
 
-        private class VirtualKeyBatchInvalidation
+        internal sealed class VirtualKeyBatchInvalidation
         {
             public string[] KeyHashes { get; set; } = Array.Empty<string>();
             public DateTime Timestamp { get; set; }

--- a/Shared/ConduitLLM.Configuration/Data/MigrationCommand.cs
+++ b/Shared/ConduitLLM.Configuration/Data/MigrationCommand.cs
@@ -9,6 +9,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ConduitLLM.Configuration.ModelCatalogs;
 
+using Wolverine;
+using Wolverine.Postgresql;
+
 namespace ConduitLLM.Configuration.Data
 {
     /// <summary>
@@ -42,7 +45,7 @@ namespace ConduitLLM.Configuration.Data
 
             try
             {
-                var options = MigrationStartupOptions.FromEnvironment(logger);
+                var options = MigrationStartupOptions.ForMigrator(logger);
                 var connectionString = ConfigurationDbContextFactory.ResolveNpgsqlConnectionString();
 
                 var contextOptions = new DbContextOptionsBuilder<ConduitDbContext>()
@@ -100,17 +103,44 @@ namespace ConduitLLM.Configuration.Data
                 return;
             }
 
-            logger.LogInformation("Provisioning Wolverine durability/queue schema...");
+            logger.LogInformation("Provisioning Gateway and Admin Wolverine durability/queue schemas...");
 
-            // SetupResources resolves Wolverine's IStatefulResource registrations from
-            // DI without starting the host — no durability agents, listeners, or node
-            // leader election run.
-            using var host = Host.CreateDefaultBuilder()
-                .AddConduitWolverine(configuration, connectionString, "conduit-migrator")
-                .Build();
-            await host.SetupResources(cancellationToken);
+            await ProvisionWolverineHostAsync(
+                configuration,
+                connectionString,
+                serviceName: "conduit-gateway",
+                WolverineQueueNames.Gateway,
+                cancellationToken);
+            await ProvisionWolverineHostAsync(
+                configuration,
+                connectionString,
+                serviceName: "conduit-admin",
+                WolverineQueueNames.Admin,
+                cancellationToken);
 
             logger.LogInformation("Wolverine schema provisioned");
+        }
+
+        private static async Task ProvisionWolverineHostAsync(
+            IConfiguration configuration,
+            string connectionString,
+            string serviceName,
+            IReadOnlyList<string> queueNames,
+            CancellationToken cancellationToken)
+        {
+            // Declare the runtime queues so SetupResources creates both the service's
+            // durability schema and the shared transport schema. The host is never
+            // started, so no listeners, agents, or leader election run.
+            using var host = Host.CreateDefaultBuilder()
+                .AddConduitWolverine(configuration, connectionString, serviceName, options =>
+                {
+                    foreach (var queueName in queueNames)
+                    {
+                        options.ListenToPostgresqlQueue(queueName);
+                    }
+                })
+                .Build();
+            await host.SetupResources(cancellationToken);
         }
 
         /// <summary>

--- a/Shared/ConduitLLM.Configuration/Data/MigrationExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Data/MigrationExtensions.cs
@@ -1,12 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using ConduitLLM.Configuration.ModelCatalogs;
 
 namespace ConduitLLM.Configuration.Data
 {
     /// <summary>
-    /// Registration and startup entry points for database migration handling.
+    /// Registration for read-only database migration readiness handling.
     /// Behavior is governed by CONDUIT_MIGRATION_MODE — see <see cref="MigrationMode"/>.
     /// </summary>
     public static class MigrationExtensions
@@ -20,60 +18,8 @@ namespace ConduitLLM.Configuration.Data
                 sp.GetRequiredService<ILoggerFactory>().CreateLogger("Conduit.MigrationStartup")));
             services.AddSingleton<MigrationReadinessState>();
             services.AddSingleton<IPendingMigrationsProbe, PendingMigrationsProbe>();
-            services.AddSingleton<BundledModelCatalog>();
-            services.AddScoped<IBundledModelCatalogImporter, BundledModelCatalogImporter>();
-            services.AddScoped<SimpleMigrationService>();
             services.AddHostedService<MigrationWaitService>();
             return services;
-        }
-
-        /// <summary>
-        /// Run migration startup handling per CONDUIT_MIGRATION_MODE:
-        /// Apply migrates inline (advisory-lock protected) before the server starts;
-        /// Wait returns immediately and lets <see cref="MigrationWaitService"/> gate
-        /// readiness until an external migrator catches the schema up;
-        /// Skip does nothing.
-        /// </summary>
-        public static async Task RunDatabaseMigrationAsync(this IHost app)
-        {
-            using var scope = app.Services.CreateScope();
-            var logger = scope.ServiceProvider.GetRequiredService<ILogger<SimpleMigrationService>>();
-            var options = scope.ServiceProvider.GetRequiredService<MigrationStartupOptions>();
-            var state = scope.ServiceProvider.GetRequiredService<MigrationReadinessState>();
-
-            switch (options.Mode)
-            {
-                case MigrationMode.Skip:
-                    logger.LogWarning(
-                        "CONDUIT_MIGRATION_MODE=Skip: migrations and schema checks are disabled. " +
-                        "Ensure your database schema is up to date!");
-                    state.IsSchemaCurrent = true;
-                    return;
-
-                case MigrationMode.Wait:
-                    // MigrationWaitService polls and flips readiness once the schema is
-                    // current; the service starts serving with /health/ready failing.
-                    logger.LogInformation(
-                        "CONDUIT_MIGRATION_MODE=Wait: this instance will not migrate; readiness is gated until the schema is current.");
-                    return;
-
-                case MigrationMode.Apply:
-                default:
-                    try
-                    {
-                        logger.LogInformation("Running database migrations...");
-                        var migrationService = scope.ServiceProvider.GetRequiredService<SimpleMigrationService>();
-                        await migrationService.MigrateAsync();
-                        state.IsSchemaCurrent = true;
-                        logger.LogInformation("Database migrations completed successfully");
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Failed to run database migrations");
-                        throw new InvalidOperationException("Database migration failed. Application cannot start.", ex);
-                    }
-                    return;
-            }
         }
     }
 }

--- a/Shared/ConduitLLM.Configuration/Data/MigrationReadinessState.cs
+++ b/Shared/ConduitLLM.Configuration/Data/MigrationReadinessState.cs
@@ -2,13 +2,19 @@ namespace ConduitLLM.Configuration.Data
 {
     /// <summary>
     /// Process-wide flag: does the database schema contain every migration this binary
-    /// knows about? Set before the server binds in Apply/Skip modes; flipped by
-    /// <see cref="MigrationWaitService"/> in Wait mode. Gates /health/ready via
+    /// knows about? Initially current only in explicit Skip mode and otherwise flipped
+    /// by <see cref="MigrationWaitService"/>. Gates /health/ready via
     /// <see cref="HealthChecks.PendingMigrationsReadinessCheck"/>.
     /// </summary>
     public sealed class MigrationReadinessState
     {
         private volatile bool _isSchemaCurrent;
+
+        public MigrationReadinessState(MigrationStartupOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            _isSchemaCurrent = options.Mode == MigrationMode.Skip;
+        }
 
         public bool IsSchemaCurrent
         {

--- a/Shared/ConduitLLM.Configuration/Data/MigrationStartupOptions.cs
+++ b/Shared/ConduitLLM.Configuration/Data/MigrationStartupOptions.cs
@@ -8,16 +8,9 @@ namespace ConduitLLM.Configuration.Data
     public enum MigrationMode
     {
         /// <summary>
-        /// Apply pending migrations inline before serving traffic, serialized across
-        /// instances by a Postgres advisory lock. Default; the right mode for
-        /// development and single-writer deployments.
-        /// </summary>
-        Apply,
-
-        /// <summary>
         /// Never migrate. Poll until the schema contains every migration this binary
-        /// knows about, gating /health/ready in the meantime. The right mode for
-        /// production services when a release-hook migrator runs "migrate" separately.
+        /// knows about, gating /health/ready in the meantime. This is the default;
+        /// a release hook or one-shot job must run "migrate" separately.
         /// </summary>
         Wait,
 
@@ -38,12 +31,12 @@ namespace ConduitLLM.Configuration.Data
 
         public const int DefaultLockTimeoutSeconds = 300;
 
-        public MigrationMode Mode { get; init; } = MigrationMode.Apply;
+        public MigrationMode Mode { get; init; } = MigrationMode.Wait;
 
         /// <summary>
-        /// How long an Apply-mode instance waits for the advisory lock before failing
-        /// startup. Only contended waiters can time out — the lock winner holds it for
-        /// as long as the migration takes. 0 means wait indefinitely.
+        /// How long the explicit migrator waits for the advisory lock before failing.
+        /// Only contended waiters can time out — the lock winner holds it for as long
+        /// as the migration takes. 0 means wait indefinitely.
         /// </summary>
         public int LockTimeoutSeconds { get; init; } = DefaultLockTimeoutSeconds;
 
@@ -61,14 +54,20 @@ namespace ConduitLLM.Configuration.Data
             MigrationMode mode;
             if (string.IsNullOrWhiteSpace(rawMode))
             {
-                mode = MigrationMode.Apply;
+                mode = MigrationMode.Wait;
             }
-            else if (!Enum.TryParse(rawMode.Trim(), ignoreCase: true, out mode))
+            else if (string.Equals(rawMode.Trim(), "Apply", StringComparison.OrdinalIgnoreCase))
             {
-                // Fail fast: silently applying migrations in a misconfigured production
-                // service is worse than refusing to start.
                 throw new InvalidOperationException(
-                    $"Unrecognized {ModeVariable} value '{rawMode}'. Valid values: Apply, Wait, Skip.");
+                    $"{ModeVariable}=Apply is no longer supported because web services never mutate the schema. " +
+                    $"Run the explicit migrator ('dotnet ConduitLLM.Admin.dll {MigrationCommand.Verb}') before rollout, " +
+                    $"then use {ModeVariable}=Wait.");
+            }
+            else if (!Enum.TryParse(rawMode.Trim(), ignoreCase: true, out mode)
+                || !Enum.IsDefined(mode))
+            {
+                throw new InvalidOperationException(
+                    $"Unrecognized {ModeVariable} value '{rawMode}'. Valid values: Wait, Skip.");
             }
 
             return new MigrationStartupOptions
@@ -76,6 +75,24 @@ namespace ConduitLLM.Configuration.Data
                 Mode = mode,
                 LockTimeoutSeconds = ParseNonNegativeSeconds(LockTimeoutVariable, DefaultLockTimeoutSeconds),
                 WaitTimeoutSeconds = ParseNonNegativeSeconds(WaitTimeoutVariable, 0)
+            };
+        }
+
+        /// <summary>
+        /// Options for the explicit migration command. Runtime migration mode is
+        /// intentionally ignored: the command itself is the authorization to mutate
+        /// the schema.
+        /// </summary>
+        public static MigrationStartupOptions ForMigrator(ILogger logger)
+        {
+            WarnOnRemovedVariables(logger);
+            return new MigrationStartupOptions
+            {
+                Mode = MigrationMode.Wait,
+                LockTimeoutSeconds = ParseNonNegativeSeconds(
+                    LockTimeoutVariable,
+                    DefaultLockTimeoutSeconds),
+                WaitTimeoutSeconds = 0
             };
         }
 

--- a/Shared/ConduitLLM.Configuration/Data/MigrationWaitService.cs
+++ b/Shared/ConduitLLM.Configuration/Data/MigrationWaitService.cs
@@ -37,8 +37,8 @@ namespace ConduitLLM.Configuration.Data
     /// In Wait mode, polls until the schema contains every migration this binary knows
     /// about (an external migrator — the "migrate" verb — applies them), then flips
     /// <see cref="MigrationReadinessState"/> so /health/ready starts passing. No-op in
-    /// Apply/Skip modes. An unreachable database is not fatal: readiness simply stays
-    /// down, which is the correct signal for orchestrators.
+    /// Skip mode. An unreachable database is not fatal: readiness simply stays
+    /// down with an actionable diagnostic, which is the correct signal for orchestrators.
     /// </summary>
     public sealed class MigrationWaitService : BackgroundService
     {
@@ -77,7 +77,8 @@ namespace ConduitLLM.Configuration.Data
             await Task.Yield();
 
             _logger.LogInformation(
-                "Migration mode is Wait: this instance will not migrate. Polling until the schema is current; /health/ready is gated until then.");
+                "This service never applies database migrations. Polling until the schema is current; " +
+                "/health/ready is gated until then. Run 'dotnet ConduitLLM.Admin.dll migrate' before rollout.");
 
             var elapsed = Stopwatch.StartNew();
             var interval = InitialPollInterval;
@@ -95,7 +96,8 @@ namespace ConduitLLM.Configuration.Data
                     }
 
                     _logger.LogInformation(
-                        "Waiting for {PendingCount} pending migration(s) to be applied by the migrator (next: {NextMigration})",
+                        "Waiting for {PendingCount} pending migration(s) (next: {NextMigration}). " +
+                        "Run 'dotnet ConduitLLM.Admin.dll migrate' before rollout.",
                         pending.Count, pending[0]);
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -110,7 +112,8 @@ namespace ConduitLLM.Configuration.Data
                 if (_options.WaitTimeoutSeconds > 0 && elapsed.Elapsed.TotalSeconds >= _options.WaitTimeoutSeconds)
                 {
                     _logger.LogCritical(
-                        "Schema did not become current within {WaitTimeoutVariable}={TimeoutSeconds}s. Stopping application.",
+                        "Schema did not become current within {WaitTimeoutVariable}={TimeoutSeconds}s. " +
+                        "Run 'dotnet ConduitLLM.Admin.dll migrate', then restart the service. Stopping application.",
                         MigrationStartupOptions.WaitTimeoutVariable, _options.WaitTimeoutSeconds);
                     _lifetime.StopApplication();
                     return;

--- a/Shared/ConduitLLM.Configuration/Data/README.md
+++ b/Shared/ConduitLLM.Configuration/Data/README.md
@@ -1,7 +1,8 @@
 # Database Migration Infrastructure
 
-Runtime migration handling for the single EF Core context (`ConduitDbContext`,
-PostgreSQL only). Behavior is governed by `CONDUIT_MIGRATION_MODE` — the full
+Release migration and runtime readiness handling for the single EF Core context
+(`ConduitDbContext`, PostgreSQL only). Normal services are read-only with respect
+to schema; behavior is governed by `CONDUIT_MIGRATION_MODE` — the full
 operational guide is
 [docs/operations/deployment/migration-deployment-strategy.md](../../../docs/operations/deployment/migration-deployment-strategy.md),
 and the schema-compatibility rules are
@@ -11,12 +12,12 @@ and the schema-compatibility rules are
 
 | File | Role |
 |---|---|
-| `MigrationStartupOptions.cs` | `CONDUIT_MIGRATION_MODE` (`Apply`/`Wait`/`Skip`) + timeout env parsing; warns on removed legacy variables |
+| `MigrationStartupOptions.cs` | `CONDUIT_MIGRATION_MODE` (`Wait`/`Skip`) + timeout env parsing; rejects legacy `Apply` |
 | `SimpleMigrationService.cs` | Applies migrations + seeds default data under a blocking session-scoped `pg_advisory_lock(7891011)` |
 | `MigrationWaitService.cs` | Wait mode: background poll of pending migrations; flips readiness when the schema is current |
 | `MigrationReadinessState.cs` | Process-wide "schema is current" flag |
 | `../HealthChecks/PendingMigrationsReadinessCheck.cs` | Gates `/health/ready` (tag `ready`) on that flag |
-| `MigrationExtensions.cs` | DI registration (`AddDatabaseMigration`) + startup dispatch (`RunDatabaseMigrationAsync`) |
+| `MigrationExtensions.cs` | Read-only readiness registration (`AddDatabaseMigration`) |
 | `MigrationCommand.cs` | `migrate` CLI verb: standalone migrator + Wolverine schema provisioning (release-hook entry point) |
 | `ExecutionStrategyExtensions.cs` | `ExecuteInTransactionAsync` — explicit transactions compatible with `EnableRetryOnFailure` |
 | `ConfigurationDbContextFactory.cs` | Design-time factory; also resolves `DATABASE_URL` for the migrate verb |
@@ -33,3 +34,5 @@ and the schema-compatibility rules are
   (waiter timeout `CONDUIT_MIGRATION_LOCK_TIMEOUT_SECONDS`), then re-check
   `GetPendingMigrationsAsync()` and find nothing to do.
 - **Seeding runs under the lock** and is idempotent.
+- **Web processes are schema-read-only.** Only the `migrate` verb constructs
+  `SimpleMigrationService` or enables Wolverine resource provisioning.

--- a/Shared/ConduitLLM.Configuration/HealthChecks/PendingMigrationsReadinessCheck.cs
+++ b/Shared/ConduitLLM.Configuration/HealthChecks/PendingMigrationsReadinessCheck.cs
@@ -7,9 +7,8 @@ namespace ConduitLLM.Configuration.HealthChecks
     /// <summary>
     /// Fails readiness until <see cref="MigrationReadinessState"/> reports the schema
     /// current. Must be registered with the "ready" tag — /health/ready filters on it.
-    /// In Apply/Skip modes the state is set before the server binds, so this check
-    /// never fails there; in Wait mode it holds readiness at 503 until the external
-    /// migrator has applied all migrations this binary knows about.
+    /// In Skip mode the state starts current; otherwise it holds readiness at 503 until
+    /// the external migrator has applied all migrations this binary knows about.
     /// </summary>
     public class PendingMigrationsReadinessCheck : IHealthCheck
     {
@@ -27,7 +26,7 @@ namespace ConduitLLM.Configuration.HealthChecks
             return Task.FromResult(_state.IsSchemaCurrent
                 ? HealthCheckResult.Healthy("Database schema is current")
                 : HealthCheckResult.Unhealthy(
-                    "Database schema is not current; waiting for migrations to be applied"));
+                    "Database schema is not current. Run 'dotnet ConduitLLM.Admin.dll migrate' before rollout."));
         }
     }
 }

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineMessagingExtensions.cs
@@ -44,9 +44,9 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
 
         /// <summary>
         /// Configuration key controlling automatic provisioning of Wolverine's durability
-        /// and queue tables at startup (default <c>true</c>). Production deployments that
-        /// manage schema explicitly set this to <c>false</c> and provision via script —
-        /// see the Phase 2 plan (#924).
+        /// and queue tables at startup (default <c>false</c>). The explicit
+        /// <c>migrate</c> release step owns provisioning. Development environments may
+        /// opt in when intentionally running without that step.
         /// </summary>
         public const string AutoProvisionKey = "ConduitLLM:Messaging:Wolverine:AutoProvision";
 
@@ -108,7 +108,7 @@ namespace ConduitLLM.Configuration.Messaging.Wolverine
         {
             var schemaName = configuration[SchemaNameKey]
                 ?? $"wolverine_{serviceName.Replace('-', '_')}";
-            var autoProvision = configuration.GetValue(AutoProvisionKey, true);
+            var autoProvision = configuration.GetValue(AutoProvisionKey, false);
             var inMemory = UsesInMemoryTransport(configuration);
 
             return host.UseWolverine(opts =>

--- a/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineQueueNames.cs
+++ b/Shared/ConduitLLM.Configuration/Messaging/Wolverine/WolverineQueueNames.cs
@@ -1,0 +1,22 @@
+namespace ConduitLLM.Configuration.Messaging.Wolverine;
+
+/// <summary>
+/// PostgreSQL queue resources shared by runtime topology and the explicit
+/// migration command.
+/// </summary>
+public static class WolverineQueueNames
+{
+    public const string GatewayEvents = "gateway-events";
+    public const string AdminEvents = "admin-events";
+
+    public static IReadOnlyList<string> Gateway { get; } =
+    [
+        ConduitEndpointPolicies.WebhookDelivery.Name,
+        ConduitEndpointPolicies.SpendUpdate.Name,
+        ConduitEndpointPolicies.VideoGeneration.Name,
+        ConduitEndpointPolicies.ImageGeneration.Name,
+        GatewayEvents
+    ];
+
+    public static IReadOnlyList<string> Admin { get; } = [AdminEvents];
+}

--- a/Shared/ConduitLLM.Configuration/Serialization/ConfigurationHttpJsonContext.cs
+++ b/Shared/ConduitLLM.Configuration/Serialization/ConfigurationHttpJsonContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Configuration.DTOs;
+
+namespace ConduitLLM.Configuration.Serialization;
+
+/// <summary>
+/// Source-generated metadata for shared HTTP response contracts.
+/// </summary>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(DiscoveryModelsResponse))]
+public partial class ConfigurationHttpJsonContext : JsonSerializerContext;

--- a/Shared/ConduitLLM.Configuration/Serialization/ConfigurationSignalRJsonContext.cs
+++ b/Shared/ConduitLLM.Configuration/Serialization/ConfigurationSignalRJsonContext.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Configuration.DTOs.SignalR;
+
+namespace ConduitLLM.Configuration.Serialization;
+
+/// <summary>
+/// Source-generated metadata for the live SignalR notification payload families.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(WebhookDeliveryAttempt))]
+[JsonSerializable(typeof(WebhookDeliverySuccess))]
+[JsonSerializable(typeof(WebhookDeliveryFailure))]
+[JsonSerializable(typeof(WebhookRetryInfo))]
+[JsonSerializable(typeof(WebhookStatistics))]
+[JsonSerializable(typeof(WebhookCircuitBreakerState))]
+[JsonSerializable(typeof(VirtualKeyCreatedNotification))]
+[JsonSerializable(typeof(VirtualKeyUpdatedNotification))]
+[JsonSerializable(typeof(VirtualKeyDeletedNotification))]
+[JsonSerializable(typeof(VirtualKeyStatusChangedNotification))]
+[JsonSerializable(typeof(VirtualKeyStatusNotification))]
+[JsonSerializable(typeof(RateLimitNotification))]
+[JsonSerializable(typeof(SystemAnnouncementNotification))]
+[JsonSerializable(typeof(ServiceDegradationNotification))]
+[JsonSerializable(typeof(ServiceRestorationNotification))]
+[JsonSerializable(typeof(ModelMappingNotification))]
+[JsonSerializable(typeof(ModelCapabilitiesNotification))]
+[JsonSerializable(typeof(ModelAvailabilityNotification))]
+[JsonSerializable(typeof(SpendUpdateNotification))]
+[JsonSerializable(typeof(BudgetAlertNotification))]
+[JsonSerializable(typeof(SpendSummaryNotification))]
+[JsonSerializable(typeof(UnusualSpendingNotification))]
+public partial class ConfigurationSignalRJsonContext : JsonSerializerContext;

--- a/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
+++ b/Shared/ConduitLLM.Core/ConduitLLM.Core.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ConduitLLM.Tests" />
+    <InternalsVisibleTo Include="ConduitLLM.SerializationTests" />
   </ItemGroup>
 
 </Project>

--- a/Shared/ConduitLLM.Core/Extensions/SignalRConfigurationExtensions.cs
+++ b/Shared/ConduitLLM.Core/Extensions/SignalRConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using ConduitLLM.Configuration.Serialization;
 
 namespace ConduitLLM.Core.Extensions
 {
@@ -40,6 +41,20 @@ namespace ConduitLLM.Core.Extensions
                 options.StreamBufferCapacity = 10;
 
                 configureHubOptions?.Invoke(options);
+            });
+
+            signalRBuilder.AddJsonProtocol(options =>
+            {
+                var resolverChain = options.PayloadSerializerOptions.TypeInfoResolverChain;
+                resolverChain.Insert(
+                    0,
+                    ConfigurationSignalRJsonContext.Default);
+                if (resolverChain.All(static resolver =>
+                        resolver is not System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver))
+                {
+                    resolverChain.Add(
+                        new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver());
+                }
             });
 
             // Add MessagePack protocol support with LZ4 compression

--- a/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
+++ b/Shared/ConduitLLM.Core/Messaging/ConduitMessagingTopology.cs
@@ -34,10 +34,10 @@ namespace ConduitLLM.Core.Messaging
     public static class ConduitMessagingTopology
     {
         /// <summary>Default queue for Gateway-consumed events without a tuned policy.</summary>
-        public const string GatewayEventsQueue = "gateway-events";
+        public const string GatewayEventsQueue = WolverineQueueNames.GatewayEvents;
 
         /// <summary>Queue for the shared cache events consumed by the Admin host.</summary>
-        public const string AdminEventsQueue = "admin-events";
+        public const string AdminEventsQueue = WolverineQueueNames.AdminEvents;
 
         /// <summary>webhook-delivery (tuned: <see cref="ConduitEndpointPolicies.WebhookDelivery"/>).</summary>
         public static readonly IReadOnlyList<Type> WebhookDeliveryEvents = new[]

--- a/Shared/ConduitLLM.Core/Serialization/CoreHttpJsonContext.cs
+++ b/Shared/ConduitLLM.Core/Serialization/CoreHttpJsonContext.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Core.Models;
+
+namespace ConduitLLM.Core.Serialization;
+
+/// <summary>
+/// Source-generated metadata for the highest-volume OpenAI-compatible HTTP contracts.
+/// Metadata mode deliberately keeps the caller's naming, converter, and ignore policies
+/// authoritative so Gateway wire behavior is unchanged.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(ChatCompletionRequest))]
+[JsonSerializable(typeof(ChatCompletionResponse))]
+[JsonSerializable(typeof(ChatCompletionChunk))]
+[JsonSerializable(typeof(OpenAIErrorResponse))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(List<object>))]
+[JsonSerializable(typeof(object[]))]
+public partial class CoreHttpJsonContext : JsonSerializerContext;

--- a/Shared/ConduitLLM.Core/Serialization/CoreMessagingJsonContext.cs
+++ b/Shared/ConduitLLM.Core/Serialization/CoreMessagingJsonContext.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Configuration.Events;
+using ConduitLLM.Core.Events;
+
+namespace ConduitLLM.Core.Serialization;
+
+/// <summary>
+/// Source-generated metadata for every message in the Gateway/Admin Wolverine topology.
+/// Wolverine's existing default JSON shape is retained (Pascal-case CLR property names,
+/// numeric enums, and explicit <see cref="JsonPropertyNameAttribute"/> overrides).
+/// </summary>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(WebhookDeliveryRequested))]
+[JsonSerializable(typeof(SpendUpdateRequested))]
+[JsonSerializable(typeof(VideoGenerationRequested))]
+[JsonSerializable(typeof(VideoGenerationCancelled))]
+[JsonSerializable(typeof(VideoProgressCheckRequested))]
+[JsonSerializable(typeof(ImageGenerationRequested))]
+[JsonSerializable(typeof(ImageGenerationCancelled))]
+[JsonSerializable(typeof(VirtualKeyUpdated))]
+[JsonSerializable(typeof(VirtualKeyCreated))]
+[JsonSerializable(typeof(VirtualKeyDeleted))]
+[JsonSerializable(typeof(SpendUpdated))]
+[JsonSerializable(typeof(SpendThresholdExceeded))]
+[JsonSerializable(typeof(ProviderCreated))]
+[JsonSerializable(typeof(ProviderUpdated))]
+[JsonSerializable(typeof(ProviderDeleted))]
+[JsonSerializable(typeof(ModelUpdated))]
+[JsonSerializable(typeof(DiscoveryCacheInvalidationRequested))]
+[JsonSerializable(typeof(AsyncTaskCreated))]
+[JsonSerializable(typeof(AsyncTaskUpdated))]
+[JsonSerializable(typeof(AsyncTaskDeleted))]
+[JsonSerializable(typeof(MediaGenerationCompleted))]
+[JsonSerializable(typeof(VideoGenerationStarted))]
+[JsonSerializable(typeof(MediaCleanupAlertRaised))]
+[JsonSerializable(typeof(ModelMappingChanged))]
+[JsonSerializable(typeof(ModelCostChanged))]
+[JsonSerializable(typeof(IpFilterChanged))]
+[JsonSerializable(typeof(ProviderToolChanged))]
+[JsonSerializable(typeof(ProviderKeyCredentialCreated))]
+[JsonSerializable(typeof(ProviderKeyCredentialUpdated))]
+[JsonSerializable(typeof(ProviderKeyCredentialDeleted))]
+[JsonSerializable(typeof(ProviderKeyCredentialPrimaryChanged))]
+[JsonSerializable(typeof(ProviderKeyDisabledEvent))]
+[JsonSerializable(typeof(ProviderKeyReenabledEvent))]
+[JsonSerializable(typeof(ImageGenerationProgress))]
+[JsonSerializable(typeof(ImageGenerationCompleted))]
+[JsonSerializable(typeof(ImageGenerationFailed))]
+[JsonSerializable(typeof(VideoGenerationProgress))]
+[JsonSerializable(typeof(VideoGenerationCompleted))]
+[JsonSerializable(typeof(VideoGenerationFailed))]
+[JsonSerializable(typeof(BatchSpendFlushRequestedEvent))]
+[JsonSerializable(typeof(GlobalSettingChanged))]
+[JsonSerializable(typeof(GlobalSettingsReloadRequested))]
+[JsonSerializable(typeof(FunctionConfigurationChanged))]
+[JsonSerializable(typeof(FunctionDiscoveryCacheInvalidationRequested))]
+[JsonSerializable(typeof(GatewayHeartbeat))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(Dictionary<string, JsonElement>))]
+[JsonSerializable(typeof(List<object>))]
+[JsonSerializable(typeof(object[]))]
+public partial class CoreMessagingJsonContext : JsonSerializerContext;

--- a/Shared/ConduitLLM.Core/Serialization/CoreRedisJsonContext.cs
+++ b/Shared/ConduitLLM.Core/Serialization/CoreRedisJsonContext.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Core.Services;
+
+namespace ConduitLLM.Core.Serialization;
+
+/// <summary>
+/// Source-generated metadata for persisted Core Redis reliability payloads.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(RedisWebhookCircuitBreaker.CircuitState))]
+internal partial class CoreRedisJsonContext : JsonSerializerContext;

--- a/Shared/ConduitLLM.Core/Services/RedisCacheServiceBase.cs
+++ b/Shared/ConduitLLM.Core/Services/RedisCacheServiceBase.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using ConduitLLM.Configuration.Constants;
@@ -114,11 +115,43 @@ public abstract class RedisCacheServiceBase
     }
 
     /// <summary>
+    /// Read a cache entry with source-generated metadata.
+    /// </summary>
+    protected async Task<T?> TryGetCacheEntryAsync<T>(
+        string cacheKey,
+        JsonTypeInfo<T> jsonTypeInfo) where T : class
+    {
+        var cachedValue = await Database.StringGetAsync(cacheKey);
+        if (!cachedValue.HasValue)
+        {
+            return null;
+        }
+
+        var jsonString = (string?)cachedValue;
+        return jsonString is null
+            ? null
+            : JsonSerializer.Deserialize(jsonString, jsonTypeInfo);
+    }
+
+    /// <summary>
     /// Serialize and store a value in Redis.
     /// </summary>
     protected async Task SetCacheEntryAsync<T>(string cacheKey, T value, TimeSpan? expiry = null)
     {
         var json = JsonSerializer.Serialize(value, JsonOptions);
+        await Database.StringSetAsync(cacheKey, json, expiry ?? DefaultExpiry);
+    }
+
+    /// <summary>
+    /// Serialize and store a value with source-generated metadata.
+    /// </summary>
+    protected async Task SetCacheEntryAsync<T>(
+        string cacheKey,
+        T value,
+        JsonTypeInfo<T> jsonTypeInfo,
+        TimeSpan? expiry = null)
+    {
+        var json = JsonSerializer.Serialize(value, jsonTypeInfo);
         await Database.StringSetAsync(cacheKey, json, expiry ?? DefaultExpiry);
     }
 

--- a/Shared/ConduitLLM.Core/Services/RedisWebhookCircuitBreaker.cs
+++ b/Shared/ConduitLLM.Core/Services/RedisWebhookCircuitBreaker.cs
@@ -1,4 +1,5 @@
 using ConduitLLM.Core.Constants;
+using ConduitLLM.Core.Serialization;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System.Text.Json;
@@ -43,7 +44,7 @@ namespace ConduitLLM.Core.Services
                 
                 if (state.HasValue)
                 {
-                    var circuitState = JsonSerializer.Deserialize<CircuitState>(state.ToString());
+                    var circuitState = DeserializeCircuitState(state);
                     if (circuitState != null)
                     {
                         // Check if circuit should transition from Open to Half-Open
@@ -56,7 +57,7 @@ namespace ConduitLLM.Core.Services
                             
                             circuitState.State = "HalfOpen";
                             circuitState.HalfOpenTestAt = DateTime.UtcNow;
-                            var newState = JsonSerializer.Serialize(circuitState);
+                            var newState = SerializeCircuitState(circuitState);
                             transaction.StringSetAsync(stateKey, newState, _openDuration);
                             
                             if (transaction.Execute())
@@ -105,7 +106,7 @@ namespace ConduitLLM.Core.Services
                 
                 if (currentState.HasValue)
                 {
-                    var circuitState = JsonSerializer.Deserialize<CircuitState>(currentState.ToString());
+                    var circuitState = DeserializeCircuitState(currentState);
                     if (circuitState != null && (circuitState.State == "Open" || circuitState.State == "HalfOpen"))
                     {
                         // Close the circuit
@@ -139,7 +140,7 @@ namespace ConduitLLM.Core.Services
                 
                 if (currentState.HasValue)
                 {
-                    var circuitState = JsonSerializer.Deserialize<CircuitState>(currentState.ToString());
+                    var circuitState = DeserializeCircuitState(currentState);
                     if (circuitState != null && circuitState.State == "HalfOpen")
                     {
                         // Failed in half-open state, immediately open circuit again
@@ -200,7 +201,7 @@ namespace ConduitLLM.Core.Services
                 
                 if (stateTask.Result.HasValue)
                 {
-                    var circuitState = JsonSerializer.Deserialize<CircuitState>(stateTask.Result.ToString());
+                    var circuitState = DeserializeCircuitState(stateTask.Result);
                     if (circuitState != null)
                     {
                         isOpen = circuitState.State == "Open";
@@ -237,7 +238,7 @@ namespace ConduitLLM.Core.Services
                 };
                 
                 var stateKey = RedisKeys.WebhookCircuit.State(urlHash);
-                var stateJson = JsonSerializer.Serialize(circuitState);
+                var stateJson = SerializeCircuitState(circuitState);
                 
                 db.StringSet(stateKey, stateJson, _openDuration.Add(TimeSpan.FromMinutes(5)));
                 
@@ -256,7 +257,7 @@ namespace ConduitLLM.Core.Services
             }
         }
         
-        private class CircuitState
+        internal sealed class CircuitState
         {
             public string State { get; set; } = "Closed"; // Closed, Open, HalfOpen
             public DateTime OpenedAt { get; set; }
@@ -264,5 +265,11 @@ namespace ConduitLLM.Core.Services
             public int FailureCount { get; set; }
             public string WebhookUrl { get; set; } = string.Empty;
         }
+
+        private static CircuitState? DeserializeCircuitState(RedisValue value) =>
+            JsonSerializer.Deserialize(value.ToString(), CoreRedisJsonContext.Default.CircuitState);
+
+        private static string SerializeCircuitState(CircuitState value) =>
+            JsonSerializer.Serialize(value, CoreRedisJsonContext.Default.CircuitState);
     }
 }

--- a/Shared/ConduitLLM.Core/Utilities/HttpClientHelper.cs
+++ b/Shared/ConduitLLM.Core/Utilities/HttpClientHelper.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 using ConduitLLM.Core.Exceptions;
 
@@ -167,6 +168,69 @@ namespace ConduitLLM.Core.Utilities
         }
 
         /// <summary>
+        /// Sends a GET request and deserializes the response with source-generated metadata.
+        /// </summary>
+        public static async Task<TResponse> GetJsonAsync<TResponse>(
+            HttpClient client,
+            string endpoint,
+            JsonTypeInfo<TResponse> responseTypeInfo,
+            IDictionary<string, string>? headers = null,
+            ILogger? logger = null,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                LogRequestHeaderNames(request, logger);
+                logger?.LogDebug("Sending GET request to {Endpoint}", endpoint);
+
+                using var response = await client.SendAsync(request, cancellationToken);
+                return await ProcessResponseAsync(
+                    response,
+                    responseTypeInfo,
+                    logger,
+                    cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                logger?.LogError(ex, "HTTP request error communicating with API at {Endpoint}", endpoint);
+                throw new LLMCommunicationException($"HTTP request error: {ex.Message}", ex);
+            }
+            catch (TaskCanceledException ex) when (cancellationToken.IsCancellationRequested)
+            {
+                logger?.LogWarning("Request to {Endpoint} was cancelled", endpoint);
+                throw new LLMCommunicationException("Request was cancelled", ex);
+            }
+            catch (TaskCanceledException ex)
+            {
+                logger?.LogError(ex, "Request to {Endpoint} timed out", endpoint);
+                throw new LLMCommunicationException("Request timed out", ex);
+            }
+            catch (JsonException ex)
+            {
+                logger?.LogError(ex, "Failed to deserialize JSON response from {Endpoint}", endpoint);
+                throw new LLMCommunicationException($"Failed to deserialize response: {ex.Message}", ex);
+            }
+            catch (Exception ex) when (
+                ex is not LLMCommunicationException &&
+                ex is not ConfigurationException &&
+                ex is not ModelNotFoundException &&
+                ex is not ValidationException)
+            {
+                logger?.LogError(ex, "Unexpected error during API communication with {Endpoint}", endpoint);
+                throw new LLMCommunicationException($"Unexpected error: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
         /// Creates an HTTP request with JSON content and headers.
         /// </summary>
         private static HttpRequestMessage CreateJsonRequest<TRequest>(
@@ -282,6 +346,62 @@ namespace ConduitLLM.Core.Utilities
             {
                 // Log the full response on error for debugging
                 logger?.LogError(ex, "Failed to deserialize response. Redacted content: {Content}",
+                    SensitiveDataRedactor.Redact(responseContent));
+                throw;
+            }
+        }
+
+        private static async Task<TResponse> ProcessResponseAsync<TResponse>(
+            HttpResponseMessage response,
+            JsonTypeInfo<TResponse> responseTypeInfo,
+            ILogger? logger,
+            CancellationToken cancellationToken)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await ReadErrorContentAsync(response, cancellationToken);
+                logger?.LogError("API error: {StatusCode} - {Content}", response.StatusCode, errorContent);
+
+                // Preserve the existing provider-specific diagnostic used by the options-based path.
+                if (errorContent.Contains("\"message\": null") &&
+                    errorContent.Contains("image_generation_user_error"))
+                {
+                    logger?.LogWarning(
+                        "Detected possible OpenAI quota/billing issue - image generation errors with null messages often indicate insufficient quota");
+                    throw new LLMCommunicationException(
+                        $"API returned an error: {(int)response.StatusCode} {response.StatusCode} - Possible quota/billing issue. Please check your provider account status.",
+                        response.StatusCode,
+                        errorContent,
+                        null);
+                }
+
+                throw new LLMCommunicationException(
+                    $"API returned an error: {(int)response.StatusCode} {response.StatusCode} - {SensitiveDataRedactor.Redact(errorContent)}",
+                    response.StatusCode,
+                    errorContent,
+                    null);
+            }
+
+            logger?.LogDebug("Received successful response with status code {StatusCode}", response.StatusCode);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (logger?.IsEnabled(LogLevel.Debug) == true)
+            {
+                var safeContent = SensitiveDataRedactor.Redact(responseContent);
+                var preview = safeContent.Length > 500 ? safeContent[..500] + "..." : safeContent;
+                logger.LogDebug("Response content preview: {Content}", preview);
+            }
+
+            try
+            {
+                return JsonSerializer.Deserialize(responseContent, responseTypeInfo)
+                    ?? throw new LLMCommunicationException("Failed to deserialize response - result was null");
+            }
+            catch (JsonException ex)
+            {
+                logger?.LogError(
+                    ex,
+                    "Failed to deserialize response. Redacted content: {Content}",
                     SensitiveDataRedactor.Redact(responseContent));
                 throw;
             }

--- a/Shared/ConduitLLM.Providers/AssemblyInfo.cs
+++ b/Shared/ConduitLLM.Providers/AssemblyInfo.cs
@@ -2,4 +2,5 @@ using System.Runtime.CompilerServices;
 
 // Make internals visible to the test project
 [assembly: InternalsVisibleTo("ConduitLLM.Tests")]
+[assembly: InternalsVisibleTo("ConduitLLM.SerializationTests")]
 [assembly: InternalsVisibleTo("ConduitLLM.Admin")]

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Chat.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Chat.cs
@@ -4,6 +4,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Core.Utilities;
 using ConduitLLM.Providers.Helpers;
+using ConduitLLM.Providers.Serialization;
 
 using Microsoft.Extensions.Logging;
 
@@ -34,7 +35,9 @@ namespace ConduitLLM.Providers.Bedrock
                 await ThrowOnErrorAsync(httpResponse, "chat completion", cancellationToken);
 
                 var body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
-                var converseResponse = JsonSerializer.Deserialize<BedrockConverseResponse>(body, DefaultJsonOptions)
+                var converseResponse = JsonSerializer.Deserialize(
+                        body,
+                        ProvidersJsonContext.Default.BedrockConverseResponse)
                     ?? throw new LLMCommunicationException("Bedrock returned an empty converse response.");
 
                 var response = MapToCoreResponse(converseResponse, request.Model ?? ProviderModelId);
@@ -336,8 +339,8 @@ namespace ConduitLLM.Providers.Bedrock
             {
                 return serialized.GetString() switch
                 {
-                    "auto" => new BedrockToolChoice { Auto = new { } },
-                    "required" => new BedrockToolChoice { Any = new { } },
+                    "auto" => new BedrockToolChoice { Auto = CreateEmptyJsonObject() },
+                    "required" => new BedrockToolChoice { Any = CreateEmptyJsonObject() },
                     _ => null
                 };
             }
@@ -351,6 +354,12 @@ namespace ConduitLLM.Providers.Bedrock
             }
 
             return null;
+        }
+
+        private static JsonElement CreateEmptyJsonObject()
+        {
+            using var document = JsonDocument.Parse("{}");
+            return document.RootElement.Clone();
         }
 
         internal ChatCompletionResponse MapToCoreResponse(BedrockConverseResponse response, string modelId)

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Models.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Models.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Providers.Common.Models;
+using ConduitLLM.Providers.Serialization;
 
 using Microsoft.Extensions.Logging;
 
@@ -36,7 +37,9 @@ namespace ConduitLLM.Providers.Bedrock
                 await ThrowOnErrorAsync(httpResponse, "model discovery", cancellationToken);
 
                 var body = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
-                var parsed = JsonSerializer.Deserialize<BedrockListFoundationModelsResponse>(body, DefaultJsonOptions);
+                var parsed = JsonSerializer.Deserialize(
+                    body,
+                    ProvidersJsonContext.Default.BedrockListFoundationModelsResponse);
 
                 return parsed?.ModelSummaries?
                     .Where(summary => !string.IsNullOrWhiteSpace(summary.ModelId))

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Streaming.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.Streaming.cs
@@ -1,8 +1,10 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Models;
+using ConduitLLM.Providers.Serialization;
 using ConduitLLM.Providers.Streaming;
 
 using Microsoft.Extensions.Logging;
@@ -204,7 +206,10 @@ namespace ConduitLLM.Providers.Bedrock
         {
             try
             {
-                return JsonSerializer.Deserialize<T>(message.Payload, DefaultJsonOptions);
+                var typeInfo = ProvidersJsonContext.Default.GetTypeInfo(typeof(T)) as JsonTypeInfo<T>
+                    ?? throw new JsonException(
+                        $"No generated JSON metadata is registered for Bedrock stream type {typeof(T).FullName}.");
+                return JsonSerializer.Deserialize(message.Payload, typeInfo);
             }
             catch (JsonException ex)
             {

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockClient.cs
@@ -7,6 +7,7 @@ using ConduitLLM.Core.Exceptions;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.Authentication;
 using ConduitLLM.Providers.Configuration;
+using ConduitLLM.Providers.Serialization;
 
 using Microsoft.Extensions.Logging;
 
@@ -150,8 +151,10 @@ namespace ConduitLLM.Providers.Bedrock
         /// <summary>
         /// Serializes a Bedrock request body with the client's camelCase conventions.
         /// </summary>
-        internal static byte[] SerializePayload<T>(T body) =>
-            JsonSerializer.SerializeToUtf8Bytes(body, DefaultJsonOptions);
+        internal static byte[] SerializePayload(BedrockConverseRequest body) =>
+            JsonSerializer.SerializeToUtf8Bytes(
+                body,
+                ProvidersJsonContext.Default.BedrockConverseRequest);
 
         /// <summary>
         /// Authentication is applied per request (SigV4 covers the payload), so no client-level

--- a/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockModels.cs
+++ b/Shared/ConduitLLM.Providers/Providers/Bedrock/BedrockModels.cs
@@ -100,8 +100,8 @@ namespace ConduitLLM.Providers.Bedrock
     /// <summary>Exactly one member is set: <c>auto</c>, <c>any</c>, or a named <c>tool</c>.</summary>
     internal class BedrockToolChoice
     {
-        public object? Auto { get; set; }
-        public object? Any { get; set; }
+        public JsonElement? Auto { get; set; }
+        public JsonElement? Any { get; set; }
         public BedrockNamedToolChoice? Tool { get; set; }
     }
 

--- a/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
+++ b/Shared/ConduitLLM.Providers/Providers/OpenRouter/OpenRouterClient.cs
@@ -4,6 +4,7 @@ using ConduitLLM.Configuration;
 using ConduitLLM.Configuration.Entities;
 using ConduitLLM.Core.Models;
 using ConduitLLM.Providers.Configuration;
+using ConduitLLM.Providers.Serialization;
 using InternalModels = ConduitLLM.Providers.Common.Models;
 using CoreUtils = ConduitLLM.Core.Utilities;
 
@@ -127,8 +128,8 @@ namespace ConduitLLM.Providers.OpenRouter
                     var response = await CoreUtils.HttpClientHelper.GetJsonAsync<OpenRouterCatalogResponse>(
                         client,
                         endpoint,
+                        ProvidersJsonContext.Default.OpenRouterCatalogResponse,
                         headers,
-                        DefaultJsonOptions,
                         Logger,
                         cancellationToken);
 

--- a/Shared/ConduitLLM.Providers/Serialization/ProvidersJsonContext.cs
+++ b/Shared/ConduitLLM.Providers/Serialization/ProvidersJsonContext.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+using ConduitLLM.Providers.Bedrock;
+using ConduitLLM.Providers.OpenRouter;
+
+namespace ConduitLLM.Providers.Serialization;
+
+/// <summary>
+/// Source-generated metadata for selected high-volume provider request/response paths.
+/// </summary>
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(BedrockConverseRequest))]
+[JsonSerializable(typeof(BedrockConverseResponse))]
+[JsonSerializable(typeof(BedrockListFoundationModelsResponse))]
+[JsonSerializable(typeof(BedrockStreamMessageStart))]
+[JsonSerializable(typeof(BedrockStreamContentBlockStart))]
+[JsonSerializable(typeof(BedrockStreamContentBlockDelta))]
+[JsonSerializable(typeof(BedrockStreamMessageStop))]
+[JsonSerializable(typeof(BedrockStreamMetadata))]
+[JsonSerializable(typeof(OpenRouterCatalogResponse))]
+internal partial class ProvidersJsonContext : JsonSerializerContext;

--- a/Tests/ConduitLLM.Benchmarks/JsonSourceGenerationBenchmarks.cs
+++ b/Tests/ConduitLLM.Benchmarks/JsonSourceGenerationBenchmarks.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+using BenchmarkDotNet.Attributes;
+
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Serialization;
+
+namespace ConduitLLM.Benchmarks;
+
+/// <summary>
+/// Compares reflection metadata lookup with the generated metadata used by the Gateway
+/// chat response path.
+/// </summary>
+/// <remarks>
+/// Run with:
+/// <c>dotnet run -c Release --project Tests/ConduitLLM.Benchmarks -- --filter *JsonSourceGeneration*</c>.
+/// </remarks>
+[MemoryDiagnoser]
+public class JsonSourceGenerationBenchmarks
+{
+    private static readonly JsonSerializerOptions ReflectionOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    private ChatCompletionResponse _response = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _response = new ChatCompletionResponse
+        {
+            Id = "chatcmpl-benchmark",
+            Object = "chat.completion",
+            Created = 1_722_083_696,
+            Model = "gpt-benchmark",
+            Choices =
+            [
+                new Choice
+                {
+                    Index = 0,
+                    FinishReason = "stop",
+                    Message = new Message
+                    {
+                        Role = "assistant",
+                        Content = "A representative short completion."
+                    }
+                }
+            ],
+            Usage = new Usage
+            {
+                PromptTokens = 24,
+                CompletionTokens = 6,
+                TotalTokens = 30
+            }
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public string ReflectionMetadata() =>
+        JsonSerializer.Serialize(_response, ReflectionOptions);
+
+    [Benchmark]
+    public string SourceGeneratedMetadata() =>
+        JsonSerializer.Serialize(_response, CoreHttpJsonContext.Default.ChatCompletionResponse);
+}

--- a/Tests/ConduitLLM.SerializationTests/ConduitLLM.SerializationTests.csproj
+++ b/Tests/ConduitLLM.SerializationTests/ConduitLLM.SerializationTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\ConduitLLM.Configuration\ConduitLLM.Configuration.csproj" />
+    <ProjectReference Include="..\..\Shared\ConduitLLM.Core\ConduitLLM.Core.csproj" />
+    <ProjectReference Include="..\..\Shared\ConduitLLM.Providers\ConduitLLM.Providers.csproj" />
+    <ProjectReference Include="..\..\Services\ConduitLLM.Admin\ConduitLLM.Admin.csproj" />
+    <ProjectReference Include="..\..\Services\ConduitLLM.Gateway\ConduitLLM.Gateway.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/admin-problem-details.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/admin-problem-details.json
@@ -1,0 +1,14 @@
+{
+  "code": "validation_error",
+  "traceId": "trace-sourcegen",
+  "errors": {
+    "model": [
+      "The model field is required."
+    ]
+  },
+  "type": "https://errors.conduit.test/validation",
+  "title": "Validation failed",
+  "status": 400,
+  "detail": "The request was invalid.",
+  "instance": "/api/test"
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/bedrock-converse-response.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/bedrock-converse-response.json
@@ -1,0 +1,18 @@
+{
+  "output": {
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "text": "Hello from Bedrock"
+        }
+      ]
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 4,
+    "outputTokens": 3,
+    "totalTokens": 7
+  }
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/gateway-chat-response.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/gateway-chat-response.json
@@ -1,0 +1,21 @@
+{
+  "id": "chatcmpl-sourcegen",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "created": 1722083696,
+  "model": "gpt-test",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 4,
+    "completion_tokens": 2,
+    "total_tokens": 6
+  }
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/gateway-model-list.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/gateway-model-list.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "id": "gpt-test",
+      "object": "model",
+      "created": 1722083696,
+      "owned_by": "conduit"
+    }
+  ],
+  "object": "list"
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/redis-model-cost-legacy.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/redis-model-cost-legacy.json
@@ -1,0 +1,14 @@
+{
+  "Id": 7,
+  "CostName": "Legacy token pricing",
+  "PricingModel": 0,
+  "InputCostPerMillionTokens": 1.25,
+  "OutputCostPerMillionTokens": 5.00,
+  "CreatedAt": "2026-07-27T12:34:56Z",
+  "UpdatedAt": "2026-07-27T12:34:56Z",
+  "ModelType": "chat",
+  "IsActive": true,
+  "EffectiveDate": "2026-07-27T12:34:56Z",
+  "Priority": 10,
+  "SupportsBatchProcessing": false
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/redis-virtual-key-invalidation.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/redis-virtual-key-invalidation.json
@@ -1,0 +1,7 @@
+{
+  "KeyHashes": [
+    "hash-one",
+    "hash-two"
+  ],
+  "Timestamp": "2026-07-27T12:34:56Z"
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/redis-webhook-circuit-state.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/redis-webhook-circuit-state.json
@@ -1,0 +1,7 @@
+{
+  "State": "Open",
+  "OpenedAt": "2026-07-27T12:34:56Z",
+  "HalfOpenTestAt": null,
+  "FailureCount": 5,
+  "WebhookUrl": "https://hooks.example.test/events"
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/signalr-virtual-key-created.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/signalr-virtual-key-created.json
@@ -1,0 +1,11 @@
+{
+  "keyId": 42,
+  "keyName": "serialization-test",
+  "isEnabled": true,
+  "maxBudget": 25.50,
+  "allowedModels": "gpt-test",
+  "rateLimitPerMinute": 60,
+  "createdAt": "2026-07-27T12:34:56Z",
+  "expiresAt": "2026-08-26T12:34:56Z",
+  "timestamp": "2026-07-27T12:34:56Z"
+}

--- a/Tests/ConduitLLM.SerializationTests/Fixtures/wolverine-spend-update.json
+++ b/Tests/ConduitLLM.SerializationTests/Fixtures/wolverine-spend-update.json
@@ -1,0 +1,9 @@
+{
+  "KeyId": 42,
+  "Amount": 1.25,
+  "RequestId": "req-sourcegen",
+  "PartitionKey": "42",
+  "EventId": "event-sourcegen",
+  "Timestamp": "2026-07-27T12:34:56Z",
+  "CorrelationId": "corr-sourcegen"
+}

--- a/Tests/ConduitLLM.SerializationTests/SourceGeneratedJsonCompatibilityTests.cs
+++ b/Tests/ConduitLLM.SerializationTests/SourceGeneratedJsonCompatibilityTests.cs
@@ -1,0 +1,309 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+using ConduitLLM.Admin.DTOs;
+using ConduitLLM.Admin.Serialization;
+using ConduitLLM.Configuration.Entities;
+using ConduitLLM.Configuration.DTOs.SignalR;
+using ConduitLLM.Configuration.Serialization;
+using ConduitLLM.Core.Events;
+using ConduitLLM.Core.Models;
+using ConduitLLM.Core.Serialization;
+using ConduitLLM.Core.Services;
+using ConduitLLM.Gateway.DTOs;
+using ConduitLLM.Gateway.Options;
+using ConduitLLM.Gateway.Serialization;
+using ConduitLLM.Gateway.Services;
+using ConduitLLM.Providers.Bedrock;
+using ConduitLLM.Providers.Serialization;
+
+namespace ConduitLLM.SerializationTests;
+
+public sealed class SourceGeneratedJsonCompatibilityTests
+{
+    private static readonly DateTime FixtureTime =
+        new(2026, 7, 27, 12, 34, 56, DateTimeKind.Utc);
+
+    [Fact]
+    public void Test_profile_disables_reflection_defaults()
+    {
+        Assert.False(JsonSerializer.IsReflectionEnabledByDefault);
+        Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new UnregisteredContract()));
+    }
+
+    [Fact]
+    public void Gateway_chat_contract_is_bidirectionally_compatible()
+    {
+        var value = new ChatCompletionResponse
+        {
+            Id = "chatcmpl-sourcegen",
+            Object = "chat.completion",
+            Created = 1_722_083_696,
+            Model = "gpt-test",
+            Choices =
+            [
+                new Choice
+                {
+                    Index = 0,
+                    FinishReason = "stop",
+                    Message = new Message { Role = "assistant", Content = "Hello" }
+                }
+            ],
+            Usage = new Usage
+            {
+                PromptTokens = 4,
+                CompletionTokens = 2,
+                TotalTokens = 6
+            }
+        };
+
+        AssertCompatible(
+            value,
+            CoreHttpJsonContext.Default.ChatCompletionResponse,
+            "gateway-chat-response.json",
+            SnakeCaseWireOptions());
+
+        var hostOptions = GatewayJsonOptions.Create();
+        AssertJsonEqual(
+            ReadFixture("gateway-chat-response.json"),
+            JsonSerializer.Serialize(value, hostOptions));
+    }
+
+    [Fact]
+    public void Wolverine_message_is_bidirectionally_compatible()
+    {
+        var value = new SpendUpdateRequested
+        {
+            KeyId = 42,
+            Amount = 1.25m,
+            RequestId = "req-sourcegen",
+            EventId = "event-sourcegen",
+            Timestamp = FixtureTime,
+            CorrelationId = "corr-sourcegen"
+        };
+
+        AssertCompatible(
+            value,
+            CoreMessagingJsonContext.Default.SpendUpdateRequested,
+            "wolverine-spend-update.json",
+            new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() });
+
+        var runtimeOptions = new JsonSerializerOptions
+        {
+            TypeInfoResolver = CoreMessagingJsonContext.Default
+        };
+        AssertJsonEqual(
+            ReadFixture("wolverine-spend-update.json"),
+            JsonSerializer.Serialize(value, typeof(SpendUpdateRequested), runtimeOptions));
+    }
+
+    [Fact]
+    public void SignalR_notification_preserves_live_camel_case_contract()
+    {
+        var value = new VirtualKeyCreatedNotification
+        {
+            KeyId = 42,
+            KeyName = "serialization-test",
+            IsEnabled = true,
+            MaxBudget = 25.50m,
+            AllowedModels = "gpt-test",
+            RateLimitPerMinute = 60,
+            CreatedAt = FixtureTime,
+            ExpiresAt = FixtureTime.AddDays(30),
+            Timestamp = FixtureTime
+        };
+
+        AssertCompatible(
+            value,
+            ConfigurationSignalRJsonContext.Default.VirtualKeyCreatedNotification,
+            "signalr-virtual-key-created.json",
+            CamelCaseOptions());
+    }
+
+    [Fact]
+    public void Gateway_model_list_preserves_openai_envelope()
+    {
+        var value = new ModelListResponse(
+            [new ModelListItemDto("gpt-test", "model", 1_722_083_696, "conduit")],
+            "list");
+
+        AssertCompatible(
+            value,
+            GatewayHttpJsonContext.Default.ModelListResponse,
+            "gateway-model-list.json",
+            SnakeCaseWireOptions());
+    }
+
+    [Fact]
+    public void Admin_problem_details_preserves_error_contract()
+    {
+        var value = new AdminProblemDetails
+        {
+            Type = "https://errors.conduit.test/validation",
+            Title = "Validation failed",
+            Status = 400,
+            Detail = "The request was invalid.",
+            Instance = "/api/test",
+            Code = "validation_error",
+            TraceId = "trace-sourcegen",
+            Errors = new Dictionary<string, string[]>
+            {
+                ["model"] = ["The model field is required."]
+            }
+        };
+
+        AssertCompatible(
+            value,
+            AdminHttpJsonContext.Default.AdminProblemDetails,
+            "admin-problem-details.json",
+            CamelCaseOptions());
+    }
+
+    [Fact]
+    public void Bedrock_response_preserves_provider_wire_contract()
+    {
+        var value = new BedrockConverseResponse
+        {
+            Output = new BedrockConverseOutput
+            {
+                Message = new BedrockMessage
+                {
+                    Role = "assistant",
+                    Content = [new BedrockContentBlock { Text = "Hello from Bedrock" }]
+                }
+            },
+            StopReason = "end_turn",
+            Usage = new BedrockUsage { InputTokens = 4, OutputTokens = 3, TotalTokens = 7 }
+        };
+
+        AssertCompatible(
+            value,
+            ProvidersJsonContext.Default.BedrockConverseResponse,
+            "bedrock-converse-response.json",
+            CamelCaseWireOptions());
+    }
+
+    [Fact]
+    public void Redis_reliability_payload_is_bidirectionally_compatible()
+    {
+        var value = new RedisWebhookCircuitBreaker.CircuitState
+        {
+            State = "Open",
+            OpenedAt = FixtureTime,
+            HalfOpenTestAt = null,
+            FailureCount = 5,
+            WebhookUrl = "https://hooks.example.test/events"
+        };
+
+        AssertCompatible(
+            value,
+            CoreRedisJsonContext.Default.CircuitState,
+            "redis-webhook-circuit-state.json",
+            CaseInsensitivePascalOptions());
+    }
+
+    [Fact]
+    public void Redis_invalidation_payload_is_bidirectionally_compatible()
+    {
+        var value = new RedisVirtualKeyCache.VirtualKeyBatchInvalidation
+        {
+            KeyHashes = ["hash-one", "hash-two"],
+            Timestamp = FixtureTime
+        };
+
+        AssertCompatible(
+            value,
+            GatewayRedisJsonContext.Default.VirtualKeyBatchInvalidation,
+            "redis-virtual-key-invalidation.json",
+            CaseInsensitivePascalOptions());
+    }
+
+    [Fact]
+    public void Previous_release_model_cost_cache_entry_is_readable_and_new_entry_is_legacy_readable()
+    {
+        var legacyOptions = CaseInsensitivePascalOptions();
+        var fixture = ReadFixture("redis-model-cost-legacy.json");
+
+        var generatedRead = JsonSerializer.Deserialize(
+            fixture,
+            GatewayRedisJsonContext.Default.ModelCost);
+        Assert.NotNull(generatedRead);
+        Assert.Equal(7, generatedRead.Id);
+        Assert.Equal("Legacy token pricing", generatedRead.CostName);
+
+        var generatedJson = JsonSerializer.Serialize(
+            generatedRead,
+            GatewayRedisJsonContext.Default.ModelCost);
+        var legacyRead = JsonSerializer.Deserialize<ModelCost>(generatedJson, legacyOptions);
+        Assert.NotNull(legacyRead);
+        Assert.Equal(generatedRead.Id, legacyRead.Id);
+        Assert.Equal(generatedRead.PricingModel, legacyRead.PricingModel);
+        Assert.Equal(generatedRead.InputCostPerMillionTokens, legacyRead.InputCostPerMillionTokens);
+    }
+
+    private static void AssertCompatible<T>(
+        T value,
+        JsonTypeInfo<T> generatedTypeInfo,
+        string fixtureName,
+        JsonSerializerOptions legacyOptions)
+    {
+        Assert.False(JsonSerializer.IsReflectionEnabledByDefault);
+
+        var fixture = ReadFixture(fixtureName);
+        var generatedJson = JsonSerializer.Serialize(value, generatedTypeInfo);
+        var legacyJson = JsonSerializer.Serialize(value, legacyOptions);
+
+        AssertJsonEqual(fixture, generatedJson);
+        AssertJsonEqual(fixture, legacyJson);
+
+        var generatedReadsLegacy = JsonSerializer.Deserialize(legacyJson, generatedTypeInfo);
+        Assert.NotNull(generatedReadsLegacy);
+        AssertJsonEqual(
+            generatedJson,
+            JsonSerializer.Serialize(generatedReadsLegacy, generatedTypeInfo));
+
+        var legacyReadsGenerated = JsonSerializer.Deserialize<T>(generatedJson, legacyOptions);
+        Assert.NotNull(legacyReadsGenerated);
+        AssertJsonEqual(legacyJson, JsonSerializer.Serialize(legacyReadsGenerated, legacyOptions));
+    }
+
+    private static JsonSerializerOptions SnakeCaseWireOptions() => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    private static JsonSerializerOptions CamelCaseOptions() => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    private static JsonSerializerOptions CamelCaseWireOptions() => new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    private static JsonSerializerOptions CaseInsensitivePascalOptions() => new()
+    {
+        PropertyNameCaseInsensitive = true,
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+    };
+
+    private static string ReadFixture(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", name));
+
+    private static void AssertJsonEqual(string expected, string actual) =>
+        Assert.True(
+            JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)),
+            $"Expected: {expected}{Environment.NewLine}Actual:   {actual}");
+
+    private sealed class UnregisteredContract;
+}

--- a/Tests/ConduitLLM.Tests/Configuration/Data/MigrationRegistrationTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Data/MigrationRegistrationTests.cs
@@ -1,0 +1,34 @@
+using ConduitLLM.Configuration.Data;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ConduitLLM.Tests.Configuration.Data;
+
+public sealed class MigrationRegistrationTests
+{
+    [Fact]
+    public void AddDatabaseMigration_DoesNotRegisterSchemaMutationService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddDatabaseMigration();
+
+        Assert.DoesNotContain(
+            services,
+            descriptor => descriptor.ServiceType == typeof(SimpleMigrationService));
+    }
+
+    [Theory]
+    [InlineData(MigrationMode.Wait, false)]
+    [InlineData(MigrationMode.Skip, true)]
+    public void ReadinessState_StartsAccordingToRuntimeMode(
+        MigrationMode mode,
+        bool expectedCurrent)
+    {
+        var state = new MigrationReadinessState(
+            new MigrationStartupOptions { Mode = mode });
+
+        Assert.Equal(expectedCurrent, state.IsSchemaCurrent);
+    }
+}

--- a/Tests/ConduitLLM.Tests/Configuration/Data/MigrationStartupOptionsTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Data/MigrationStartupOptionsTests.cs
@@ -42,14 +42,14 @@ namespace ConduitLLM.Tests.Configuration.Data
         }
 
         [Fact]
-        public void FromEnvironment_NoVariable_DefaultsToApply()
+        public void FromEnvironment_NoVariable_DefaultsToWait()
         {
             var options = RunWithEnvironment(
                 MigrationStartupOptions.FromEnvironment,
                 _loggerMock.Object,
                 (MigrationStartupOptions.ModeVariable, null));
 
-            Assert.Equal(MigrationMode.Apply, options.Mode);
+            Assert.Equal(MigrationMode.Wait, options.Mode);
             Assert.Equal(MigrationStartupOptions.DefaultLockTimeoutSeconds, options.LockTimeoutSeconds);
             Assert.Equal(0, options.WaitTimeoutSeconds);
         }
@@ -58,7 +58,6 @@ namespace ConduitLLM.Tests.Configuration.Data
         [InlineData("wait", MigrationMode.Wait)]
         [InlineData("Wait", MigrationMode.Wait)]
         [InlineData("WAIT", MigrationMode.Wait)]
-        [InlineData("apply", MigrationMode.Apply)]
         [InlineData("skip", MigrationMode.Skip)]
         [InlineData(" Skip ", MigrationMode.Skip)]
         public void FromEnvironment_ValidValueAnyCase_ParsesMode(string raw, MigrationMode expected)
@@ -80,6 +79,31 @@ namespace ConduitLLM.Tests.Configuration.Data
                 (MigrationStartupOptions.ModeVariable, "Automatic")));
 
             Assert.Contains("Automatic", ex.Message);
+        }
+
+        [Fact]
+        public void FromEnvironment_Apply_ThrowsWithExplicitMigratorInstruction()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => RunWithEnvironment(
+                MigrationStartupOptions.FromEnvironment,
+                _loggerMock.Object,
+                (MigrationStartupOptions.ModeVariable, "Apply")));
+
+            Assert.Contains("no longer supported", ex.Message);
+            Assert.Contains("migrate", ex.Message);
+        }
+
+        [Fact]
+        public void ForMigrator_IgnoresRuntimeMode()
+        {
+            var options = RunWithEnvironment(
+                MigrationStartupOptions.ForMigrator,
+                _loggerMock.Object,
+                (MigrationStartupOptions.ModeVariable, "Apply"),
+                (MigrationStartupOptions.LockTimeoutVariable, "42"));
+
+            Assert.Equal(MigrationMode.Wait, options.Mode);
+            Assert.Equal(42, options.LockTimeoutSeconds);
         }
 
         [Fact]

--- a/Tests/ConduitLLM.Tests/Configuration/Data/MigrationWaitServiceTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Data/MigrationWaitServiceTests.cs
@@ -12,7 +12,8 @@ namespace ConduitLLM.Tests.Configuration.Data
         private readonly Mock<IPendingMigrationsProbe> _probeMock = new();
         private readonly Mock<IHostApplicationLifetime> _lifetimeMock = new();
         private readonly Mock<ILogger<MigrationWaitService>> _loggerMock = new();
-        private readonly MigrationReadinessState _state = new();
+        private readonly MigrationReadinessState _state =
+            new(new MigrationStartupOptions { Mode = MigrationMode.Wait });
 
         private MigrationWaitService CreateService(MigrationMode mode)
         {
@@ -33,7 +34,7 @@ namespace ConduitLLM.Tests.Configuration.Data
         [Fact]
         public async Task ExecuteAsync_ModeNotWait_DoesNothing()
         {
-            var service = CreateService(MigrationMode.Apply);
+            var service = CreateService(MigrationMode.Skip);
 
             await service.StartAsync(CancellationToken.None);
             await (service.ExecuteTask ?? Task.CompletedTask);

--- a/Tests/ConduitLLM.Tests/Configuration/Data/PendingMigrationsReadinessCheckTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Data/PendingMigrationsReadinessCheckTests.cs
@@ -10,18 +10,24 @@ namespace ConduitLLM.Tests.Configuration.Data
         [Fact]
         public async Task CheckHealthAsync_SchemaNotCurrent_ReturnsUnhealthy()
         {
-            var state = new MigrationReadinessState();
+            var state = new MigrationReadinessState(
+                new MigrationStartupOptions { Mode = MigrationMode.Wait });
             var check = new PendingMigrationsReadinessCheck(state);
 
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Contains("migrate", result.Description, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
         public async Task CheckHealthAsync_SchemaCurrent_ReturnsHealthy()
         {
-            var state = new MigrationReadinessState { IsSchemaCurrent = true };
+            var state = new MigrationReadinessState(
+                new MigrationStartupOptions { Mode = MigrationMode.Wait })
+            {
+                IsSchemaCurrent = true
+            };
             var check = new PendingMigrationsReadinessCheck(state);
 
             var result = await check.CheckHealthAsync(new HealthCheckContext());

--- a/Tests/ConduitLLM.Tests/Configuration/Data/ReleaseMigrationCommandTests.cs
+++ b/Tests/ConduitLLM.Tests/Configuration/Data/ReleaseMigrationCommandTests.cs
@@ -1,0 +1,239 @@
+using ConduitLLM.Configuration;
+using ConduitLLM.Configuration.Data;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+using Npgsql;
+
+using IMigrator = Microsoft.EntityFrameworkCore.Migrations.IMigrator;
+
+namespace ConduitLLM.Tests.Configuration.Data;
+
+/// <summary>
+/// End-to-end validation of the release migration command against a real PostgreSQL
+/// server. CI supplies DATABASE_URL; local runs skip when it is absent.
+/// </summary>
+[Collection("MigrationEnvironment")]
+public sealed class ReleaseMigrationCommandTests
+{
+    [SkippableFact]
+    public async Task EmptyDatabase_BootstrapsEfAndWolverineSchemas()
+    {
+        await using var database = await TemporaryDatabase.CreateAsync();
+        using var environment = database.UseAsMigrationTarget();
+
+        var exitCode = await MigrationCommand.RunAsync();
+
+        Assert.Equal(0, exitCode);
+        await AssertSchemaCurrentAsync(database.ConnectionString);
+        Assert.True(await SchemaExistsAsync(database.ConnectionString, "wolverine_conduit_gateway"));
+        Assert.True(await SchemaExistsAsync(database.ConnectionString, "wolverine_conduit_admin"));
+        Assert.True(await SchemaExistsAsync(database.ConnectionString, "wolverine_queues"));
+    }
+
+    [SkippableFact]
+    public async Task PreviousSchema_UpgradesToCurrent()
+    {
+        await using var database = await TemporaryDatabase.CreateAsync();
+        using var environment = database.UseAsMigrationTarget();
+        await using var context = CreateContext(database.ConnectionString);
+        var migrations = context.Database.GetMigrations().ToArray();
+        Skip.If(migrations.Length < 2, "At least two migrations are required to test an upgrade.");
+        await context.GetService<IMigrator>().MigrateAsync(migrations[^2]);
+
+        var exitCode = await MigrationCommand.RunAsync();
+
+        Assert.Equal(0, exitCode);
+        await AssertSchemaCurrentAsync(database.ConnectionString);
+    }
+
+    [SkippableFact]
+    public async Task CompletedMigration_RetryIsSafeNoOp()
+    {
+        await using var database = await TemporaryDatabase.CreateAsync();
+        using var environment = database.UseAsMigrationTarget(useInMemoryTransport: true);
+
+        Assert.Equal(0, await MigrationCommand.RunAsync());
+        var appliedBeforeRetry = await GetAppliedMigrationCountAsync(database.ConnectionString);
+
+        Assert.Equal(0, await MigrationCommand.RunAsync());
+        Assert.Equal(
+            appliedBeforeRetry,
+            await GetAppliedMigrationCountAsync(database.ConnectionString));
+    }
+
+    [SkippableFact]
+    public async Task ConcurrentInvocations_AreSerializedAndSucceed()
+    {
+        await using var database = await TemporaryDatabase.CreateAsync();
+        using var environment = database.UseAsMigrationTarget();
+
+        var results = await Task.WhenAll(
+            MigrationCommand.RunAsync(),
+            MigrationCommand.RunAsync());
+
+        Assert.All(results, exitCode => Assert.Equal(0, exitCode));
+        await AssertSchemaCurrentAsync(database.ConnectionString);
+    }
+
+    [Fact]
+    public async Task UnreachableDatabase_ReturnsFailureExitCode()
+    {
+        using var environment = new EnvironmentScope(
+            ("DATABASE_URL",
+                "Host=127.0.0.1;Port=1;Database=conduit_unreachable;" +
+                "Username=conduit;Password=conduit;Timeout=1;Command Timeout=1"),
+            ("ConduitLLM__Messaging__Wolverine__Transport", "InMemory"));
+
+        var exitCode = await MigrationCommand.RunAsync();
+
+        Assert.Equal(1, exitCode);
+    }
+
+    private static ConduitDbContext CreateContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<ConduitDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+        return new ConduitDbContext(options);
+    }
+
+    private static async Task AssertSchemaCurrentAsync(string connectionString)
+    {
+        await using var context = CreateContext(connectionString);
+        Assert.Empty(await context.Database.GetPendingMigrationsAsync());
+    }
+
+    private static async Task<int> GetAppliedMigrationCountAsync(string connectionString)
+    {
+        await using var context = CreateContext(connectionString);
+        return (await context.Database.GetAppliedMigrationsAsync()).Count();
+    }
+
+    private static async Task<bool> SchemaExistsAsync(string connectionString, string schema)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = new NpgsqlCommand(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = @schema)",
+            connection);
+        command.Parameters.AddWithValue("schema", schema);
+        return (bool)(await command.ExecuteScalarAsync())!;
+    }
+
+    private sealed class TemporaryDatabase : IAsyncDisposable
+    {
+        private readonly string _adminConnectionString;
+        private readonly string _databaseName;
+
+        private TemporaryDatabase(
+            string adminConnectionString,
+            string databaseName,
+            string connectionString)
+        {
+            _adminConnectionString = adminConnectionString;
+            _databaseName = databaseName;
+            ConnectionString = connectionString;
+        }
+
+        public string ConnectionString { get; }
+
+        public static async Task<TemporaryDatabase> CreateAsync()
+        {
+            var configured = Environment.GetEnvironmentVariable("DATABASE_URL");
+            Skip.If(
+                string.IsNullOrWhiteSpace(configured),
+                "DATABASE_URL is required for release migration integration tests.");
+
+            var source = ConfigurationDbContextFactory.ResolveNpgsqlConnectionString();
+            var databaseName = $"conduit_release_migration_{Guid.NewGuid():N}";
+            var adminBuilder = new NpgsqlConnectionStringBuilder(source)
+            {
+                Database = "postgres",
+                Pooling = false
+            };
+            var targetBuilder = new NpgsqlConnectionStringBuilder(source)
+            {
+                Database = databaseName,
+                Pooling = false
+            };
+
+            await using var connection = new NpgsqlConnection(adminBuilder.ConnectionString);
+            try
+            {
+                await connection.OpenAsync();
+            }
+            catch (Exception ex)
+            {
+                Skip.If(true, $"DATABASE_URL is not reachable: {ex.Message}");
+            }
+
+            await using var command = new NpgsqlCommand(
+                $"CREATE DATABASE \"{databaseName}\"",
+                connection);
+            await command.ExecuteNonQueryAsync();
+
+            return new TemporaryDatabase(
+                adminBuilder.ConnectionString,
+                databaseName,
+                targetBuilder.ConnectionString);
+        }
+
+        public EnvironmentScope UseAsMigrationTarget(bool useInMemoryTransport = false)
+            => new(
+                ("DATABASE_URL", ConnectionString),
+                ("CONDUIT_MIGRATION_MODE", "Wait"),
+                ("ConduitLLM__Messaging__Wolverine__Transport",
+                    useInMemoryTransport ? "InMemory" : "Postgresql"),
+                ("ConduitLLM__Messaging__Wolverine__AutoProvision", "false"));
+
+        public async ValueTask DisposeAsync()
+        {
+            NpgsqlConnection.ClearAllPools();
+            await using var connection = new NpgsqlConnection(_adminConnectionString);
+            await connection.OpenAsync();
+            await using (var terminate = new NpgsqlCommand(
+                """
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = @database AND pid <> pg_backend_pid()
+                """,
+                connection))
+            {
+                terminate.Parameters.AddWithValue("database", _databaseName);
+                await terminate.ExecuteNonQueryAsync();
+            }
+
+            await using var drop = new NpgsqlCommand(
+                $"DROP DATABASE IF EXISTS \"{_databaseName}\"",
+                connection);
+            await drop.ExecuteNonQueryAsync();
+        }
+    }
+
+    private sealed class EnvironmentScope : IDisposable
+    {
+        private readonly IReadOnlyList<(string Name, string? Value)> _saved;
+
+        public EnvironmentScope(params (string Name, string? Value)[] variables)
+        {
+            _saved = variables
+                .Select(variable =>
+                    (variable.Name, Environment.GetEnvironmentVariable(variable.Name)))
+                .ToArray();
+            foreach (var (name, value) in variables)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in _saved)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
+}

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -5,7 +5,8 @@
     <IsConduitTestProject Condition="'$(MSBuildProjectName)' == 'ConduitLLM.Tests' Or
                                      '$(MSBuildProjectName)' == 'ConduitLLM.IntegrationTests' Or
                                      '$(MSBuildProjectName)' == 'ConduitLLM.FaultInjectionTests' Or
-                                     '$(MSBuildProjectName)' == 'ConduitLLM.BillingInvariantTests'">true</IsConduitTestProject>
+                                     '$(MSBuildProjectName)' == 'ConduitLLM.BillingInvariantTests' Or
+                                     '$(MSBuildProjectName)' == 'ConduitLLM.SerializationTests'">true</IsConduitTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsConduitTestProject)' == 'true'">

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,8 +8,8 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       # Development defaults to Internal so provider errors are debuggable; override in .env
       CONDUIT_CUSTOMER_MODE: "${CONDUIT_CUSTOMER_MODE:-Internal}"
-      # Messaging runs on Wolverine (PostgreSQL transport) — the only backend as of #932.
-      ConduitLLM__Messaging__Wolverine__AutoProvision: "true"
+      # The one-shot migrate service owns EF and Wolverine schema provisioning.
+      ConduitLLM__Messaging__Wolverine__AutoProvision: "false"
       # OpenTelemetry tracing configuration
       Telemetry__OtlpEndpoint: "http://jaeger:4317"
       Telemetry__TracingEnabled: "true"
@@ -41,8 +41,8 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       # Must match the api service — Admin reports this value on the System Info page
       CONDUIT_CUSTOMER_MODE: "${CONDUIT_CUSTOMER_MODE:-Internal}"
-      # Messaging runs on Wolverine (PostgreSQL transport) — the only backend as of #932.
-      ConduitLLM__Messaging__Wolverine__AutoProvision: "true"
+      # The one-shot migrate service owns EF and Wolverine schema provisioning.
+      ConduitLLM__Messaging__Wolverine__AutoProvision: "false"
       # OpenTelemetry tracing configuration
       Telemetry__OtlpEndpoint: "http://jaeger:4317"
       Telemetry__TracingEnabled: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,25 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-      
+
+  # One-shot release gate. Both web services wait for this command to succeed and
+  # never mutate EF or Wolverine schemas during their own startup.
+  migrate:
+    build:
+      context: .
+      dockerfile: Services/ConduitLLM.Admin/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
+      ASPNETCORE_ENVIRONMENT: Production
+      ConduitLLM__Messaging__Wolverine__AutoProvision: "false"
+    command: ["migrate"]
+    restart: "no"
+    healthcheck:
+      disable: true
+
   redis:
     # Redis 7.4+ enables per-connection hash-field TTL; older external servers use timer cleanup.
     image: redis:7.4.2-alpine
@@ -36,13 +54,15 @@ services:
       context: .
       dockerfile: Services/ConduitLLM.Gateway/Dockerfile
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
+      CONDUIT_MIGRATION_MODE: "Wait"
+      ConduitLLM__Messaging__Wolverine__AutoProvision: "false"
       # Customer error visibility: External (default, sanitized) or Internal (raw provider detail)
       CONDUIT_CUSTOMER_MODE: "${CONDUIT_CUSTOMER_MODE:-External}"
       # Messaging runs on Wolverine (PostgreSQL transport) — the only backend as of #932.
@@ -109,13 +129,15 @@ services:
       context: .
       dockerfile: Services/ConduitLLM.Admin/Dockerfile
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql://conduit:conduitpass@postgres:5432/conduitdb
       ASPNETCORE_ENVIRONMENT: Production
+      CONDUIT_MIGRATION_MODE: "Wait"
+      ConduitLLM__Messaging__Wolverine__AutoProvision: "false"
       # Must match the api service — Admin reports this value on the System Info page
       CONDUIT_CUSTOMER_MODE: "${CONDUIT_CUSTOMER_MODE:-External}"
       # Messaging runs on Wolverine (PostgreSQL transport) — the only backend as of #932.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Conduit's configuration lives in two places, and knowing which is which is most 
 | Lives in | The **environment** (env vars / secrets) | The **database**, edited through the Admin UI |
 | Set by | Your deployment / container platform | Operators, live, in WebAdmin |
 | Changes take effect | On restart | Immediately, no redeploy |
-| Examples | Database URL, keys, storage, migration mode | Providers, virtual keys, model mappings, costs, routing policies |
+| Examples | Database URL, keys, storage, migration readiness mode | Providers, virtual keys, model mappings, costs, routing policies |
 
 The rule of thumb: **infrastructure and secrets are deploy-time; everything about how Conduit routes,
 prices, and gates requests is runtime.**
@@ -31,9 +31,10 @@ of the areas, not a copy of that file:
   (see [Monitoring](./monitoring.md#securing-the-health-endpoints)). Human admins sign in to WebAdmin
   through Clerk, configured with its own keys.
 - **Database** — a single **PostgreSQL** connection URL (`DATABASE_URL`) is required; Conduit is
-  Postgres-only. Schema changes are governed by a **migration mode** (`CONDUIT_MIGRATION_MODE`) that
-  chooses whether a booting service applies migrations itself, waits for an external migration to
-  finish first, or skips the step — the mechanism behind zero-downtime deploys.
+  Postgres-only. Gateway and Admin startup never changes the schema. Run the Admin image's explicit
+  `migrate` command before rolling out either service; the default `CONDUIT_MIGRATION_MODE=Wait`
+  keeps readiness down until that command has brought the schema current. See the
+  [migration deployment strategy](./operations/deployment/migration-deployment-strategy.md).
 - **Customer mode** — `CONDUIT_CUSTOMER_MODE` decides how much provider error detail customers see
   in every customer-facing emission (HTTP error responses, SSE error events, async task status,
   webhook payloads, SignalR failure events). `External` (the default) returns classified generic

--- a/docs/decisions/0004-json-source-generation-contract-inventory.md
+++ b/docs/decisions/0004-json-source-generation-contract-inventory.md
@@ -1,0 +1,85 @@
+# JSON source-generation contract inventory
+
+Status: Accepted
+
+Issue: #1357
+
+## Decision
+
+Conduit uses explicit `JsonSerializerContext` metadata for its highest-value
+HTTP, messaging, Redis, SignalR, and provider contracts. Metadata generation
+keeps existing host serializer policies authoritative, so this change does not
+alter property names, enum representation, null/default handling, or
+polymorphism.
+
+Reflection remains available as a fallback for lower-volume and deliberately
+dynamic graphs. The focused compatibility project disables reflection
+globally, which ensures every graph listed below is complete.
+
+## Inventory
+
+| Contract family | Context and owner | Wire options | Producer / consumer | Compatibility coverage |
+| --- | --- | --- | --- | --- |
+| OpenAI-compatible chat and errors | `CoreHttpJsonContext` / Core | `snake_case`, omit nulls; existing host converters remain authoritative | Gateway endpoints and SDK clients | `gateway-chat-response.json`; production Gateway options also exercised |
+| Gateway discovery, models, files, uploads, and cancellation | `GatewayHttpJsonContext` and `ConfigurationHttpJsonContext` / Gateway and Configuration | `snake_case`, omit nulls | Gateway endpoints / API clients | `gateway-model-list.json`; reflection-disabled metadata closure |
+| Admin errors, representative lists, and batch-spend status | `AdminHttpJsonContext` / Admin | `camelCase`, case-insensitive reads | Admin minimal APIs / WebAdmin and API clients | `admin-problem-details.json`; reflection-disabled metadata closure |
+| Wolverine topology messages | `CoreMessagingJsonContext` / Core | Existing Pascal-case CLR names, numeric enums, and explicit JSON attributes | Gateway and Admin publishers / Wolverine handlers | `wolverine-spend-update.json`; runtime resolver-chain serialization |
+| Gateway Redis cache and invalidation payloads | `GatewayRedisJsonContext` / Gateway | Existing Pascal-case names, case-insensitive reads | Gateway instances across a rolling deployment | `redis-model-cost-legacy.json` old-to-new and new-to-old; `redis-virtual-key-invalidation.json` |
+| Redis webhook reliability state | `CoreRedisJsonContext` / Core | Existing Pascal-case names, case-insensitive reads | Webhook circuit-breaker instances | `redis-webhook-circuit-state.json` |
+| Live SignalR notifications | `ConfigurationSignalRJsonContext` / Configuration | `camelCase`, case-insensitive reads | Admin notification hubs / WebAdmin | `signalr-virtual-key-created.json`; reflection-disabled metadata closure |
+| Bedrock requests, responses, model discovery, and streams | `ProvidersJsonContext` / Providers | `camelCase`, omit nulls, case-insensitive reads | Bedrock client / AWS Bedrock | `bedrock-converse-response.json`; existing provider tests |
+| OpenRouter catalog | `ProvidersJsonContext` / Providers | `camelCase`, omit nulls, case-insensitive reads | OpenRouter client / OpenRouter API | Reflection-disabled metadata closure; existing provider tests |
+
+Batch-spend Redis accumulation uses scalar Redis values and hashes rather than
+JSON documents. Its durable flush event is included in
+`CoreMessagingJsonContext`.
+
+## Compatibility boundaries
+
+- The removed queued SignalR polymorphic envelope and its
+  `DefaultJsonTypeInfoResolver` modifier are not present in the current
+  Gateway/Admin path. The live strongly typed notification DTOs are generated
+  without introducing a discriminator or changing the wire contract.
+- Converted graphs do not require reflective discovery for arbitrary CLR
+  objects. Existing OpenAI-compatible extension slots accept only supported
+  JSON primitives, `JsonElement`, or source-generated bounded collection
+  shapes; the reflection-disabled suite exercises those paths. Bedrock
+  tool-choice marker objects now use `JsonElement` instead of unbounded
+  `object`.
+- The existing non-generic `JsonStringEnumConverter` remains a host fallback
+  for endpoints outside this inventory. Converted contexts either preserve
+  numeric enum behavior or contain no enum requiring the converter; they do not
+  add a new runtime converter-factory dependency.
+- Redis fixtures model a previous release using an explicit reflection resolver.
+  They prove both previous-release payloads read on the new release and
+  new-release payloads read with the previous serializer policy.
+
+## Reflection-disabled verification
+
+`ConduitLLM.SerializationTests` sets
+`JsonSerializerIsReflectionEnabledByDefault=false`. It checks representative
+fixtures in both directions and verifies that an unregistered type fails.
+
+Run:
+
+```powershell
+dotnet test Tests/ConduitLLM.SerializationTests/ConduitLLM.SerializationTests.csproj -c Release
+```
+
+## Benchmark
+
+BenchmarkDotNet, .NET 10.0.10, Intel Core i5-12400F, 8 measured iterations:
+
+| Serializer metadata | Mean | Allocated | Ratio |
+| --- | ---: | ---: | ---: |
+| Reflection | 774.0 ns | 920 B | 1.00 |
+| Source-generated | 737.9 ns | 920 B | 0.95 |
+
+The representative chat response is approximately 4.7% faster with unchanged
+per-operation allocation.
+
+Run:
+
+```powershell
+dotnet run --project Tests/ConduitLLM.Benchmarks/ConduitLLM.Benchmarks.csproj -c Release -- --filter *JsonSourceGeneration*
+```

--- a/docs/operations/deployment/migration-deployment-strategy.md
+++ b/docs/operations/deployment/migration-deployment-strategy.md
@@ -1,0 +1,87 @@
+# Database migration deployment strategy
+
+Conduit uses one explicit release step to own all schema changes. Gateway and
+Admin processes do not call `Database.Migrate`, `EnsureCreated`, or Wolverine
+auto-provisioning during normal startup.
+
+## Release sequence
+
+1. Build the Admin, Gateway, and WebAdmin candidate images.
+2. Run the candidate Admin image once with the `migrate` argument.
+3. Only after exit code `0`, roll out Gateway and Admin (and promote any floating
+   image tags).
+
+The migrator applies EF Core migrations, imports the bundled model catalog on an
+empty installation, and provisions Wolverine's PostgreSQL schemas. A non-zero
+exit code must stop the rollout. Existing services remain available because
+they have not been updated yet.
+
+The tag-triggered GitHub Actions release workflow implements this sequence.
+Configure the `production` GitHub Environment with a
+`CONDUIT_RELEASE_DATABASE_URL` secret that is reachable from its runner. Candidate
+images are pushed under a `-candidate` suffix; version and `latest`/`beta` tags
+are not changed until the migration succeeds.
+
+## Commands
+
+For the repository's Compose deployment, one command performs the migration:
+
+```bash
+docker compose run --rm migrate
+```
+
+`docker compose up -d` also runs the same one-shot service automatically and
+starts both APIs only after it succeeds.
+
+For another container platform, run the release's Admin image as a Job or release
+hook:
+
+```bash
+docker run --rm \
+  -e DATABASE_URL \
+  -e CONDUIT_MIGRATION_LOCK_TIMEOUT_SECONDS=600 \
+  ghcr.io/nickna/conduit-admin:<version> migrate
+```
+
+For a source checkout:
+
+```bash
+dotnet run --project Services/ConduitLLM.Admin -- migrate
+```
+
+Both normal services should use `CONDUIT_MIGRATION_MODE=Wait` (the default) and
+`ConduitLLM__Messaging__Wolverine__AutoProvision=false` (also the default).
+`Wait` performs read-only pending-migration probes and returns `503` from
+`/health/ready` until the schema is current. The readiness message tells the
+operator to run the explicit migrator. `Skip` disables this guard for tests or a
+deliberate break-glass operation. The removed `Apply` value fails startup with an
+actionable error instead of silently mutating the database.
+
+## Retries and concurrency
+
+The command is idempotent. It checks EF's migration history on every run, so a
+retry after success is a no-op apart from idempotent seed/provisioning work.
+
+EF migration and seed work is serialized by the session-scoped PostgreSQL
+advisory lock `7891011`. A second invocation waits, then rechecks the migration
+history after the winner finishes. Wolverine resource setup is idempotent, so
+concurrent invocations are harmless. Set
+`CONDUIT_MIGRATION_LOCK_TIMEOUT_SECONDS` to bound how long a contender waits;
+`0` waits indefinitely.
+
+If the migrator fails, inspect its logs, correct the database or network problem,
+and rerun the same command. Do not start a rollout with
+`CONDUIT_MIGRATION_MODE=Skip` to bypass a failed release migration.
+
+## Validation
+
+The migration validation workflow runs the release command against:
+
+- an empty database;
+- a database at the previous migration;
+- an already-current database (safe retry);
+- two concurrent invocations; and
+- an unreachable database (non-zero release gate).
+
+It also checks for pending model changes and uploads an idempotent SQL script for
+DBA review or manual recovery.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,14 +18,16 @@ repository root unless a command says otherwise.
 | Run the full local build/test/coverage flow | `./scripts/test/ci-build-test.ps1` |
 | Produce or inspect detailed coverage | `./scripts/test/coverage-dashboard.ps1 run|report|summary` |
 | Validate EF Core migrations | `./scripts/migrations/validate-migrations.ps1 -CheckPending` |
+| Apply release migrations locally | `docker compose run --rm migrate` |
 | Run the Gateway/Admin messaging smoke test | `./scripts/test/wolverine-two-host-smoke.ps1` |
 | Run local CodeQL analysis | `./scripts/test/test-codeql.ps1` |
 
 `dev.ps1` is the canonical development entry point. It always combines
 `docker-compose.yml` with `docker-compose.dev.yml`; do not invoke the
-development override file by itself. When its database has no model identifiers,
-the release's embedded provider catalogs are seeded by the application migration
-path automatically. Use `-SeedModelCatalog` to ask the running Admin API to merge
+development override file by itself. Its one-shot `migrate` service applies EF
+and Wolverine schema changes before either API starts. When its database has no
+model identifiers, the release's embedded provider catalogs are seeded by that
+migrator. Use `-SeedModelCatalog` to ask the running Admin API to merge
 the embedded snapshot again after rebuilding with catalog changes.
 
 ## Optional maintenance tools

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -354,7 +354,7 @@ function Build-Containers {
             $buildArgs += '--no-cache'
         }
 
-        $buildArgs += @('api', 'admin', 'webadmin')
+        $buildArgs += @('migrate', 'api', 'admin', 'webadmin')
 
         docker compose @buildArgs
 
@@ -452,7 +452,10 @@ function Start-Development {
             throw "Docker Compose failed to start the development environment"
         }
 
-        $expectedServices = @(docker compose -f docker-compose.yml -f docker-compose.dev.yml config --services)
+        $expectedServices = @(
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml config --services |
+                Where-Object { $_ -ne 'migrate' }
+        )
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to determine expected Docker Compose services"
         }
@@ -467,9 +470,8 @@ function Start-Development {
             throw "Services did not reach running state: $($missingServices -join ', ')"
         }
 
-        # Seed a new local database with every checked-in provider catalog. The
-        # script skips databases that already have identifiers unless explicitly
-        # asked to refresh them.
+        # The one-shot migrator seeds a new database from the checked-in catalogs.
+        # This script skips populated databases unless explicitly asked to refresh.
         $seedScript = Join-Path $scriptDir 'dev' 'seed-model-catalog.ps1'
         if ($SeedModelCatalog) {
             & $seedScript -Force

--- a/scripts/test/verify-admin-media-rdg.ps1
+++ b/scripts/test/verify-admin-media-rdg.ps1
@@ -1,0 +1,61 @@
+param(
+    [switch]$NoRestore
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "../..")
+$project = Join-Path $repoRoot "Services/ConduitLLM.Admin/ConduitLLM.Admin.csproj"
+$generatedRoot = Join-Path `
+    $repoRoot `
+    "artifacts/conduit-admin-rdg-$PID-$([Guid]::NewGuid().ToString('N'))"
+
+try {
+    $arguments = @(
+        "build"
+        $project
+        "--configuration", "Release"
+        "-t:Rebuild"
+        "-p:EmitCompilerGeneratedFiles=true"
+        "-p:CompilerGeneratedFilesOutputPath=$generatedRoot"
+        "-p:UseSharedCompilation=false"
+    )
+    if ($NoRestore) {
+        $arguments += "--no-restore"
+    }
+
+    & dotnet @arguments
+    $buildExitCode = $LASTEXITCODE
+
+    if ($buildExitCode -ne 0) {
+        throw "Admin Release build failed with exit code $buildExitCode."
+    }
+
+    $routeSources = @(
+        Get-ChildItem `
+            -Path $generatedRoot `
+            -Recurse `
+            -Filter "GeneratedRouteBuilderExtensions.g.cs" `
+            -File
+    )
+    if ($routeSources.Count -eq 0) {
+        throw "RequestDelegateGenerator did not emit GeneratedRouteBuilderExtensions.g.cs."
+    }
+
+    $routeSource = ($routeSources | ForEach-Object { Get-Content $_.FullName -Raw }) `
+        -join [Environment]::NewLine
+    $mediaHandlers = [Regex]::Matches(
+        $routeSource,
+        "var handler = Cast\(del,[^\r\n]*MediaEndpoints\.MediaEndpointLog")
+
+    if ($mediaHandlers.Count -ne 9) {
+        throw "Expected 9 generated media handlers using MediaEndpointLog; found $($mediaHandlers.Count)."
+    }
+
+    Write-Host "Admin RDG guard passed: all 9 affected media handlers were generated at compile time."
+}
+finally {
+    if (Test-Path -LiteralPath $generatedRoot) {
+        Remove-Item -LiteralPath $generatedRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- closes #1357 by adding source-generated System.Text.Json metadata to Gateway/Admin HTTP, Wolverine, Redis, SignalR, Bedrock, and OpenRouter hot paths; keeps explicit reflection fallback for plugin/dynamic payloads and adds compatibility fixtures, benchmarks, and an ADR inventory
- closes #1356 by restoring Request Delegate Generator coverage for all nine media handlers and making RDG012 a build error with a generated-source CI guard
- closes #1355 by removing EF/Wolverine schema mutation from normal Gateway/Admin startup, provisioning the real service/queue schemas through the explicit migrator, gating Compose and tagged releases on that command, and adding readiness diagnostics, deployment docs, and real-Postgres release tests

## Validation

- `dotnet build Conduit.slnx -c Release --no-restore`
- `dotnet test Tests/ConduitLLM.Tests/ConduitLLM.Tests.csproj -c Release --no-build --no-restore` (3,679 passed, 10 skipped)
- `dotnet test Tests/ConduitLLM.SerializationTests/ConduitLLM.SerializationTests.csproj -c Release --no-build --no-restore` (10 passed)
- Admin media endpoint suite (262 passed, 3 skipped) and RDG generated-source verification
- release migration suite against PostgreSQL 16: empty bootstrap, previous-schema upgrade, idempotent retry, concurrent invocations, and failed gate (5 passed)
- migration-model validation, Docker Compose config validation, and GitHub workflow validation

The JSON benchmark measured about 4.7% lower mean time with unchanged allocation for the representative Gateway response.

## Deployment note

The tagged release workflow now requires `CONDUIT_RELEASE_DATABASE_URL` in the `production` GitHub Environment. Candidate images are promoted to version/channel tags only after the migration exits successfully.

Closes #1357
Closes #1356
Closes #1355